### PR TITLE
[Perf] Do not copy kernel parameters.

### DIFF
--- a/gstaichi/runtime/amdgpu/kernel_launcher.cpp
+++ b/gstaichi/runtime/amdgpu/kernel_launcher.cpp
@@ -19,7 +19,7 @@ void KernelLauncher::launch_llvm_kernel(Handle handle,
   auto launcher_ctx = contexts_[handle.get_launch_id()];
   auto *executor = get_runtime_executor();
   auto *amdgpu_module = launcher_ctx.jit_module;
-  const auto &parameters = launcher_ctx.parameters;
+  const auto &parameters = *launcher_ctx.parameters;
   const auto &offloaded_tasks = launcher_ctx.offloaded_tasks;
 
   AMDGPUContext::get_instance().make_current();
@@ -145,12 +145,11 @@ KernelLauncher::Handle KernelLauncher::register_llvm_kernel(
     auto *executor = get_runtime_executor();
 
     auto data = compiled.get_internal_data().compiled_data.clone();
-    auto parameters = compiled.get_internal_data().args;
     auto *jit_module = executor->create_jit_module(std::move(data.module));
 
     // Populate ctx
     ctx.jit_module = jit_module;
-    ctx.parameters = std::move(parameters);
+    ctx.parameters = &compiled.get_internal_data().args;
     ctx.offloaded_tasks = std::move(data.tasks);
 
     compiled.set_handle(handle);

--- a/gstaichi/runtime/amdgpu/kernel_launcher.h
+++ b/gstaichi/runtime/amdgpu/kernel_launcher.h
@@ -11,7 +11,7 @@ class KernelLauncher : public LLVM::KernelLauncher {
 
   struct Context {
     JITModule *jit_module{nullptr};
-    std::vector<std::pair<int, Callable::Parameter>> parameters;
+    const std::vector<std::pair<int, Callable::Parameter>> *parameters;
     std::vector<OffloadedTask> offloaded_tasks;
   };
 

--- a/gstaichi/runtime/cpu/kernel_launcher.cpp
+++ b/gstaichi/runtime/cpu/kernel_launcher.cpp
@@ -13,7 +13,7 @@ void KernelLauncher::launch_llvm_kernel(Handle handle,
   ctx.get_context().runtime = executor->get_llvm_runtime();
   // For gstaichi ndarrays, context.array_ptrs saves pointer to its
   // |DeviceAllocation|, CPU backend actually want to use the raw ptr here.
-  const auto &parameters = launcher_ctx.parameters;
+  const auto &parameters = *launcher_ctx.parameters;
   for (int i = 0; i < (int)parameters.size(); i++) {
     const auto &kv = parameters[i];
     const auto &arg_id = kv.first;
@@ -59,7 +59,6 @@ KernelLauncher::Handle KernelLauncher::register_llvm_kernel(
     auto *executor = get_runtime_executor();
 
     auto data = compiled.get_internal_data().compiled_data.clone();
-    auto parameters = compiled.get_internal_data().args;
     auto *jit_module = executor->create_jit_module(std::move(data.module));
 
     // Construct task_funcs
@@ -74,7 +73,7 @@ KernelLauncher::Handle KernelLauncher::register_llvm_kernel(
     }
 
     // Populate ctx
-    ctx.parameters = std::move(parameters);
+    ctx.parameters = &compiled.get_internal_data().args;
     ctx.task_funcs = std::move(task_funcs);
 
     compiled.set_handle(handle);

--- a/gstaichi/runtime/cpu/kernel_launcher.h
+++ b/gstaichi/runtime/cpu/kernel_launcher.h
@@ -12,7 +12,7 @@ class KernelLauncher : public LLVM::KernelLauncher {
   struct Context {
     using TaskFunc = int32 (*)(void *);
     std::vector<TaskFunc> task_funcs;
-    std::vector<std::pair<int, Callable::Parameter>> parameters;
+    const std::vector<std::pair<int, Callable::Parameter>> *parameters;
   };
 
  public:

--- a/gstaichi/runtime/cuda/kernel_launcher.cpp
+++ b/gstaichi/runtime/cuda/kernel_launcher.cpp
@@ -18,7 +18,7 @@ void KernelLauncher::launch_llvm_kernel(Handle handle,
   auto launcher_ctx = contexts_[handle.get_launch_id()];
   auto *executor = get_runtime_executor();
   auto *cuda_module = launcher_ctx.jit_module;
-  const auto &parameters = launcher_ctx.parameters;
+  const auto &parameters = *launcher_ctx.parameters;
   const auto &offloaded_tasks = launcher_ctx.offloaded_tasks;
 
   CUDAContext::get_instance().make_current();
@@ -177,12 +177,11 @@ KernelLauncher::Handle KernelLauncher::register_llvm_kernel(
     auto *executor = get_runtime_executor();
 
     auto data = compiled.get_internal_data().compiled_data.clone();
-    auto parameters = compiled.get_internal_data().args;
     auto *jit_module = executor->create_jit_module(std::move(data.module));
 
     // Populate ctx
     ctx.jit_module = jit_module;
-    ctx.parameters = std::move(parameters);
+    ctx.parameters = &compiled.get_internal_data().args;
     ctx.offloaded_tasks = std::move(data.tasks);
 
     compiled.set_handle(handle);

--- a/gstaichi/runtime/cuda/kernel_launcher.h
+++ b/gstaichi/runtime/cuda/kernel_launcher.h
@@ -11,7 +11,7 @@ class KernelLauncher : public LLVM::KernelLauncher {
 
   struct Context {
     JITModule *jit_module{nullptr};
-    std::vector<std::pair<int, Callable::Parameter>> parameters;
+    const std::vector<std::pair<int, Callable::Parameter>> *parameters;
     std::vector<OffloadedTask> offloaded_tasks;
   };
 


### PR DESCRIPTION
Running single franka benchmark on Coreweave cluster:
```bash
GS_ENABLE_NDARRAY=1 pytest --print -sv -m "benchmarks" -n 0 \
    "tests/test_rigid_benchmarks.py::test_speed[batched_franka-None-None-0-cpu]"
```

| PR (branch) | runtime FPS |
| -------- | ------- |
| #259 (hp/prune-unused-dataclass-fields-adding-fastcache) | 1120FPS |
| + #263 (duburcqa/avoid_dyn_cast) | 1200FPS  |
| + #266 (duburcqa/launch_context_fixedsize_key) | 1560FPS  |
| **+ #267 (duburcqa/kernel_params_nocopy)** | **1710FPS**  |
| + #264 (duburcqa/template_mapper_arg_cache) | 2470FPS  |
| + #265 (duburcqa/update_x86_arch) | 2520FPS  |