### PR TITLE
[build] Pin pytest-rerunfailures to < 16

### DIFF
--- a/misc/ci_setup.py
+++ b/misc/ci_setup.py
@@ -188,7 +188,7 @@ class Installer:
                 "sourceinspect",
                 "pytest",
                 "pytest-xdist",
-                "pytest-rerunfailures",
+                "pytest-rerunfailures<16.0",
                 "pytest-cov",
                 "coverage",
                 "torch",

--- a/misc/ci_setup.py
+++ b/misc/ci_setup.py
@@ -188,6 +188,8 @@ class Installer:
                 "sourceinspect",
                 "pytest",
                 "pytest-xdist",
+                # 16.0 upgrade broke xfail, caused fatal errors, see
+                # https://github.com/Genesis-Embodied-AI/gstaichi/pull/162
                 "pytest-rerunfailures<16.0",
                 "pytest-cov",
                 "coverage",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,7 @@ pytest
 git+https://github.com/taichi-dev/pytest-xdist@a3b5ad3038#egg=pytest-xdist
 # 16.0 upgrade broke xfail, caused fatal errors, see
 # https://github.com/Genesis-Embodied-AI/gstaichi/pull/162
-pytest-rerunfailures<16.0 
+pytest-rerunfailures<16.0
 pytest-cov
 pytest-retry
 numpy>=2.0.0  # otherwise, on windows, tries to install 1.26.4, which has no wheel for python 3.13

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,9 @@
 Pillow
 pytest
 git+https://github.com/taichi-dev/pytest-xdist@a3b5ad3038#egg=pytest-xdist
-pytest-rerunfailures<16.0
+# 16.0 upgrade broke xfail, caused fatal errors, see
+# https://github.com/Genesis-Embodied-AI/gstaichi/pull/162
+pytest-rerunfailures<16.0 
 pytest-cov
 pytest-retry
 numpy>=2.0.0  # otherwise, on windows, tries to install 1.26.4, which has no wheel for python 3.13

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 Pillow
 pytest
 git+https://github.com/taichi-dev/pytest-xdist@a3b5ad3038#egg=pytest-xdist
-pytest-rerunfailures
+pytest-rerunfailures<16.0
 pytest-cov
 pytest-retry
 numpy>=2.0.0  # otherwise, on windows, tries to install 1.26.4, which has no wheel for python 3.13


### PR DESCRIPTION
Issue: #

### Brief Summary

- Without this we get weird build errors like https://github.com/Genesis-Embodied-AI/gstaichi/actions/runs/17323917591/job/49186207999
- see also https://github.com/pytest-dev/pytest-rerunfailures/issues/302
- and https://github.com/Genesis-Embodied-AI/Genesis/pull/1654

copilot:summary

### Walkthrough

copilot:walkthrough
