### PR TITLE
[doc] Fix readme links to docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ pip install gstaichi
 
 # Documentation
 
-- [docs](docs/lang/articles)
-- [API reference](https://ideal-adventure-2n6lpyw.pages.github.io/gstaichi.html)
+- [docs](https://genesis-embodied-ai.github.io/gstaichi/user_guide/index.html)
+- [API reference](https://genesis-embodied-ai.github.io/gstaichi/autoapi/index.html)
 
 # Something is broken!
 


### PR DESCRIPTION
Issue: #

### Brief Summary

Fix readme links to docs (which have been broken all this time... Better late than never :) )

Also, before you say "but the version is wrong", I created a ticket for that https://linear.app/genesis-ai-company/issue/CMP-112/find-out-why-python-version-in-doc-is-wrong )

copilot:summary

### Walkthrough

copilot:walkthrough
