### PR TITLE
[Lang] Allow static if expression as top level in for loop iterator

### DIFF
--- a/python/gstaichi/lang/ast/ast_transformer.py
+++ b/python/gstaichi/lang/ast/ast_transformer.py
@@ -1120,7 +1120,8 @@ class ASTTransformer(Builder):
                 is_static_if = get_decorator(ctx, node.iter.test) == "static"
                 if not is_static_if:
                     raise GsTaichiSyntaxError(
-                        "Using non static inlined if statement as for-loop iterable is not currently supported.")
+                        "Using non static inlined if statement as for-loop iterable is not currently supported."
+                    )
                 next_iter = _iter.body if _iter.test.ptr else _iter.orelse
                 new_for = ast.For(
                     target=node.target,

--- a/python/gstaichi/lang/ast/ast_transformer.py
+++ b/python/gstaichi/lang/ast/ast_transformer.py
@@ -1108,11 +1108,11 @@ class ASTTransformer(Builder):
             ):
                 return ASTTransformer.build_range_for(ctx, node)
             elif isinstance(node.iter, ast.IfExp):
-                # handle inline if expression as the top level iterator expression, e.g.:
+                # Handle inline if expression as the top level iterator expression, e.g.:
                 #
                 #   for i in range(foo) if ti.static(some_flag) else ti.static(range(bar))
                 #
-                # this appears to generalize to:
+                # Empirically, this appears to generalize to:
                 # - being an inner loop
                 # - either side can be static or not, as long as the if expression itself is static
                 _iter = node.iter

--- a/python/gstaichi/lang/ast/ast_transformer.py
+++ b/python/gstaichi/lang/ast/ast_transformer.py
@@ -1096,14 +1096,14 @@ class ASTTransformer(Builder):
         elif isinstance(node.iter, ast.IfExp):
             print("got ifexp")
             # lets just hard-code this for now...
-            iter = node.iter
+            _iter = node.iter
             build_stmt(ctx, node.iter)
             is_static_if = get_decorator(ctx, node.iter.test) == "static"
             print("is static if", is_static_if)
             if not is_static_if:
                 raise GsTaichiSyntaxError("using non static if with for not currently supported")
-            print("if node.iter.test.ptr:", iter.test.ptr)
-            next_iter = iter.body if iter.test.ptr else iter.orelse
+            print("if node.iter.test.ptr:", _iter.test.ptr)
+            next_iter = _iter.body if _iter.test.ptr else _iter.orelse
             print("next", ast.dump(next_iter, indent=2))
             new_for = ast.For(
                 target=node.target,

--- a/python/gstaichi/lang/ast/ast_transformer.py
+++ b/python/gstaichi/lang/ast/ast_transformer.py
@@ -1074,7 +1074,68 @@ class ASTTransformer(Builder):
         return None
 
     @staticmethod
+    def handle_for(ctx: ASTTransformerContext, node: ast.For, decorator: str) -> None:
+        if decorator == "ndrange":
+            print(".   ndrange")
+            if double_decorator != "":
+                raise GsTaichiSyntaxError("No decorator is allowed inside 'ti.ndrange")
+            return ASTTransformer.build_ndrange_for(ctx, node)
+        if decorator == "grouped":
+            print(".   grouped")
+            if double_decorator == "static":
+                raise GsTaichiSyntaxError("'ti.static' is not allowed inside 'ti.grouped'")
+            elif double_decorator == "ndrange":
+                return ASTTransformer.build_grouped_ndrange_for(ctx, node)
+            elif double_decorator == "grouped":
+                raise GsTaichiSyntaxError("'ti.grouped' cannot be nested")
+            else:
+                return ASTTransformer.build_struct_for(ctx, node, is_grouped=True)
+        elif isinstance(node.iter, ast.Call) and isinstance(node.iter.func, ast.Name) and node.iter.func.id == "range":
+            print(".   elif")
+            return ASTTransformer.build_range_for(ctx, node)
+        elif isinstance(node.iter, ast.IfExp):
+            print("got ifexp")
+            # lets just hard-code this for now...
+            iter = node.iter
+            build_stmt(ctx, node.iter)
+            is_static_if = get_decorator(ctx, node.iter.test) == "static"
+            print("is static if", is_static_if)
+            if not is_static_if:
+                raise GsTaichiSyntaxError("using non static if with for not currently supported")
+            print("if node.iter.test.ptr:", iter.test.ptr)
+            next_iter = iter.body if iter.test.ptr else iter.orelse
+            print("next", ast.dump(next_iter, indent=2))
+            new_for = ast.For(
+                target=node.target,
+                iter=next_iter,
+                body=node.body,
+                orelse=None,
+                type_comment=getattr(node, "type_comment", None),
+                lineno=node.lineno,
+                end_lineno=node.end_lineno,
+                col_offset=node.col_offset,
+                end_col_offset=node.end_col_offset,
+            )
+            return ASTTransformer.handle_for(ctx, new_for, decorator)
+        else:
+            print(".   else")
+            print("ast.dump(node)", ast.dump(node, indent=2))
+            print("ast.dump(node.iter)", ast.dump(node.iter, indent=2))
+            build_stmt(ctx, node.iter)
+            if isinstance(node.iter.ptr, mesh.MeshElementField):
+                if not _ti_core.is_extension_supported(impl.default_cfg().arch, _ti_core.Extension.mesh):
+                    raise Exception(
+                        "Backend " + str(impl.default_cfg().arch) + " doesn't support MeshGsTaichi extension"
+                    )
+                return ASTTransformer.build_mesh_for(ctx, node)
+            if isinstance(node.iter.ptr, mesh.MeshRelationAccessProxy):
+                return ASTTransformer.build_nested_mesh_for(ctx, node)
+            # Struct for
+            return ASTTransformer.build_struct_for(ctx, node, is_grouped=False)
+
+    @staticmethod
     def build_For(ctx: ASTTransformerContext, node: ast.For) -> None:
+        print("build for", ast.dump(node, indent=2))
         if node.orelse:
             raise GsTaichiSyntaxError("'else' clause for 'for' not supported in GsTaichi kernels")
         decorator = get_decorator(ctx, node.iter)
@@ -1083,42 +1144,21 @@ class ASTTransformer(Builder):
             double_decorator = get_decorator(ctx, node.iter.args[0])
 
         if decorator == "static":
+            print("  for is static")
             if double_decorator == "static":
                 raise GsTaichiSyntaxError("'ti.static' cannot be nested")
             with ctx.loop_scope_guard(is_static=True):
                 return ASTTransformer.build_static_for(ctx, node, double_decorator == "grouped")
         with ctx.loop_scope_guard():
-            if decorator == "ndrange":
-                if double_decorator != "":
-                    raise GsTaichiSyntaxError("No decorator is allowed inside 'ti.ndrange")
-                return ASTTransformer.build_ndrange_for(ctx, node)
-            if decorator == "grouped":
-                if double_decorator == "static":
-                    raise GsTaichiSyntaxError("'ti.static' is not allowed inside 'ti.grouped'")
-                elif double_decorator == "ndrange":
-                    return ASTTransformer.build_grouped_ndrange_for(ctx, node)
-                elif double_decorator == "grouped":
-                    raise GsTaichiSyntaxError("'ti.grouped' cannot be nested")
-                else:
-                    return ASTTransformer.build_struct_for(ctx, node, is_grouped=True)
-            elif (
-                isinstance(node.iter, ast.Call)
-                and isinstance(node.iter.func, ast.Name)
-                and node.iter.func.id == "range"
-            ):
-                return ASTTransformer.build_range_for(ctx, node)
-            else:
-                build_stmt(ctx, node.iter)
-                if isinstance(node.iter.ptr, mesh.MeshElementField):
-                    if not _ti_core.is_extension_supported(impl.default_cfg().arch, _ti_core.Extension.mesh):
-                        raise Exception(
-                            "Backend " + str(impl.default_cfg().arch) + " doesn't support MeshGsTaichi extension"
-                        )
-                    return ASTTransformer.build_mesh_for(ctx, node)
-                if isinstance(node.iter.ptr, mesh.MeshRelationAccessProxy):
-                    return ASTTransformer.build_nested_mesh_for(ctx, node)
-                # Struct for
-                return ASTTransformer.build_struct_for(ctx, node, is_grouped=False)
+            print(
+                "  set ctx loop scope guard decorator",
+                decorator,
+                "none?",
+                decorator is None,
+                type(decorator),
+                decorator == "",
+            )
+            return ASTTransformer.handle_for(ctx, node, decorator)
 
     @staticmethod
     def build_While(ctx: ASTTransformerContext, node: ast.While) -> None:

--- a/python/gstaichi/lang/ast/ast_transformer.py
+++ b/python/gstaichi/lang/ast/ast_transformer.py
@@ -1110,7 +1110,7 @@ class ASTTransformer(Builder):
             elif isinstance(node.iter, ast.IfExp):
                 # lets just "hard-code" this for now...
                 # here we are handling cases like
-                # for i in range(foo) if ti.static(some_flag) else range(ti.static(bar))
+                # for i in range(foo) if ti.static(some_flag) else ti.static(range(bar))
                 # this appears to generalize to:
                 # - being an inner loop
                 # - either side can be static or not, as long as the if expression itself is static

--- a/python/gstaichi/lang/ast/ast_transformer.py
+++ b/python/gstaichi/lang/ast/ast_transformer.py
@@ -1116,12 +1116,12 @@ class ASTTransformer(Builder):
                 # - being an inner loop
                 # - either side can be static or not, as long as the if expression itself is static
                 _iter = node.iter
-                build_stmt(ctx, node.iter)
                 is_static_if = get_decorator(ctx, node.iter.test) == "static"
                 if not is_static_if:
                     raise GsTaichiSyntaxError(
                         "Using non static inlined if statement as for-loop iterable is not currently supported."
                     )
+                build_stmt(ctx, _iter.test)
                 next_iter = _iter.body if _iter.test.ptr else _iter.orelse
                 new_for = ast.For(
                     target=node.target,

--- a/tests/python/gstaichi/lang/fast_caching/test_src_ll_cache.py
+++ b/tests/python/gstaichi/lang/fast_caching/test_src_ll_cache.py
@@ -1,5 +1,4 @@
 import pathlib
-import platform
 import sys
 
 import pytest

--- a/tests/python/test_for.py
+++ b/tests/python/test_for.py
@@ -30,7 +30,6 @@ def test_for_static_if_iter_runs(use_field: bool, is_inner: bool, static_value: 
         def k1(a: V_ANNOT) -> None:
             for b in range(B):
                 for i in range(N_left) if ti.static(static_value) else ti.static(range(N_right)):
-                    print(i)
                     a[b, i] = 1
 
     else:
@@ -38,12 +37,10 @@ def test_for_static_if_iter_runs(use_field: bool, is_inner: bool, static_value: 
         @ti.kernel
         def k1(a: V_ANNOT) -> None:
             for i in range(N_left) if ti.static(static_value) else ti.static(range(N_right)):
-                print(i)
                 a[0, i] = 1
 
     a = V(ti.i32, (B, 6))
     k1(a)
-    print(a.to_numpy())
 
     def create_expected():
         a_expected = np.zeros(dtype=np.int32, shape=(B, 6))
@@ -56,10 +53,8 @@ def test_for_static_if_iter_runs(use_field: bool, is_inner: bool, static_value: 
 
 
 @pytest.mark.parametrize("is_static", [False, True])
-@pytest.mark.parametrize("is_inner", [False, True])
-@pytest.mark.parametrize("use_field", [False, True])
 @test_utils.test()
-def test_for_static_if_iter_static_ranges(use_field: bool, is_inner: bool, is_static: bool) -> None:
+def test_for_static_if_iter_static_ranges(is_static: bool) -> None:
     # see comments on test_for_static_if_iter_runs for discussion of testing static vs non static ranges
 
     # In this test, we verify that the static side is really static, and that the non-static side is
@@ -74,7 +69,6 @@ def test_for_static_if_iter_static_ranges(use_field: bool, is_inner: bool, is_st
     def k1(break_threshold: ti.i32) -> None:
         for b in range(B):
             for i in ti.static(range(N_left)) if ti.static(is_static) else range(N_right):
-                print(i)
                 if i >= break_threshold:
                     break
 

--- a/tests/python/test_for.py
+++ b/tests/python/test_for.py
@@ -14,7 +14,7 @@ def test_for_static_if_iter_runs(use_field: bool, is_inner: bool, static_value: 
     # Note that we currently dont have a way to turn static range on/off using some kind of variable/parameter.
     # So, for now, we'll have one side as static range, and one side as non-static range.
     # Since the code itself treats either side identically (same code path except for choosing one or the other side),
-    # whilst the test isn't ideal, it should give identical coverage to something more rigorous
+    # whilst the test isn't ideal, it should give identical coverage to something more rigorous.
     # We can think about approaches to parametrizing the static range in the future (nop function, macro,
     # parametrizablle ti.static, parametrizable ti.range, etc...).
     B = 2

--- a/tests/python/test_for.py
+++ b/tests/python/test_for.py
@@ -1,0 +1,81 @@
+import gstaichi as ti
+from tests import test_utils
+import pytest
+import numpy as np
+
+
+@pytest.mark.parametrize("static_value", [False, True])
+@pytest.mark.parametrize("is_inner", [False, True])
+@pytest.mark.parametrize("use_field", [False, True])
+@test_utils.test()
+def test_for_static_if_iter_runs(use_field: bool, is_inner: bool, static_value: bool) -> None:
+    # Note that we currently dont have a way to turn static range on/off using some kind of variable/parameter
+    # So, for now, we'll have one side as static range, and one side as non-static range
+    # Since the code itself treats either side identically (same code path except for choosing one or the other side),
+    # whilst the test isn't ideal, it should give identical coverage to something more rigorous
+    # We can think about approaches to parametrizing the static range in the future (nop function, macro, 
+    # parametrizablle ti.static, parametrizable ti.range, etc...)
+    B = 2
+    N_left = 3
+    N_right = 5
+
+    V = ti.field if use_field else ti.ndarray
+    V_ANNOT = ti.Template if use_field else ti.types.NDArray[ti.i32, 2]
+
+    if is_inner:
+        @ti.kernel
+        def k1(a: V_ANNOT) -> None:
+            for b in range(B):
+                for i in range(N_left) if ti.static(static_value) else ti.static(range(N_right)):
+                    print(i)
+                    a[b, i] = 1
+    else:
+        @ti.kernel
+        def k1(a: V_ANNOT) -> None:
+            for i in range(N_left) if ti.static(static_value) else ti.static(range(N_right)):
+                print(i)
+                a[0, i] = 1
+    a = V(ti.i32, (B, 6))
+    k1(a)
+    print(a.to_numpy())
+
+    def create_expected():
+        a_expected = np.zeros(dtype=np.int32, shape=(B, 6))
+        for b in range(B) if is_inner else range(1):
+            for i in range(N_left) if static_value else range(N_right):
+                a_expected[b, i] = 1
+        return a_expected
+ 
+    assert np.all(create_expected() == a.to_numpy())
+
+
+@pytest.mark.parametrize("is_static", [False, True])
+@pytest.mark.parametrize("is_inner", [False, True])
+@pytest.mark.parametrize("use_field", [False, True])
+@test_utils.test()
+def test_for_static_if_iter_static_ranges(use_field: bool, is_inner: bool, is_static: bool) -> None:
+    # see comments on test_for_static_if_iter_runs for discussion of testing static vs non static ranges
+
+    # In this test, we verify that the static side is really static, and that the non-static side is
+    # really non-static, by adding a conditional break to each, and seeing if that causes compilation to fail
+    
+    # Note that break is only valid in inner loops, so we only test the inner loop case
+    B = 2
+    N_left = 3
+    N_right = 5
+
+    @ti.kernel
+    def k1(break_threshold: ti.i32) -> None:
+        for b in range(B):
+            for i in ti.static(range(N_left)) if ti.static(is_static) else range(N_right):
+                print(i)
+                if i >= break_threshold:
+                    break
+
+    if is_static:
+        with pytest.raises(ti.GsTaichiCompilationError,
+                      match="You are trying to `break` a static `for` loop"):
+            k1(0)
+    else:
+        # dynamic break is ok, since not static for range
+        k1(0)

--- a/tests/python/test_for.py
+++ b/tests/python/test_for.py
@@ -76,5 +76,5 @@ def test_for_static_if_iter_static_ranges(is_static: bool) -> None:
         with pytest.raises(ti.GsTaichiCompilationError, match="You are trying to `break` a static `for` loop"):
             k1(0)
     else:
-        # dynamic break is ok, since not static for range
+        # Dynamic break is ok, since not static for range.
         k1(0)

--- a/tests/python/test_for.py
+++ b/tests/python/test_for.py
@@ -11,12 +11,12 @@ from tests import test_utils
 @pytest.mark.parametrize("use_field", [False, True])
 @test_utils.test()
 def test_for_static_if_iter_runs(use_field: bool, is_inner: bool, static_value: bool) -> None:
-    # Note that we currently dont have a way to turn static range on/off using some kind of variable/parameter
-    # So, for now, we'll have one side as static range, and one side as non-static range
+    # Note that we currently dont have a way to turn static range on/off using some kind of variable/parameter.
+    # So, for now, we'll have one side as static range, and one side as non-static range.
     # Since the code itself treats either side identically (same code path except for choosing one or the other side),
     # whilst the test isn't ideal, it should give identical coverage to something more rigorous
     # We can think about approaches to parametrizing the static range in the future (nop function, macro,
-    # parametrizablle ti.static, parametrizable ti.range, etc...)
+    # parametrizablle ti.static, parametrizable ti.range, etc...).
     B = 2
     N_left = 3
     N_right = 5
@@ -55,12 +55,12 @@ def test_for_static_if_iter_runs(use_field: bool, is_inner: bool, static_value: 
 @pytest.mark.parametrize("is_static", [False, True])
 @test_utils.test()
 def test_for_static_if_iter_static_ranges(is_static: bool) -> None:
-    # see comments on test_for_static_if_iter_runs for discussion of testing static vs non static ranges
+    # See comments on test_for_static_if_iter_runs for discussion of testing static vs non static ranges.
 
     # In this test, we verify that the static side is really static, and that the non-static side is
-    # really non-static, by adding a conditional break to each, and seeing if that causes compilation to fail
+    # really non-static, by adding a conditional break to each, and seeing if that causes compilation to fail.
 
-    # Note that break is only valid in inner loops, so we only test the inner loop case
+    # Note that break is only valid in inner loops, so we only test the inner loop case.
     B = 2
     N_left = 3
     N_right = 5

--- a/tests/python/test_for.py
+++ b/tests/python/test_for.py
@@ -87,7 +87,7 @@ def test_for_static_if_iter_static_ranges(is_static: bool) -> None:
 @test_utils.test()
 def test_for_static_if_forwards_backwards(use_field: bool) -> None:
     """
-    Test a forwards/backwards requirement for rigid body differentiation
+    Test a forwards/backwards requirement for rigid body differentiation.
     """
     MAX_LINKs = 3
     BATCH_SIZE = 1

--- a/tests/python/test_for.py
+++ b/tests/python/test_for.py
@@ -1,7 +1,9 @@
-import gstaichi as ti
-from tests import test_utils
-import pytest
 import numpy as np
+import pytest
+
+import gstaichi as ti
+
+from tests import test_utils
 
 
 @pytest.mark.parametrize("static_value", [False, True])
@@ -13,7 +15,7 @@ def test_for_static_if_iter_runs(use_field: bool, is_inner: bool, static_value: 
     # So, for now, we'll have one side as static range, and one side as non-static range
     # Since the code itself treats either side identically (same code path except for choosing one or the other side),
     # whilst the test isn't ideal, it should give identical coverage to something more rigorous
-    # We can think about approaches to parametrizing the static range in the future (nop function, macro, 
+    # We can think about approaches to parametrizing the static range in the future (nop function, macro,
     # parametrizablle ti.static, parametrizable ti.range, etc...)
     B = 2
     N_left = 3
@@ -23,18 +25,22 @@ def test_for_static_if_iter_runs(use_field: bool, is_inner: bool, static_value: 
     V_ANNOT = ti.Template if use_field else ti.types.NDArray[ti.i32, 2]
 
     if is_inner:
+
         @ti.kernel
         def k1(a: V_ANNOT) -> None:
             for b in range(B):
                 for i in range(N_left) if ti.static(static_value) else ti.static(range(N_right)):
                     print(i)
                     a[b, i] = 1
+
     else:
+
         @ti.kernel
         def k1(a: V_ANNOT) -> None:
             for i in range(N_left) if ti.static(static_value) else ti.static(range(N_right)):
                 print(i)
                 a[0, i] = 1
+
     a = V(ti.i32, (B, 6))
     k1(a)
     print(a.to_numpy())
@@ -45,7 +51,7 @@ def test_for_static_if_iter_runs(use_field: bool, is_inner: bool, static_value: 
             for i in range(N_left) if static_value else range(N_right):
                 a_expected[b, i] = 1
         return a_expected
- 
+
     assert np.all(create_expected() == a.to_numpy())
 
 
@@ -58,7 +64,7 @@ def test_for_static_if_iter_static_ranges(use_field: bool, is_inner: bool, is_st
 
     # In this test, we verify that the static side is really static, and that the non-static side is
     # really non-static, by adding a conditional break to each, and seeing if that causes compilation to fail
-    
+
     # Note that break is only valid in inner loops, so we only test the inner loop case
     B = 2
     N_left = 3
@@ -73,8 +79,7 @@ def test_for_static_if_iter_static_ranges(use_field: bool, is_inner: bool, is_st
                     break
 
     if is_static:
-        with pytest.raises(ti.GsTaichiCompilationError,
-                      match="You are trying to `break` a static `for` loop"):
+        with pytest.raises(ti.GsTaichiCompilationError, match="You are trying to `break` a static `for` loop"):
             k1(0)
     else:
         # dynamic break is ok, since not static for range

--- a/tests/python/test_for.py
+++ b/tests/python/test_for.py
@@ -27,20 +27,20 @@ def test_for_static_if_iter_runs(use_field: bool, is_inner: bool, static_value: 
     if is_inner:
 
         @ti.kernel
-        def k1(a: V_ANNOT) -> None:
+        def k1(a: V_ANNOT, n_left: ti.i32) -> None:
             for b in range(B):
-                for i in range(N_left) if ti.static(static_value) else ti.static(range(N_right)):
+                for i in range(n_left) if ti.static(static_value) else ti.static(range(N_right)):
                     a[b, i] = 1
 
     else:
 
         @ti.kernel
-        def k1(a: V_ANNOT) -> None:
-            for i in range(N_left) if ti.static(static_value) else ti.static(range(N_right)):
+        def k1(a: V_ANNOT, n_left: ti.i32) -> None:
+            for i in range(n_left) if ti.static(static_value) else ti.static(range(N_right)):
                 a[0, i] = 1
 
     a = V(ti.i32, (B, 6))
-    k1(a)
+    k1(a, N_left)
 
     def create_expected():
         a_expected = np.zeros(dtype=np.int32, shape=(B, 6))
@@ -66,15 +66,15 @@ def test_for_static_if_iter_static_ranges(is_static: bool) -> None:
     N_right = 5
 
     @ti.kernel
-    def k1(break_threshold: ti.i32) -> None:
+    def k1(break_threshold: ti.i32, n_right: ti.i32) -> None:
         for b in range(B):
-            for i in ti.static(range(N_left)) if ti.static(is_static) else range(N_right):
+            for i in ti.static(range(N_left)) if ti.static(is_static) else range(n_right):
                 if i >= break_threshold:
                     break
 
     if is_static:
         with pytest.raises(ti.GsTaichiCompilationError, match="You are trying to `break` a static `for` loop"):
-            k1(0)
+            k1(0, N_right)
     else:
         # Dynamic break is ok, since not static for range.
-        k1(0)
+        k1(0, N_right)


### PR DESCRIPTION
Issue: #

### Brief Summary

Allow static if expression as top level in for loop iterator expression

Concretely, this allows structures such as:
```
for i in range(foo) if ti.static(some_flag) else range(ti.static(bar)):
```

this appears to generalize to:
- being an inner loop, e.g.
```
for b in range(B):
    for i in range(foo) if ti.static(some_flag) else range(ti.static(bar)):
```
- either side of the for iterator can be static or not, as long as the `if` expression itself is static

copilot:summary

### Walkthrough

copilot:walkthrough
