### PR TITLE
[Test] Completely skip test_matrix_ndarray_oob on windows

### DIFF
--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -833,6 +833,7 @@ def test_scalar_ndarray_oob():
     check_out_of_bound=True,
     gdb_trigger=False,
 )
+# TODO: investigate why this crashes sometimes on Windows
 @pytest.mark.skipif(sys.platform == "win32", reason="Crashes frequently on windows")
 def test_matrix_ndarray_oob():
     @ti.kernel


### PR DESCRIPTION
Issue: #

### Brief Summary

Completely skip test_matrix_ndarray_oob on windows
- since it crashes with 'fatal error: access violation', sometimes
- eg https://github.com/Genesis-Embodied-AI/gstaichi/actions/runs/18409442557/job/52459716546

<img width="2672" height="1124" alt="Screenshot 2025-10-10 at 11 11 41" src="https://github.com/user-attachments/assets/8b14852d-3bff-4f25-b4d6-5c40c7b81c63" />

copilot:summary

### Walkthrough

copilot:walkthrough
