### PR TITLE
[CI] Add test coverage reporting as PR comments

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,8 +49,8 @@ jobs:
           git fetch origin ${{ github.base_ref }} --depth=1
           diff-cover coverage.xml \
             --compare-branch=origin/${{ github.base_ref }} \
-            --md-report=diff-cover.md \
-            --fail-under=0 || true
+            --fail-under=0 \
+            --format markdown > diff-cover.md || true
           DIFF_COV=$(diff-cover coverage.xml \
             --compare-branch=origin/${{ github.base_ref }} \
             --fail-under=0 2>&1 \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -85,3 +85,9 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           path: coverage-comment.md
+      - name: Diff coverage check
+        if: github.event_name == 'pull_request'
+        run: |
+          diff-cover coverage.xml \
+            --compare-branch=origin/${{ github.base_ref }} \
+            --fail-under=80

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -50,7 +50,7 @@ jobs:
           diff-cover coverage.xml \
             --compare-branch=origin/${{ github.base_ref }} \
             --fail-under=0 \
-            --format markdown > diff-cover.md || true
+            --format markdown:diff-cover.md || true
           DIFF_COV=$(diff-cover coverage.xml \
             --compare-branch=origin/${{ github.base_ref }} \
             --fail-under=0 2>&1 \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ${{ matrix.OS }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Python check
         uses: actions/setup-python@v4
         with:
@@ -40,8 +42,46 @@ jobs:
       - name: Linux test
         run: |
           bash .github/workflows/scripts_new/linux/4_test.sh
-      - name: Pytest coverage comment
+      - name: Generate coverage PR comment
         if: github.event_name == 'pull_request'
-        uses: MishaKav/pytest-coverage-comment@v1
+        run: |
+          pip install diff-cover
+          git fetch origin ${{ github.base_ref }} --depth=1
+          diff-cover coverage.xml \
+            --compare-branch=origin/${{ github.base_ref }} \
+            --md-report=diff-cover.md \
+            --fail-under=0 || true
+          DIFF_COV=$(diff-cover coverage.xml \
+            --compare-branch=origin/${{ github.base_ref }} \
+            --fail-under=0 2>&1 \
+            | grep -oP 'Diff Coverage: \K[\d.]+%' || echo 'N/A')
+          OVERALL=$(tail -1 pytest-coverage.txt | grep -oP '\d+%' || echo 'N/A')
+          {
+            echo '## Coverage Report'
+            echo ''
+            echo '| Metric | Value |'
+            echo '|--------|-------|'
+            echo "| **Diff coverage** (changed lines only) | **${DIFF_COV}** |"
+            echo "| Overall project coverage | ${OVERALL} |"
+            echo ''
+            echo '<details>'
+            echo '<summary>Changed files coverage details</summary>'
+            echo ''
+            cat diff-cover.md
+            echo ''
+            echo '</details>'
+            echo ''
+            echo '<details>'
+            echo '<summary>Full coverage report (files below 100%)</summary>'
+            echo ''
+            echo '```'
+            head -200 pytest-coverage.txt
+            echo '```'
+            echo ''
+            echo '</details>'
+          } > coverage-comment.md
+      - name: Post coverage comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          pytest-coverage-path: pytest-coverage.txt
+          path: coverage-comment.md

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,9 @@ on:
       - reopened
       - synchronize
   workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -37,3 +40,8 @@ jobs:
       - name: Linux test
         run: |
           bash .github/workflows/scripts_new/linux/4_test.sh
+      - name: Pytest coverage comment
+        if: github.event_name == 'pull_request'
+        uses: MishaKav/pytest-coverage-comment@v1
+        with:
+          pytest-coverage-path: pytest-coverage.txt

--- a/.github/workflows/scripts_new/linux/4_test.sh
+++ b/.github/workflows/scripts_new/linux/4_test.sh
@@ -8,8 +8,11 @@ export QD_LIB_DIR="$(python -c 'import quadrants as ti; print(ti.__path__[0])' |
 ./build/quadrants_cpp_tests  --gtest_filter=-AMDGPU.*
 
 # Phase 1: run all tests except torch-dependent ones
-python tests/run_tests.py -v -r 3 -m "not needs_torch"
+python tests/run_tests.py -v -r 3 -m "not needs_torch" --coverage
 
 # Phase 2: install torch, run only torch tests
 pip install torch --index-url https://download.pytorch.org/whl/cpu
-python tests/run_tests.py -v -r 3 -m needs_torch
+python tests/run_tests.py -v -r 3 -m needs_torch --coverage --cov-append
+
+# Generate coverage text report for PR comment
+coverage report --show-missing > pytest-coverage.txt

--- a/.github/workflows/scripts_new/linux/4_test.sh
+++ b/.github/workflows/scripts_new/linux/4_test.sh
@@ -14,5 +14,6 @@ python tests/run_tests.py -v -r 3 -m "not needs_torch" --coverage
 pip install torch --index-url https://download.pytorch.org/whl/cpu
 python tests/run_tests.py -v -r 3 -m needs_torch --coverage --cov-append
 
-# Generate coverage text report for PR comment
-coverage report --show-missing > pytest-coverage.txt
+# Generate coverage reports
+coverage xml -o coverage.xml
+coverage report --show-missing --skip-covered > pytest-coverage.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,14 @@ requires = [
 # things, without doing full c++ build
 build-backend = "setuptools.build_meta"
 
+[tool.coverage.report]
+exclude_also = [
+    "@qd\\.func",
+    "@qd\\.kernel",
+    "@ti\\.func",
+    "@ti\\.kernel",
+]
+
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore:Calling non-taichi function",


### PR DESCRIPTION
Enable pytest-cov in Linux CI and post coverage summary as a PR comment via MishaKav/pytest-coverage-comment. Uses only the built-in GITHUB_TOKEN — no external service or org permissions.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
