### PR TITLE
[Misc] Remove dead InternalFuncStmt type_check override

### DIFF
--- a/quadrants/transforms/type_check.cpp
+++ b/quadrants/transforms/type_check.cpp
@@ -521,11 +521,6 @@ class TypeCheck : public IRVisitor {
     stmt->ret_type.set_is_pointer(true);
   }
 
-  void visit(InternalFuncStmt *stmt) override {
-    // TODO: support return type specification
-    stmt->ret_type = PrimitiveType::i32;
-  }
-
   void visit(BitStructStoreStmt *stmt) override {
     // do nothing
   }


### PR DESCRIPTION
TypeCheck has allow_undefined_visitor=true, so removing this override is a no-op. The original code was actively wrong (overwriting correct ret_type with i32), but nothing downstream relied on ret_type from the type_check pass for InternalFuncStmt, so the bug was latent. Removing the override eliminates the misleading TODO and prevents a future pass from accidentally depending on the wrong type.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
