### PR TITLE
[Build] Fix broken builds, hopefully

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ endif()
 
 # No support of Python for Android build; or in any case taichi is integrated
 # in another project as submodule.
+set(PYBIND11_VERSION "2.13.6" CACHE STRING "Pybind11 version to use")
 option(TI_WITH_PYTHON "Build with Python language binding" ON)
 if (TI_WITH_PYTHON AND NOT ANDROID)
     include(cmake/PythonNumpyPybind11.cmake)

--- a/cmake/PythonNumpyPybind11.cmake
+++ b/cmake/PythonNumpyPybind11.cmake
@@ -12,10 +12,11 @@ include_directories(${NUMPY_INCLUDE_DIR})
 
 include(FetchContent)
 
+message("Using pybind11 version: ${PYBIND11_VERSION}")
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY https://github.com/pybind/pybind11.git
-  GIT_TAG v2.13.6  # Should be less than 3.0.0 for now
+  GIT_TAG v${PYBIND11_VERSION}  # Should be less than 3.0.0 for now
      # pybind11 3.0.0 caused builds to start failing. This PR downgrades pybind11 to latest <3.0.0 release,
      # which fixes the issue
      # whilst we could probably get 3.0.0 working too, I feel that x.0.0 releases, in opensource (and closed source


### PR DESCRIPTION
Issue: #

### Brief Summary

pybind11 3.0.0 came out 10 hours ago, and builds started failing at the same time, with pybind11 realted issue. This PR downgrades pybind11 to latest <3.0.0 release, which hoepfully will fix the issue (tested in a manylinux container, failed build without this change, succeeded with it 🤞 )

copilot:summary

### Walkthrough

copilot:walkthrough
