### PR TITLE
[Type] Update _graph.py to use GraphBuilderCxx

### DIFF
--- a/python/taichi/graph/_graph.py
+++ b/python/taichi/graph/_graph.py
@@ -49,7 +49,7 @@ class Sequential:
 
 class GraphBuilder:
     def __init__(self):
-        self._graph_builder = _ti_core.GraphBuilder()
+        self._graph_builder = _ti_core.GraphBuilderCxx()
 
     def dispatch(self, kernel_fn, *args):
         kernel_cpp = gen_cpp_kernel(kernel_fn, args)


### PR DESCRIPTION
Issue: #

### Brief Summary

Not sure how this got past unit-tests, but test_vector_int is failing on main, eg:
- https://github.com/Genesis-Embodied-AI/gstaichi/actions/runs/16632801720/job/47066349175?pr=113

I can reproduce this locally:

<img width="2798" height="1048" alt="Screenshot 2025-07-31 at 8 24 32 AM" src="https://github.com/user-attachments/assets/528e011e-ca42-4d68-b207-34a1ed2d49c0" />

Correcting GraphBuilder => GraphBuilderCxx (following https://github.com/Genesis-Embodied-AI/gstaichi/pull/69, presumably), fixes the issue:

<img width="1882" height="1016" alt="Screenshot 2025-07-31 at 8 25 13 AM" src="https://github.com/user-attachments/assets/87306ae0-35fa-4bfc-8639-d81b8efde9b8" />


copilot:summary

### Walkthrough

copilot:walkthrough
