### PR TITLE
[Misc] Migrate pydantic to use config dict

### DIFF
--- a/python/gstaichi/lang/_wrap_inspect.py
+++ b/python/gstaichi/lang/_wrap_inspect.py
@@ -22,7 +22,7 @@ import tempfile
 from typing import Callable
 
 import dill
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 _builtin_getfile = inspect.getfile
 _builtin_findsource = inspect.findsource
@@ -194,8 +194,7 @@ class FunctionSourceInfo(BaseModel):
     start_lineno: int
     end_lineno: int
 
-    class Config:
-        frozen = True
+    model_config = ConfigDict(frozen=True)
 
 
 def get_source_info_and_src(func: Callable) -> tuple[FunctionSourceInfo, list[str]]:


### PR DESCRIPTION
Issue: #

### Brief Summary

- avoid deprecated messages:
```
[...].venv\Lib\site-packages\gstaichi\lang\_wrap_inspect.py:191: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    class FunctionSourceInfo(BaseModel):
```

copilot:summary

### Walkthrough

copilot:walkthrough
