### PR TITLE
[Misc] Rename ASTTransformerContext to ASTTransformerFuncContext

### DIFF
--- a/python/gstaichi/lang/_func_base.py
+++ b/python/gstaichi/lang/_func_base.py
@@ -22,7 +22,7 @@ from gstaichi._lib.core.gstaichi_python import KernelLaunchContext
 from gstaichi.lang import _kernel_impl_dataclass, impl
 from gstaichi.lang._ndarray import Ndarray
 from gstaichi.lang._wrap_inspect import get_source_info_and_src
-from gstaichi.lang.ast import ASTTransformerContext
+from gstaichi.lang.ast import ASTTransformerFuncContext
 from gstaichi.lang.exception import (
     GsTaichiRuntimeError,
     GsTaichiRuntimeTypeError,
@@ -195,7 +195,7 @@ class FuncBase:
         ast_builder: "ASTBuilder | None" = None,
         is_real_function: bool = False,
         current_kernel: "Kernel | None" = None,
-    ) -> tuple[ast.Module, ASTTransformerContext]:
+    ) -> tuple[ast.Module, ASTTransformerFuncContext]:
         function_source_info, src = get_source_info_and_src(self.func)
         src = [textwrap.fill(line, tabsize=4, width=9999) for line in src]
         tree = ast.parse(textwrap.dedent("\n".join(src)))
@@ -230,7 +230,7 @@ class FuncBase:
 
         args_instance_key = current_kernel.currently_compiling_materialize_key
         assert args_instance_key is not None
-        ctx = ASTTransformerContext(
+        ctx = ASTTransformerFuncContext(
             excluded_parameters=excluded_parameters,
             is_kernel=is_kernel,
             is_pure=is_pure,

--- a/python/gstaichi/lang/_kernel_impl_dataclass.py
+++ b/python/gstaichi/lang/_kernel_impl_dataclass.py
@@ -6,7 +6,7 @@ from typing import Any
 from gstaichi.lang import util
 from gstaichi.lang._dataclass_util import create_flat_name
 from gstaichi.lang.ast import (
-    ASTTransformerContext,
+    ASTTransformerFuncContext,
 )
 from gstaichi.lang.kernel_arguments import ArgMetadata
 
@@ -61,7 +61,7 @@ def _populate_struct_locals_from_params_dict(basename: str, struct_locals, struc
             struct_locals.add(child_name)
 
 
-def extract_struct_locals_from_context(ctx: ASTTransformerContext) -> set[str]:
+def extract_struct_locals_from_context(ctx: ASTTransformerFuncContext) -> set[str]:
     """
     Provides meta information for later tarnsformation of nodes in AST
 

--- a/python/gstaichi/lang/ast/__init__.py
+++ b/python/gstaichi/lang/ast/__init__.py
@@ -1,7 +1,7 @@
 # type: ignore
 
-from gstaichi.lang.ast.ast_transformer_utils import ASTTransformerContext
+from gstaichi.lang.ast.ast_transformer_utils import ASTTransformerFuncContext
 from gstaichi.lang.ast.checkers import KernelSimplicityASTChecker
 from gstaichi.lang.ast.transform import transform_tree
 
-__all__ = ["ASTTransformerContext", "KernelSimplicityASTChecker", "transform_tree"]
+__all__ = ["ASTTransformerFuncContext", "KernelSimplicityASTChecker", "transform_tree"]

--- a/python/gstaichi/lang/ast/ast_transformer_utils.py
+++ b/python/gstaichi/lang/ast/ast_transformer_utils.py
@@ -27,7 +27,7 @@ AutodiffMode = _ti_core.AutodiffMode
 
 
 class Builder:
-    def __call__(self, ctx: "ASTTransformerContext", node: ast.AST):
+    def __call__(self, ctx: "ASTTransformerFuncContext", node: ast.AST):
         method_name = "build_" + node.__class__.__name__
         method = getattr(self, method_name, None)
         try:
@@ -172,7 +172,7 @@ class PureViolation:
     var_name: str
 
 
-class ASTTransformerContext:
+class ASTTransformerFuncContext:
     def __init__(
         self,
         excluded_parameters,
@@ -394,7 +394,7 @@ class ASTTransformerContext:
         return msg
 
 
-def get_decorator(ctx: ASTTransformerContext, node) -> str:
+def get_decorator(ctx: ASTTransformerFuncContext, node) -> str:
     if not isinstance(node, ast.Call):
         return ""
     for wanted, name in [

--- a/python/gstaichi/lang/ast/ast_transformers/call_transformer.py
+++ b/python/gstaichi/lang/ast/ast_transformers/call_transformer.py
@@ -21,7 +21,7 @@ from gstaichi.lang import (
 from gstaichi.lang import ops as ti_ops
 from gstaichi.lang._dataclass_util import create_flat_name
 from gstaichi.lang.ast.ast_transformer_utils import (
-    ASTTransformerContext,
+    ASTTransformerFuncContext,
     get_decorator,
 )
 from gstaichi.lang.exception import (
@@ -36,7 +36,7 @@ from gstaichi.types import primitive_types
 
 class CallTransformer:
     @staticmethod
-    def _build_call_if_is_builtin(ctx: ASTTransformerContext, node, args, keywords):
+    def _build_call_if_is_builtin(ctx: ASTTransformerFuncContext, node, args, keywords):
         from gstaichi.lang import matrix_ops  # pylint: disable=C0415
 
         func = node.func.ptr
@@ -66,7 +66,7 @@ class CallTransformer:
         return False
 
     @staticmethod
-    def _build_call_if_is_type(ctx: ASTTransformerContext, node, args, keywords):
+    def _build_call_if_is_type(ctx: ASTTransformerFuncContext, node, args, keywords):
         func = node.func.ptr
         if id(func) in primitive_types.type_ids:
             if len(args) != 1 or keywords:
@@ -84,7 +84,7 @@ class CallTransformer:
         return False
 
     @staticmethod
-    def _is_external_func(ctx: ASTTransformerContext, func) -> bool:
+    def _is_external_func(ctx: ASTTransformerFuncContext, func) -> bool:
         if ctx.is_in_static_scope():  # allow external function in static scope
             return False
         if hasattr(func, "_is_gstaichi_function") or hasattr(func, "_is_wrapped_kernel"):  # gstaichi func/kernel
@@ -94,7 +94,7 @@ class CallTransformer:
         return True
 
     @staticmethod
-    def _warn_if_is_external_func(ctx: ASTTransformerContext, node):
+    def _warn_if_is_external_func(ctx: ASTTransformerFuncContext, node):
         func = node.func.ptr
         if not CallTransformer._is_external_func(ctx, func):
             return
@@ -167,7 +167,7 @@ class CallTransformer:
 
     @staticmethod
     def _expand_Call_dataclass_args(
-        ctx: ASTTransformerContext, args: tuple[ast.stmt, ...]
+        ctx: ASTTransformerFuncContext, args: tuple[ast.stmt, ...]
     ) -> tuple[tuple[ast.stmt, ...], tuple[ast.stmt, ...]]:
         """
         We require that each node has a .ptr attribute added to it, that contains
@@ -212,7 +212,7 @@ class CallTransformer:
 
     @staticmethod
     def _expand_Call_dataclass_kwargs(
-        ctx: ASTTransformerContext, kwargs: list[ast.keyword]
+        ctx: ASTTransformerFuncContext, kwargs: list[ast.keyword]
     ) -> tuple[list[ast.keyword], list[ast.keyword]]:
         """
         We require that each node has a .ptr attribute added to it, that contains
@@ -263,7 +263,7 @@ class CallTransformer:
         return added_kwargs, kwargs_new
 
     @staticmethod
-    def build_Call(ctx: ASTTransformerContext, node: ast.Call, build_stmt, build_stmts) -> Any | None:
+    def build_Call(ctx: ASTTransformerFuncContext, node: ast.Call, build_stmt, build_stmts) -> Any | None:
         """
         example ast:
         Call(func=Name(id='f2', ctx=Load()), args=[Name(id='my_struct_ab', ctx=Load())], keywords=[])

--- a/python/gstaichi/lang/ast/ast_transformers/function_def_transformer.py
+++ b/python/gstaichi/lang/ast/ast_transformers/function_def_transformer.py
@@ -19,7 +19,7 @@ from gstaichi.lang import (
 from gstaichi.lang import ops as ti_ops
 from gstaichi.lang._dataclass_util import create_flat_name
 from gstaichi.lang.ast.ast_transformer_utils import (
-    ASTTransformerContext,
+    ASTTransformerFuncContext,
 )
 from gstaichi.lang.exception import (
     GsTaichiSyntaxError,
@@ -33,7 +33,7 @@ from gstaichi.types import annotations, ndarray_type, primitive_types
 class FunctionDefTransformer:
     @staticmethod
     def _decl_and_create_variable(
-        ctx: ASTTransformerContext,
+        ctx: ASTTransformerFuncContext,
         annotation: Any,
         name: str,
         this_arg_features: tuple[tuple[Any, ...], ...] | None,
@@ -80,7 +80,7 @@ class FunctionDefTransformer:
 
     @staticmethod
     def _transform_kernel_arg(
-        ctx: ASTTransformerContext,
+        ctx: ASTTransformerFuncContext,
         argument_name: str,
         argument_type: Any,
         this_arg_features: tuple[Any, ...],
@@ -130,7 +130,7 @@ class FunctionDefTransformer:
             ctx.create_variable(argument_name, obj)
 
     @staticmethod
-    def _transform_as_kernel(ctx: ASTTransformerContext, node: ast.FunctionDef, args: ast.arguments) -> None:
+    def _transform_as_kernel(ctx: ASTTransformerFuncContext, node: ast.FunctionDef, args: ast.arguments) -> None:
         assert ctx.func is not None
         assert ctx.arg_features is not None
         if node.returns is not None:
@@ -157,7 +157,7 @@ class FunctionDefTransformer:
 
     @staticmethod
     def _transform_func_arg(
-        ctx: ASTTransformerContext,
+        ctx: ASTTransformerFuncContext,
         argument_name: str,
         argument_type: Any,
         data: Any,
@@ -249,7 +249,7 @@ class FunctionDefTransformer:
         return None
 
     @staticmethod
-    def _transform_as_func(ctx: ASTTransformerContext, node: ast.FunctionDef, args: ast.arguments) -> None:
+    def _transform_as_func(ctx: ASTTransformerFuncContext, node: ast.FunctionDef, args: ast.arguments) -> None:
         # pylint: disable=import-outside-toplevel
         from gstaichi.lang.kernel_impl import Func
 
@@ -266,9 +266,9 @@ class FunctionDefTransformer:
 
     @staticmethod
     def build_FunctionDef(
-        ctx: ASTTransformerContext,
+        ctx: ASTTransformerFuncContext,
         node: ast.FunctionDef,
-        build_stmts: Callable[[ASTTransformerContext, list[ast.stmt]], None],
+        build_stmts: Callable[[ASTTransformerFuncContext, list[ast.stmt]], None],
     ) -> None:
         if ctx.visited_funcdef:
             raise GsTaichiSyntaxError(

--- a/python/gstaichi/lang/ast/transform.py
+++ b/python/gstaichi/lang/ast/transform.py
@@ -1,9 +1,9 @@
 # type: ignore
 
 from gstaichi.lang.ast.ast_transformer import ASTTransformer
-from gstaichi.lang.ast.ast_transformer_utils import ASTTransformerContext
+from gstaichi.lang.ast.ast_transformer_utils import ASTTransformerFuncContext
 
 
-def transform_tree(tree, ctx: ASTTransformerContext):
+def transform_tree(tree, ctx: ASTTransformerFuncContext):
     ASTTransformer()(ctx, tree)
     return ctx.return_data

--- a/python/gstaichi/lang/kernel.py
+++ b/python/gstaichi/lang/kernel.py
@@ -27,7 +27,10 @@ from gstaichi.lang.ast import (
     KernelSimplicityASTChecker,
     transform_tree,
 )
-from gstaichi.lang.ast.ast_transformer_utils import ASTTransformerContext, ReturnStatus
+from gstaichi.lang.ast.ast_transformer_utils import (
+    ASTTransformerFuncContext,
+    ReturnStatus,
+)
 from gstaichi.lang.exception import (
     GsTaichiRuntimeTypeError,
     GsTaichiSyntaxError,
@@ -159,7 +162,7 @@ class LaunchContextBufferCache:
 class ASTGenerator:
     def __init__(
         self,
-        ctx: ASTTransformerContext,
+        ctx: ASTTransformerFuncContext,
         kernel_name: str,
         current_kernel: "Kernel",
         only_parse_function_def: bool,

--- a/tests/python/gstaichi/lang/ast/test_call_transformer.py
+++ b/tests/python/gstaichi/lang/ast/test_call_transformer.py
@@ -4,7 +4,7 @@ import dataclasses
 import pytest
 
 import gstaichi as ti
-from gstaichi.lang.ast.ast_transformer_utils import ASTTransformerContext
+from gstaichi.lang.ast.ast_transformer_utils import ASTTransformerFuncContext
 from gstaichi.lang.ast.ast_transformers.call_transformer import CallTransformer
 
 from tests import test_utils
@@ -77,7 +77,7 @@ def test_expand_Call_dataclass_args(args_in: tuple[ast.stmt, ...], expected_args
         arg.col_offset = 1
         arg.end_col_offset = 2
 
-    class MockContext(ASTTransformerContext):
+    class MockContext(ASTTransformerFuncContext):
         def __init__(self):
             self.used_py_dataclass_parameters_enforcing = None
 


### PR DESCRIPTION
Issue: #

### Brief Summary
- Rename ASTTransformerContext to ASTTransformerFuncContext
    - Part of https://github.com/Genesis-Embodied-AI/gstaichi/pull/333/files

copilot:summary

### Walkthrough

copilot:walkthrough
