### PR TITLE
[Build] Pin manylinux arm to 2025.11.11-1

### DIFF
--- a/.github/workflows/manylinux_wheel.yml
+++ b/.github/workflows/manylinux_wheel.yml
@@ -17,7 +17,7 @@ jobs:
   build_wheel:
     name: Manylinux wheel Build
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.os == 'ubuntu-22.04' && 'quay.io/pypa/manylinux_2_28_x86_64:latest' || matrix.os == 'ubuntu-22.04-arm' && 'quay.io/pypa/manylinux_2_34_aarch64::2025.11.11-1' }}
+    container: ${{ matrix.os == 'ubuntu-22.04' && 'quay.io/pypa/manylinux_2_28_x86_64:latest' || matrix.os == 'ubuntu-22.04-arm' && 'quay.io/pypa/manylinux_2_34_aarch64:2025.11.11-1' }}
     concurrency:
       # group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}-${{ matrix.PYTHON_CP_VERSION }}-${{ matrix.PYTHON_CP_VERSION != 'cp310' && 'all' || github.sha }}-build
       group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}-${{ matrix.PYTHON_CP_VERSION }}-${{matrix.os}}-build


### PR DESCRIPTION
Issue: #

### Brief Summary

- main is failing, for arm linux, following an update to manylinux 2 34 image yesterday
- this PR pins manylinux arm to the previous version of the manylinux 2 34 image, which builds ok.

copilot:summary

### Walkthrough

copilot:walkthrough
