### PR TITLE
[Build] Remove conditional guard on -Wno-unused-but-set-variabl

### DIFF
--- a/cmake/TaichiCXXFlags.cmake
+++ b/cmake/TaichiCXXFlags.cmake
@@ -99,13 +99,10 @@ else()
     # However, some of these "constexpr" are debug flags and will be manually enabled upon debugging.
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unneeded-internal-declaration ")
 
-    # FIXME: Check why Android don't support check_cxx_compiler_flag
-    if (NOT ANDROID)
-        # if we don't set -Wno-unused-but-set-variable, then Eigen build will fail anyway,
-        # in a way that is not obvious why, without very close inspection.
-        # So we will simply set it
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable ")
-    endif()
+    # if we don't set -Wno-unused-but-set-variable, then Eigen build will fail anyway,
+    # in a way that is not obvious why, without very close inspection.
+    # So we will simply set it
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable ")
 endif ()
 
 # (penguinliong) When building for iOS with Xcode `CMAKE_SYSTEM_PROCESSOR`


### PR DESCRIPTION
Issue: #

### Brief Summary

Remove conditional guard on -Wno-unused-but-set-variabl

When compiler doesn't detect this option, the build crashes anyway, with build errors in eigen, which are not obvious to track down to the conditional check failling (typically because compiler doesnt run correctly ,and one overrode the compiler check, earlier in the build).

copilot:summary

### Walkthrough

copilot:walkthrough
