### PR TITLE
[doc] Remove copyright from header

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,7 +12,7 @@ __version__ = ".".join([str(v) for v in ti.__version__])
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "GsTaichi"
-copyright = "2023 GsTaichi Graphics Inc; 2025 Genesis AI Inc"
+copyright = "2025 Genesis AI Inc"
 author = ""
 release = __version__
 version = __version__


### PR DESCRIPTION
Issue: #

### Brief Summary

Remove Taichi graphics copyright from docs header, since we removed the upstream docs, and we are writing our own docs from scratch.

copilot:summary

### Walkthrough

copilot:walkthrough
