### PR TITLE
[Build] Wire up ./build.py --write-env for scriptable dev installs

### DIFF
--- a/.github/workflows/scripts/ti_build/alter.py
+++ b/.github/workflows/scripts/ti_build/alter.py
@@ -154,7 +154,12 @@ def _write_env(path):
 
 
 def handle_alternate_actions():
-    if misc.options.shell:
+    if misc.options.write_env:
+        cmake_args.writeback()
+        _write_env(misc.options.write_env)
+        misc.info(f"Environment written to {misc.options.write_env}")
+        sys.exit(0)
+    elif misc.options.shell:
         enter_shell()
     else:
         return


### PR DESCRIPTION
The --write-env flag was already parsed but never handled. This connects it to the existing _write_env() helper so that build environment variables (LLVM_DIR, QUADRANTS_CMAKE_ARGS, etc.) can be exported to a .sh/.json/.ps1 file without entering an interactive shell.

Usage: ./build.py --write-env build_env.sh
       source build_env.sh
       python setup.py develop
Made-with: Cursor

Issue: #

### Brief Summary

Basically means that AIs can now build Quadrants for themselves, rather than waiting for me to do it for them 😅

copilot:summary

### Walkthrough

copilot:walkthrough
