### PR TITLE
Demote "PTX cache key not set" message from warning to debug.

### DIFF
--- a/gstaichi/runtime/cuda/ptx_cache.cpp
+++ b/gstaichi/runtime/cuda/ptx_cache.cpp
@@ -122,7 +122,7 @@ void PtxCache::dump() {
   // Dump cached CompiledKernelData to disk
   for (auto &[_, k] : dataWrapperByCacheKey) {
     if (!k.ptx.has_value()) {
-      TI_WARN("PTX for cache_key {} is not set, skipping dump",
+      TI_DEBUG("PTX for cache_key {} is not set, skipping dump",
               k.metadata.cache_key);
       continue;
     }


### PR DESCRIPTION
See https://github.com/Genesis-Embodied-AI/Genesis/pull/1618
