### PR TITLE
[Mac] Fix metal device build

### DIFF
--- a/taichi/rhi/metal/metal_device.mm
+++ b/taichi/rhi/metal/metal_device.mm
@@ -1,8 +1,8 @@
+#include "taichi/rhi/metal/metal_device.h"
 #include "spirv_msl.hpp"
 #include "taichi/rhi/device.h"
 #include "taichi/rhi/device_capability.h"
 #include "taichi/rhi/impl_support.h"
-#include "taichi/rhi/metal/metal_device.h"
 
 namespace taichi::lang {
 namespace metal {


### PR DESCRIPTION
Issue: #

### Brief Summary

Upgrade metal device from building on Mac OS ~11 to building on Mac OS 15.

See https://genesis-ai-company.slack.com/archives/C08UKDR6KGR/p1749077734526669?thread_ts=1749076147.261559&cid=C08UKDR6KGR for context

Pre-requisite for merging https://github.com/genesis-company/taichi/pull/5

Fix metal device build, that is currently failing on https://github.com/genesis-company/taichi/actions/runs/15453980092/job/43502395019?pr=5

copilot:summary

### Walkthrough

copilot:walkthrough
