### PR TITLE
[type] Fix NotImplementedError

### DIFF
--- a/python/gstaichi/types/annotations.py
+++ b/python/gstaichi/types/annotations.py
@@ -37,7 +37,7 @@ class Template(Generic[T]):
         self.ndim = ndim
 
     def __getitem__(self, i: Any) -> T:
-        raise NotImplemented
+        raise NotImplementedError()
 
 
 template = Template

--- a/python/gstaichi/types/ndarray_type.py
+++ b/python/gstaichi/types/ndarray_type.py
@@ -142,11 +142,11 @@ class NdarrayType:
 
     def __getitem__(self, i: Any) -> Any:
         # needed for pyright
-        raise NotImplemented
+        raise NotImplementedError()
 
     def __setitem__(self, i: Any, v: Any) -> None:
         # needed for pyright
-        raise NotImplemented
+        raise NotImplementedError()
 
 
 ndarray = NdarrayType


### PR DESCRIPTION
Issue: #

### Brief Summary

- `NotImplemented` was being used as an exception in python for not implemented methods
- however the correct exception should be `NotImplementedError()`
- this PR addresses this

copilot:summary

### Walkthrough

copilot:walkthrough
