### PR TITLE
[Doc] Check markup links

### DIFF
--- a/docs/lang/articles/reference/operator.md
+++ b/docs/lang/articles/reference/operator.md
@@ -56,7 +56,9 @@ Python3 distinguishes `/` (true division) and `//` (floor division), e.g., `1.0 
   operands to the default integral type.
 
 To avoid such implicit casting, you can manually cast your operands to
-desired types, using `ti.cast`.
+desired types, using `ti.cast`. Please see
+[Default precisions](#default-precisions) for more details on
+default numerical types.
 
 Taichi also provides `ti.raw_div` function which performs true division if one of the operands is floating point type
 and performs floor division if both operands are integral types.

--- a/docs/lang/articles/reference/simt.md
+++ b/docs/lang/articles/reference/simt.md
@@ -27,6 +27,9 @@ similar to the [usage in CUDA kernels](https://developer.nvidia.com/blog/using-c
 |`ti.simt.warp.active_mask`  | `__activemask`    |
 |`ti.simt.warp.sync`         | `__syncwarp`      |
 
+See [Taichi's API reference](https://docs.taichi-lang.org/api/taichi/lang/simt/warp/#module-taichi.lang.simt.warp)
+for more information on each function.
+
 Here is an example of performing data exchange within a warp in Taichi:
 
 


### PR DESCRIPTION
Issue: #

### Brief Summary

Check markup links (this is not part of existing upstream checks; I'm adding it)

copilot:summary

### Walkthrough

copilot:walkthrough
