### PR TITLE
[misc] Add capabilities to facilitate fastcache debugging

### DIFF
--- a/gstaichi/compilation_manager/kernel_compilation_manager.cpp
+++ b/gstaichi/compilation_manager/kernel_compilation_manager.cpp
@@ -86,8 +86,7 @@ CompileResult KernelCompilationManager::load_or_compile(
                            ? *cached_kernel
                            : compile_and_cache_kernel(
                                  kernel_key, compile_config, caps, kernel_def),
-                       cache_hit,
-                       kernel_key};
+                       cache_hit, kernel_key};
 }
 
 void KernelCompilationManager::dump() {

--- a/gstaichi/compilation_manager/kernel_compilation_manager.cpp
+++ b/gstaichi/compilation_manager/kernel_compilation_manager.cpp
@@ -86,7 +86,8 @@ CompileResult KernelCompilationManager::load_or_compile(
                            ? *cached_kernel
                            : compile_and_cache_kernel(
                                  kernel_key, compile_config, caps, kernel_def),
-                       cache_hit};
+                       cache_hit,
+                       kernel_key};
 }
 
 void KernelCompilationManager::dump() {

--- a/gstaichi/compilation_manager/kernel_compilation_manager.h
+++ b/gstaichi/compilation_manager/kernel_compilation_manager.h
@@ -47,6 +47,7 @@ struct CacheData {
 struct CompileResult {
   const CompiledKernelData &compiled_kernel_data;
   bool cache_hit;
+  std::string cache_key;
 };
 
 class KernelCompilationManager final {

--- a/gstaichi/program/compile_config.h
+++ b/gstaichi/program/compile_config.h
@@ -60,12 +60,13 @@ struct CompileConfig {
   int cpu_max_num_threads;
   int random_seed;
 
-  // LLVM backend options:
+  // Debugging options:
   bool print_struct_llvm_ir;
   bool print_kernel_llvm_ir;
   bool print_kernel_llvm_ir_optimized;
   bool print_kernel_asm;
   bool print_kernel_amdgcn;
+  std::string debug_dump_path;
 
   // CUDA/AMDGPU backend options:
   float64 device_memory_GB;

--- a/gstaichi/program/kernel.cpp
+++ b/gstaichi/program/kernel.cpp
@@ -6,6 +6,7 @@
 #include "gstaichi/common/task.h"
 #include "gstaichi/ir/statements.h"
 #include "gstaichi/program/program.h"
+#include "gstaichi/ir/transforms.h"
 
 #ifdef TI_WITH_LLVM
 #include "gstaichi/runtime/program_impls/llvm/llvm_program.h"
@@ -28,6 +29,12 @@ Kernel::Kernel(Program &program,
                AutodiffMode autodiff_mode) {
   // due to #6362, we cannot write [func, this] { return func(this); }
   this->init(program, [&] { return func(this); }, primal_name, autodiff_mode);
+}
+
+std::string Kernel::to_string() const {
+  std::string ret;
+  irpass::print(ir.get(), &ret);
+  return ret;
 }
 
 Kernel::Kernel(Program &program,

--- a/gstaichi/program/kernel.h
+++ b/gstaichi/program/kernel.h
@@ -38,6 +38,8 @@ class TI_DLL_EXPORT Kernel : public Callable {
     return ir_is_ast_;
   }
 
+  std::string to_string() const;
+
   LaunchContextBuilder make_launch_context();
 
   template <typename T>

--- a/gstaichi/python/export_lang.cpp
+++ b/gstaichi/python/export_lang.cpp
@@ -174,6 +174,7 @@ void export_lang(py::module &m) {
                      &CompileConfig::print_kernel_llvm_ir_optimized)
       .def_readwrite("print_kernel_asm", &CompileConfig::print_kernel_asm)
       .def_readwrite("print_kernel_amdgcn", &CompileConfig::print_kernel_amdgcn)
+      .def_readwrite("debug_dump_path", &CompileConfig::debug_dump_path)
       .def_readwrite("simplify_before_lower_access",
                      &CompileConfig::simplify_before_lower_access)
       .def_readwrite("simplify_after_lower_access",

--- a/gstaichi/python/export_lang.cpp
+++ b/gstaichi/python/export_lang.cpp
@@ -488,7 +488,8 @@ void export_lang(py::module &m) {
           [](const CompileResult &self) -> const CompiledKernelData & {
             return self.compiled_kernel_data;
           })
-      .def_readonly("cache_hit", &CompileResult::cache_hit);
+      .def_readonly("cache_hit", &CompileResult::cache_hit)
+      .def_readonly("cache_key", &CompileResult::cache_key);
 
   py::class_<Axis>(m, "Axis").def(py::init<int>());
   py::class_<SNode>(m, "SNodeCxx")
@@ -610,6 +611,7 @@ void export_lang(py::module &m) {
              // TODO(#2193): Also apply to @ti.func?
              self->no_activate.push_back(snode);
            })
+      .def("to_string", &Kernel::to_string)
       .def("insert_scalar_param", &Kernel::insert_scalar_param)
       .def("insert_arr_param", &Kernel::insert_arr_param)
       .def("insert_ndarray_param", &Kernel::insert_ndarray_param)

--- a/python/gstaichi/lang/impl.py
+++ b/python/gstaichi/lang/impl.py
@@ -1,4 +1,5 @@
 import numbers
+import pathlib
 import weakref
 from types import FunctionType, MethodType
 from typing import TYPE_CHECKING, Any, Iterable, Sequence
@@ -363,6 +364,7 @@ class PyGsTaichi:
         self.short_circuit_operators: bool = False
         self.unrolling_limit: int = 0
         self.src_ll_cache: bool = True
+        self.debug_dump_path: pathlib.Path = pathlib.Path("/tmp")
 
     @property
     def compiling_callable(self) -> KernelCxx | Kernel | Function:

--- a/python/gstaichi/lang/impl.py
+++ b/python/gstaichi/lang/impl.py
@@ -1,5 +1,4 @@
 import numbers
-import pathlib
 import weakref
 from types import FunctionType, MethodType
 from typing import TYPE_CHECKING, Any, Iterable, Sequence
@@ -364,7 +363,6 @@ class PyGsTaichi:
         self.short_circuit_operators: bool = False
         self.unrolling_limit: int = 0
         self.src_ll_cache: bool = True
-        self.debug_dump_path: pathlib.Path = pathlib.Path("/tmp")
 
     @property
     def compiling_callable(self) -> KernelCxx | Kernel | Function:

--- a/python/gstaichi/lang/kernel_impl.py
+++ b/python/gstaichi/lang/kernel_impl.py
@@ -1085,8 +1085,9 @@ class Kernel:
             if not compiled_kernel_data:
                 compile_result: CompileResult = prog.compile_kernel(prog.config(), prog.get_device_caps(), t_kernel)
                 if os.environ.get("TI_DUMP_KERNEL_CHECKSUMS", "0") == "1":
-                    checksums_file_path = runtime.debug_dump_path / "checksums.csv"
-                    kernels_dump_dir = runtime.debug_dump_path / "kernels"
+                    debug_dump_path = pathlib.Path(impl.current_cfg().debug_dump_path)
+                    checksums_file_path = debug_dump_path / "checksums.csv"
+                    kernels_dump_dir = debug_dump_path / "kernels"
                     file_exists = checksums_file_path.exists()
                     if self.fast_checksum:
                         with checksums_file_path.open("a") as f:

--- a/python/gstaichi/lang/kernel_impl.py
+++ b/python/gstaichi/lang/kernel_impl.py
@@ -1080,12 +1080,13 @@ class Kernel:
             )
 
         try:
-            prog = impl.get_runtime().prog
+            runtime = impl.get_runtime()
+            prog = runtime.prog
             if not compiled_kernel_data:
                 compile_result: CompileResult = prog.compile_kernel(prog.config(), prog.get_device_caps(), t_kernel)
                 if os.environ.get("TI_DUMP_KERNEL_CHECKSUMS", "0") == "1":
-                    checksums_file_path = pathlib.Path("/tmp/checksums.csv")
-                    kernels_dump_dir = pathlib.Path("/tmp/kernels")
+                    checksums_file_path = runtime.debug_dump_path / "checksums.csv"
+                    kernels_dump_dir = runtime.debug_dump_path / "kernels"
                     file_exists = checksums_file_path.exists()
                     if self.fast_checksum:
                         with checksums_file_path.open("a") as f:

--- a/python/gstaichi/lang/kernel_impl.py
+++ b/python/gstaichi/lang/kernel_impl.py
@@ -1092,7 +1092,13 @@ class Kernel:
                             dict_writer = csv.DictWriter(f, fieldnames=["kernel", "fe", "src"])
                             if not file_exists:
                                 dict_writer.writeheader()
-                            dict_writer.writerow({"kernel": self.func.__name__, "fe": compile_result.cache_key, "src": self.fast_checksum})
+                            dict_writer.writerow(
+                                {
+                                    "kernel": self.func.__name__,
+                                    "fe": compile_result.cache_key,
+                                    "src": self.fast_checksum,
+                                }
+                            )
                             f.flush()
                         kernels_dump_dir.mkdir(exist_ok=True)
                         ch_ir_path = kernels_dump_dir / f"{compile_result.cache_key}.ll"

--- a/python/gstaichi/lang/misc.py
+++ b/python/gstaichi/lang/misc.py
@@ -1,6 +1,5 @@
 import atexit
 import os
-import pathlib
 import shutil
 import tempfile
 import warnings
@@ -306,7 +305,6 @@ def init(
     require_version: str | None = None,
     print_non_pure: bool = False,
     src_ll_cache: bool = True,
-    debug_dump_path: str = "/tmp",
     **kwargs,
 ):
     """Initializes the GsTaichi runtime.
@@ -323,7 +321,6 @@ def init(
                         @ti.pure
         src_ll_cache: enable SRC-LL-CACHE, which will accelerate loading from cache, across all architectures,
                       for pure kernels (i.e. kernels declared as @ti.pure)
-        debug_dump_path: used as the base path for TI_DUMP_KERNEL_CHECKSUMS and similar
         **kwargs: GsTaichi provides highly customizable compilation through
             ``kwargs``, which allows for fine grained control of GsTaichi compiler
             behavior. Below we list some of the most frequently used ones. For a
@@ -335,6 +332,7 @@ def init(
             * ``print_ir`` (bool): Prints the CHI IR of the GsTaichi kernels.
             *``offline_cache`` (bool): Enables offline cache of the compiled kernels. Default to True. When this is enabled GsTaichi will cache compiled kernel on your local disk to accelerate future calls.
             *``random_seed`` (int): Sets the seed of the random generator. The default is 0.
+            *``debug_dump_path`` (str): used as the base path for TI_DUMP_KERNEL_CHECKSUMS and similar
     """
     # FIXME(https://github.com/taichi-dev/gstaichi/issues/4811): save the current working directory since it may be
     # changed by the Vulkan backend initialization on OS X.
@@ -424,7 +422,6 @@ def init(
         runtime.unrolling_limit = spec_cfg.unrolling_limit
         runtime.src_ll_cache = src_ll_cache
         runtime.print_non_pure = print_non_pure
-        runtime.debug_dump_path = pathlib.Path(debug_dump_path)
         _logging.set_logging_level(spec_cfg.log_level.lower())
 
     # select arch (backend):

--- a/python/gstaichi/lang/misc.py
+++ b/python/gstaichi/lang/misc.py
@@ -1,5 +1,6 @@
 import atexit
 import os
+import pathlib
 import shutil
 import tempfile
 import warnings
@@ -305,6 +306,7 @@ def init(
     require_version: str | None = None,
     print_non_pure: bool = False,
     src_ll_cache: bool = True,
+    debug_dump_path: str = "/tmp",
     **kwargs,
 ):
     """Initializes the GsTaichi runtime.
@@ -321,6 +323,7 @@ def init(
                         @ti.pure
         src_ll_cache: enable SRC-LL-CACHE, which will accelerate loading from cache, across all architectures,
                       for pure kernels (i.e. kernels declared as @ti.pure)
+        debug_dump_path: used as the base path for TI_DUMP_KERNEL_CHECKSUMS and similar
         **kwargs: GsTaichi provides highly customizable compilation through
             ``kwargs``, which allows for fine grained control of GsTaichi compiler
             behavior. Below we list some of the most frequently used ones. For a
@@ -421,6 +424,7 @@ def init(
         runtime.unrolling_limit = spec_cfg.unrolling_limit
         runtime.src_ll_cache = src_ll_cache
         runtime.print_non_pure = print_non_pure
+        runtime.debug_dump_path = pathlib.Path(debug_dump_path)
         _logging.set_logging_level(spec_cfg.log_level.lower())
 
     # select arch (backend):

--- a/tests/python/gstaichi/lang/fast_caching/test_src_ll_cache.py
+++ b/tests/python/gstaichi/lang/fast_caching/test_src_ll_cache.py
@@ -259,8 +259,9 @@ def src_ll_cache_has_return_child(args: list[str]) -> None:
 @pytest.mark.parametrize("src_ll_cache", [False, True])
 @test_utils.test()
 def test_src_ll_cache_has_return(tmp_path: pathlib.Path, src_ll_cache: bool, return_something: bool) -> None:
+    assert ti.lang is not None
     arch = ti.lang.impl.current_cfg().arch.name
-    env = os.environ
+    env = dict(os.environ)
     env["PYTHONPATH"] = "."
     # need to test what happens when loading from fast cache, so run several runs
     # - first iteration stores to cache

--- a/tests/python/test_config.py
+++ b/tests/python/test_config.py
@@ -1,0 +1,65 @@
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+import gstaichi as ti
+
+from tests import test_utils
+
+RET_SUCCESS = 42
+
+
+def config_debug_dump_path_child(args: list[str]) -> None:
+    print('args', args)
+    arch = args[0]
+    tmp_path = args[1]
+    specify_path = args[2].lower() == "true"
+    print("tmp_path", tmp_path)
+    if specify_path:
+        ti.init(debug_dump_path=tmp_path, arch=getattr(ti, arch), offline_cache=False)
+    else:
+        ti.init(arch=getattr(ti, arch), offline_cache=False)
+
+    @ti.kernel(pure=True)
+    def k1():
+        print('hello')
+
+    k1()
+    sys.exit(RET_SUCCESS)
+
+
+@pytest.mark.parametrize("specify_path", [False, True])
+@test_utils.test()
+def test_config_debug_dump_path(specify_path: bool, tmp_path: pathlib.Path):
+    if not specify_path and sys.platform == "win32":
+        pytest.skip("Default debug_dump_path for windows not supported")
+    assert ti.lang is not None
+    arch = ti.lang.impl.current_cfg().arch.name
+    cmd_line = [sys.executable, __file__, config_debug_dump_path_child.__name__, arch, str(tmp_path), str(specify_path)]
+    print(cmd_line)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = "."
+    env["TI_DUMP_KERNEL_CHECKSUMS"] = "1"
+    proc = subprocess.run(
+        cmd_line,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if proc.returncode != RET_SUCCESS:
+        print(" ".join(cmd_line))
+        print(proc.stdout)  # needs to do this to see error messages
+        print("-" * 100)
+        print(proc.stderr)
+    assert proc.returncode == RET_SUCCESS
+    if specify_path:
+        assert len(list(tmp_path.glob("*"))) > 0
+
+
+# The following lines are critical for the tests to work. If they are missing, the test will
+# incorrectly pass, without doing anything.
+if __name__ == "__main__":
+    globals()[sys.argv[1]](sys.argv[2:])

--- a/tests/python/test_config.py
+++ b/tests/python/test_config.py
@@ -13,7 +13,7 @@ RET_SUCCESS = 42
 
 
 def config_debug_dump_path_child(args: list[str]) -> None:
-    print('args', args)
+    print("args", args)
     arch = args[0]
     tmp_path = args[1]
     specify_path = args[2].lower() == "true"
@@ -25,7 +25,7 @@ def config_debug_dump_path_child(args: list[str]) -> None:
 
     @ti.kernel(pure=True)
     def k1():
-        print('hello')
+        print("hello")
 
     k1()
     sys.exit(RET_SUCCESS)


### PR DESCRIPTION
Issue: #

### Brief Summary

Add capabilities to facilitate fastcache debugging
- kernels have new method `to_string()`, available on python side, taht returns the ChiIr of the kernel, as a text string
- CompileResult have new attribute 'cache_key', available on python side, that returns the fe-ll cache cache key, as a string
- new env var option `TI_DUMP_KERNEL_CHECKSUMS=1`, which will:
     - for each kernel that has a fastcache key
          - the first time the kernel is compiled:
                - append both the fastcache key, and fe-ll cache key, to a csv file /tmp/cachekeys.csv, as a new row, along with the kernel name
                - write the ChiIr of the kernel to /tmp/kernels, with the filename set to the fe-ll cache key
     - this allows us to detect kernels where multiple fe-ll cache keys maps to a singel fastcache key
          - and compare the ChiIr for such kernels
          - to track down why the fastcache cache key is not correctly distinguishing between the two compiled variatns of this kernel

copilot:summary

### Walkthrough

copilot:walkthrough
