### PR TITLE
[Perf] @qd.perf_dispatch enhancements

### DIFF
--- a/python/quadrants/lang/_func_base.py
+++ b/python/quadrants/lang/_func_base.py
@@ -40,8 +40,6 @@ from quadrants.types import (
     template,
 )
 
-from ._exceptions import raise_exception
-from ._perf_dispatch import DispatchImpl
 from .ast.ast_transformer_utils import ASTTransformerGlobalContext
 
 if TYPE_CHECKING:
@@ -152,12 +150,6 @@ class FuncBase:
                     pass
                 elif self.is_kernel and isinstance(annotation, sparse_matrix_builder):
                     pass
-                elif self.func is DispatchImpl:
-                    raise_exception(
-                        QuadrantsSyntaxError,
-                        msg="@ti.kernel must be above @ti.perf_dispatch",
-                        err_code="PERFDISPATCH_ANNOTATION_SEQUENCE_MISMATCH",
-                    )
                 else:
                     raise QuadrantsSyntaxError(f"Invalid type annotation (argument {i}) of Taichi kernel: {annotation}")
             self.arg_metas.append(ArgMetadata(annotation, param.name, param.default))


### PR DESCRIPTION
Issue: #

### Brief Summary

- enable dispatch to python functions, not just Quadrants kernels
- add debug logging of which implementation was chosen, so not completely blind, when doesn't work 😅 , if provide env var `TI_PERFDISPATCH_PRINT_DEBUG=1`
- add `warmup`, `active`, `repeat_after_count`, `repeat_after_seconds` parameters to `@qd.perf_dispatch`

copilot:summary

### Walkthrough

copilot:walkthrough
