### PR TITLE
[perf] ensure consistent module name when using src-ll cache

### DIFF
--- a/gstaichi/codegen/compiled_kernel_data.h
+++ b/gstaichi/codegen/compiled_kernel_data.h
@@ -126,6 +126,10 @@ class CompiledKernelData {
 
   static std::unique_ptr<CompiledKernelData> load(std::istream &is, Err *p_err);
 
+  virtual std::string debug_dump_to_string() const {
+    throw std::runtime_error("debug_dump_to_string not implemented");
+  }
+
   static std::string get_err_msg(Err err);
 
  protected:

--- a/gstaichi/codegen/compiled_kernel_data.h
+++ b/gstaichi/codegen/compiled_kernel_data.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <optional>
 #include <algorithm>
+#include <stdexcept>
 
 #include "gstaichi/rhi/arch.h"
 

--- a/gstaichi/codegen/llvm/compiled_kernel_data.cpp
+++ b/gstaichi/codegen/llvm/compiled_kernel_data.cpp
@@ -61,7 +61,7 @@ CompiledKernelData::Err CompiledKernelData::load_impl(
   }
   data_.compiled_data.module = std::move(ret);
   llvm::Module *mod = data_.compiled_data.module.get();
-  mod->setModuleIdentifier(mod->getFunctionList().begin()->getName().str() + "_module");
+  mod->setModuleIdentifier("kernel");
   return Err::kNoError;
 }
 

--- a/gstaichi/codegen/llvm/compiled_kernel_data.cpp
+++ b/gstaichi/codegen/llvm/compiled_kernel_data.cpp
@@ -60,6 +60,8 @@ CompiledKernelData::Err CompiledKernelData::load_impl(
     return Err::kParseSrcCodeFailed;
   }
   data_.compiled_data.module = std::move(ret);
+  llvm::Module *mod = data_.compiled_data.module.get();
+  mod->setModuleIdentifier(mod->getFunctionList().begin()->getName().str() + "_module");
   return Err::kNoError;
 }
 

--- a/gstaichi/codegen/llvm/compiled_kernel_data.cpp
+++ b/gstaichi/codegen/llvm/compiled_kernel_data.cpp
@@ -41,6 +41,15 @@ CompiledKernelData::Err CompiledKernelData::check() const {
   return Err::kNoError;
 }
 
+std::string CompiledKernelData::debug_dump_to_string() const {
+  auto &data = this->get_internal_data().compiled_data;
+  auto *module = data.module.get();
+  std::string result;
+  llvm::raw_string_ostream oss(result);
+  module->print(oss, /*AAW=*/nullptr);
+  return oss.str();
+}
+
 CompiledKernelData::Err CompiledKernelData::load_impl(
     const CompiledKernelDataFile &file) {
   arch_ = file.arch();

--- a/gstaichi/codegen/llvm/compiled_kernel_data.h
+++ b/gstaichi/codegen/llvm/compiled_kernel_data.h
@@ -58,7 +58,8 @@ class CompiledKernelData : public lang::CompiledKernelData {
     return data_;
   }
 
-  std::string debug_dump_to_string() const override;  // for debug/dev/testing only
+  std::string debug_dump_to_string()
+      const override;  // for debug/dev/testing only
 
  protected:
   Err load_impl(const CompiledKernelDataFile &file) override;

--- a/gstaichi/codegen/llvm/compiled_kernel_data.h
+++ b/gstaichi/codegen/llvm/compiled_kernel_data.h
@@ -58,6 +58,8 @@ class CompiledKernelData : public lang::CompiledKernelData {
     return data_;
   }
 
+  std::string debug_dump_to_string() const override;  // for debug/dev/testing only
+
  protected:
   Err load_impl(const CompiledKernelDataFile &file) override;
   Err dump_impl(CompiledKernelDataFile &file) const override;

--- a/gstaichi/python/export_lang.cpp
+++ b/gstaichi/python/export_lang.cpp
@@ -352,7 +352,8 @@ void export_lang(py::module &m) {
 
   auto compiled_kernel_data =
       py::class_<CompiledKernelData>(m, "CompiledKernelData")
-      .def("_debug_dump_to_string", &CompiledKernelData::debug_dump_to_string);
+          .def("_debug_dump_to_string",
+               &CompiledKernelData::debug_dump_to_string);
 
   py::class_<Program>(m, "Program")
       .def(py::init<>())

--- a/gstaichi/python/export_lang.cpp
+++ b/gstaichi/python/export_lang.cpp
@@ -351,7 +351,8 @@ void export_lang(py::module &m) {
       py::class_<DeviceCapabilityConfig>(m, "DeviceCapabilityConfig");
 
   auto compiled_kernel_data =
-      py::class_<CompiledKernelData>(m, "CompiledKernelData");
+      py::class_<CompiledKernelData>(m, "CompiledKernelData")
+      .def("_debug_dump_to_string", &CompiledKernelData::debug_dump_to_string);
 
   py::class_<Program>(m, "Program")
       .def(py::init<>())

--- a/gstaichi/runtime/llvm/llvm_context.cpp
+++ b/gstaichi/runtime/llvm/llvm_context.cpp
@@ -1020,7 +1020,7 @@ LLVMCompiledKernel GsTaichiLLVMContext::link_compiled_tasks(
   std::unordered_set<int> used_tree_ids;
   std::unordered_set<int> tls_sizes;
   std::unordered_set<std::string> offloaded_names;
-  auto mod = new_module("kernel", linking_context_data->llvm_context);
+  auto mod = new_module(data_list[0]->tasks[0].name + "_module", linking_context_data->llvm_context);
   llvm::Linker linker(*mod);
   for (auto &datum : data_list) {
     for (auto tree_id : datum->used_tree_ids) {

--- a/gstaichi/runtime/llvm/llvm_context.cpp
+++ b/gstaichi/runtime/llvm/llvm_context.cpp
@@ -1033,7 +1033,6 @@ LLVMCompiledKernel GsTaichiLLVMContext::link_compiled_tasks(
       offloaded_names.insert(task.name);
       linked.tasks.push_back(std::move(task));
     }
-
     linker.linkInModule(clone_module_to_context(
         datum->module.get(), linking_context_data->llvm_context));
   }

--- a/gstaichi/runtime/llvm/llvm_context.cpp
+++ b/gstaichi/runtime/llvm/llvm_context.cpp
@@ -1020,7 +1020,7 @@ LLVMCompiledKernel GsTaichiLLVMContext::link_compiled_tasks(
   std::unordered_set<int> used_tree_ids;
   std::unordered_set<int> tls_sizes;
   std::unordered_set<std::string> offloaded_names;
-  auto mod = new_module(data_list[0]->tasks[0].name + "_module", linking_context_data->llvm_context);
+  auto mod = new_module("kernel", linking_context_data->llvm_context);
   llvm::Linker linker(*mod);
   for (auto &datum : data_list) {
     for (auto tree_id : datum->used_tree_ids) {
@@ -1033,6 +1033,7 @@ LLVMCompiledKernel GsTaichiLLVMContext::link_compiled_tasks(
       offloaded_names.insert(task.name);
       linked.tasks.push_back(std::move(task));
     }
+
     linker.linkInModule(clone_module_to_context(
         datum->module.get(), linking_context_data->llvm_context));
   }

--- a/python/gstaichi/lang/kernel_impl.py
+++ b/python/gstaichi/lang/kernel_impl.py
@@ -609,6 +609,7 @@ class Kernel:
         self.visited_functions: set[FunctionSourceInfo] = set()
         self.kernel_function_info: FunctionSourceInfo | None = None
         self.compiled_kernel_data_by_key: dict[CompiledKernelKeyType, CompiledKernelData] = {}
+        self._last_compiled_kernel_data: CompiledKernelData | None = None  # for dev/debug
 
         self.src_ll_cache_observations: SrcLlCacheObservations = SrcLlCacheObservations()
 
@@ -1061,6 +1062,7 @@ class Kernel:
                         compiled_kernel_data,
                     )
                     self.src_ll_cache_observations.cache_stored = True
+            self._last_compiled_kernel_data = compiled_kernel_data
             prog.launch_kernel(compiled_kernel_data, launch_ctx)
         except Exception as e:
             e = handle_exception_from_cpp(e)

--- a/tests/python/gstaichi/lang/fast_caching/test_src_ll_cache.py
+++ b/tests/python/gstaichi/lang/fast_caching/test_src_ll_cache.py
@@ -1,9 +1,11 @@
 import pathlib
+import platform
 import sys
 
 import pytest
 
 import gstaichi as ti
+import gstaichi.lang
 from gstaichi._test_tools import ti_init_same_arch
 
 from tests import test_utils
@@ -18,6 +20,7 @@ def test_src_ll_cache1(tmp_path: pathlib.Path) -> None:
         pass
 
     no_pure()
+    assert no_pure._primal is not None
     assert not no_pure._primal.src_ll_cache_observations.cache_key_generated
 
     ti_init_same_arch(offline_cache_file_path=str(tmp_path), offline_cache=True)
@@ -28,10 +31,27 @@ def test_src_ll_cache1(tmp_path: pathlib.Path) -> None:
         pass
 
     has_pure()
+    assert has_pure._primal is not None
     assert has_pure._primal.src_ll_cache_observations.cache_key_generated
     assert not has_pure._primal.src_ll_cache_observations.cache_validated
     assert not has_pure._primal.src_ll_cache_observations.cache_loaded
     assert has_pure._primal.src_ll_cache_observations.cache_stored
+    assert has_pure._primal._last_compiled_kernel_data is not None
+
+    last_compiled_kernel_data_str = None
+    if gstaichi.lang.impl.current_cfg().arch in [ti.cpu, ti.cuda]:
+        # we only support _last_compiled_kernel_data on cpu and cuda
+        # and it only changes anything on cuda anyway, because it affects the PTX
+        # cache
+        print(
+            "has_pure._primal._last_compiled_kernel_data",
+            has_pure._primal._last_compiled_kernel_data,
+            type(has_pure._primal._last_compiled_kernel_data),
+        )
+        print(dir(has_pure._primal._last_compiled_kernel_data))
+        last_compiled_kernel_data_str = has_pure._primal._last_compiled_kernel_data._debug_dump_to_string()
+        assert last_compiled_kernel_data_str is not None and last_compiled_kernel_data_str != ""
+        print("last_compiled_kernel_data_str", last_compiled_kernel_data_str)
 
     ti_init_same_arch(offline_cache_file_path=str(tmp_path), offline_cache=True)
 
@@ -39,6 +59,9 @@ def test_src_ll_cache1(tmp_path: pathlib.Path) -> None:
     assert has_pure._primal.src_ll_cache_observations.cache_key_generated
     assert has_pure._primal.src_ll_cache_observations.cache_validated
     assert has_pure._primal.src_ll_cache_observations.cache_loaded
+    if gstaichi.lang.impl.current_cfg().arch in [ti.cpu, ti.cuda]:
+        assert has_pure._primal._last_compiled_kernel_data._debug_dump_to_string() == last_compiled_kernel_data_str
+        print("last_compiled_kernel_data_str", last_compiled_kernel_data_str)
 
 
 # Should be enough to run these on cpu I think, and anything involving
@@ -77,6 +100,10 @@ def test_src_ll_cache_arg_warnings(tmp_path: pathlib.Path, capfd) -> None:
 
 @test_utils.test()
 def test_src_ll_cache_repeat_after_load(tmp_path: pathlib.Path) -> None:
+    """
+    Check that repeatedly calling kernel actually works, c.f. was doing
+    no-op for a bit.
+    """
     ti_init_same_arch(offline_cache_file_path=str(tmp_path), offline_cache=True)
 
     @ti.pure

--- a/tests/python/gstaichi/lang/fast_caching/test_src_ll_cache.py
+++ b/tests/python/gstaichi/lang/fast_caching/test_src_ll_cache.py
@@ -99,21 +99,14 @@ def test_src_ll_cache_repeat_after_load(tmp_path: pathlib.Path) -> None:
         assert a[0] == 6 + i
 
 
-@pytest.mark.parametrize(
-    "flag_value",
-    [
-        None,
-        False,
-        True,
-    ],
-)
+@pytest.mark.parametrize("src_ll_cache", [None, False, True])
 @test_utils.test()
-def test_src_ll_cache_flag(tmp_path: pathlib.Path, flag_value: bool) -> None:
+def test_src_ll_cache_flag(tmp_path: pathlib.Path, src_ll_cache: bool) -> None:
     """
     Test ti.init(src_ll_cache) flag
     """
-    if flag_value:
-        ti_init_same_arch(offline_cache_file_path=str(tmp_path), src_ll_cache=flag_value)
+    if src_ll_cache:
+        ti_init_same_arch(offline_cache_file_path=str(tmp_path), src_ll_cache=src_ll_cache)
     else:
         ti_init_same_arch()
 
@@ -124,7 +117,7 @@ def test_src_ll_cache_flag(tmp_path: pathlib.Path, flag_value: bool) -> None:
 
     k1()
     cache_used = k1._primal.src_ll_cache_observations.cache_key_generated
-    if flag_value:
-        assert cache_used == flag_value
+    if src_ll_cache:
+        assert cache_used == src_ll_cache
     else:
         assert cache_used  # default

--- a/tests/python/gstaichi/lang/test_kernel_impl_dataclass.py
+++ b/tests/python/gstaichi/lang/test_kernel_impl_dataclass.py
@@ -132,8 +132,6 @@ def test_unpack_ast_struct_expressions(ast_in: str, struct_locals: set[str], exp
     ast_in_obj = eval(ast_in.strip())
     expected_ast_obj = eval(expected_ast.strip())
     new_ast_obj = _kernel_impl_dataclass.unpack_ast_struct_expressions(ast_in_obj, struct_locals)
-    print("new_ast_obj", ast.dump(new_ast_obj, indent=2))
-    print("expected_ast_obj", ast.dump(expected_ast_obj, indent=2))
     assert ast.dump(new_ast_obj) == ast.dump(expected_ast_obj)
 
 
@@ -172,13 +170,8 @@ def test_unpack_ast_struct_expressions(ast_in: str, struct_locals: set[str], exp
 @test_utils.test()
 def test_expand_func_arguments(in_meta: list[ArgMetadata], expected_meta: list[ArgMetadata]) -> None:
     out_meta = _kernel_impl_dataclass.expand_func_arguments(in_meta)
-    print("in_meta", "\n".join([str(m) for m in in_meta]))
-    print("out_meta", "\n".join([str(m) for m in out_meta]))
-    print("expected_meta", "\n".join([str(m) for m in expected_meta]))
     out_names = [m.name for m in out_meta]
     expected_names = [m.name for m in expected_meta]
-    print("out_names", out_names)
-    print("expected_names", expected_names)
     assert out_names == expected_names
 
     out_dtypes = [m.annotation.dtype for m in out_meta]
@@ -228,14 +221,10 @@ def test_populate_global_vars_from_dataclasses(
     param_name: str, param_type: Any, expected_global_args: dict[str, Any]
 ) -> None:
     py_arg = dataclass_test_tools.build_struct(param_type)
-    print("py_arg", py_arg)
     global_vars = {}
     _kernel_impl_dataclass.populate_global_vars_from_dataclass(param_name, param_type, py_arg, global_vars)
-    print("global vars names", list(global_vars.keys()))
     expected_names = set(expected_global_args.keys())
     actual_names = set(global_vars.keys())
-    print("expected", expected_names)
-    print("actual", actual_names)
     assert expected_names == actual_names
     for name in expected_names:
         expected_type = expected_global_args[name]


### PR DESCRIPTION
Issue: #

### Brief Summary

ensure consistent module name when using src-ll cache
- the impact is that this means that the ptx kernel will only be cached once not twice
- added a test for consistency of the dumped module string

copilot:summary

### Walkthrough

copilot:walkthrough
