### PR TITLE
[Perf] Tiles 2a: add cholesky and ger

### DIFF
--- a/python/quadrants/lang/simt/_tile16.py
+++ b/python/quadrants/lang/simt/_tile16.py
@@ -306,6 +306,268 @@ def _make_tile16x16_class(dtype):
             if tid == 15:
                 self.r15 = 1.0
 
+        @qd.func
+        def _ger_sub(self, a, b):
+            """General rank-1 subtract in-place: self -= a @ b^T."""
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(0))
+            self.r0 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(1))
+            self.r1 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(2))
+            self.r2 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(3))
+            self.r3 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(4))
+            self.r4 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(5))
+            self.r5 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(6))
+            self.r6 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(7))
+            self.r7 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(8))
+            self.r8 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(9))
+            self.r9 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(10))
+            self.r10 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(11))
+            self.r11 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(12))
+            self.r12 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(13))
+            self.r13 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(14))
+            self.r14 -= a * bc
+            bc = qd.simt.subgroup.shuffle(b, qd.u32(15))
+            self.r15 -= a * bc
+
+        @qd.func
+        def cholesky_(self, eps):
+            """In-place 16x16 Cholesky factorization via subgroup shuffles.
+
+            On return, the lower triangle holds L such that A = L @ L^T.
+            Diagonal clamped to sqrt(max(value, eps)) for numerical stability.
+            """
+            tid = qd.i32(qd.simt.subgroup.invocation_id())
+            for k in range(_TILE):
+                diag_val = qd.cast(0.0, dtype)
+                if tid == k:
+                    s = qd.cast(0.0, dtype)
+                    if k > 0:
+                        s += self.r0 * self.r0
+                    if k > 1:
+                        s += self.r1 * self.r1
+                    if k > 2:
+                        s += self.r2 * self.r2
+                    if k > 3:
+                        s += self.r3 * self.r3
+                    if k > 4:
+                        s += self.r4 * self.r4
+                    if k > 5:
+                        s += self.r5 * self.r5
+                    if k > 6:
+                        s += self.r6 * self.r6
+                    if k > 7:
+                        s += self.r7 * self.r7
+                    if k > 8:
+                        s += self.r8 * self.r8
+                    if k > 9:
+                        s += self.r9 * self.r9
+                    if k > 10:
+                        s += self.r10 * self.r10
+                    if k > 11:
+                        s += self.r11 * self.r11
+                    if k > 12:
+                        s += self.r12 * self.r12
+                    if k > 13:
+                        s += self.r13 * self.r13
+                    if k > 14:
+                        s += self.r14 * self.r14
+                    cur = qd.cast(0.0, dtype)
+                    if k == 0:
+                        cur = self.r0
+                    if k == 1:
+                        cur = self.r1
+                    if k == 2:
+                        cur = self.r2
+                    if k == 3:
+                        cur = self.r3
+                    if k == 4:
+                        cur = self.r4
+                    if k == 5:
+                        cur = self.r5
+                    if k == 6:
+                        cur = self.r6
+                    if k == 7:
+                        cur = self.r7
+                    if k == 8:
+                        cur = self.r8
+                    if k == 9:
+                        cur = self.r9
+                    if k == 10:
+                        cur = self.r10
+                    if k == 11:
+                        cur = self.r11
+                    if k == 12:
+                        cur = self.r12
+                    if k == 13:
+                        cur = self.r13
+                    if k == 14:
+                        cur = self.r14
+                    if k == 15:
+                        cur = self.r15
+                    diag_val = qd.sqrt(qd.max(cur - s, eps))
+                    if k == 0:
+                        self.r0 = diag_val
+                    if k == 1:
+                        self.r1 = diag_val
+                    if k == 2:
+                        self.r2 = diag_val
+                    if k == 3:
+                        self.r3 = diag_val
+                    if k == 4:
+                        self.r4 = diag_val
+                    if k == 5:
+                        self.r5 = diag_val
+                    if k == 6:
+                        self.r6 = diag_val
+                    if k == 7:
+                        self.r7 = diag_val
+                    if k == 8:
+                        self.r8 = diag_val
+                    if k == 9:
+                        self.r9 = diag_val
+                    if k == 10:
+                        self.r10 = diag_val
+                    if k == 11:
+                        self.r11 = diag_val
+                    if k == 12:
+                        self.r12 = diag_val
+                    if k == 13:
+                        self.r13 = diag_val
+                    if k == 14:
+                        self.r14 = diag_val
+                    if k == 15:
+                        self.r15 = diag_val
+
+                diag_k = qd.simt.subgroup.shuffle(diag_val, qd.u32(k))
+
+                dot = qd.cast(0.0, dtype)
+                if k > 0:
+                    Lkj = qd.simt.subgroup.shuffle(self.r0, qd.u32(k))
+                    dot += Lkj * self.r0
+                if k > 1:
+                    Lkj = qd.simt.subgroup.shuffle(self.r1, qd.u32(k))
+                    dot += Lkj * self.r1
+                if k > 2:
+                    Lkj = qd.simt.subgroup.shuffle(self.r2, qd.u32(k))
+                    dot += Lkj * self.r2
+                if k > 3:
+                    Lkj = qd.simt.subgroup.shuffle(self.r3, qd.u32(k))
+                    dot += Lkj * self.r3
+                if k > 4:
+                    Lkj = qd.simt.subgroup.shuffle(self.r4, qd.u32(k))
+                    dot += Lkj * self.r4
+                if k > 5:
+                    Lkj = qd.simt.subgroup.shuffle(self.r5, qd.u32(k))
+                    dot += Lkj * self.r5
+                if k > 6:
+                    Lkj = qd.simt.subgroup.shuffle(self.r6, qd.u32(k))
+                    dot += Lkj * self.r6
+                if k > 7:
+                    Lkj = qd.simt.subgroup.shuffle(self.r7, qd.u32(k))
+                    dot += Lkj * self.r7
+                if k > 8:
+                    Lkj = qd.simt.subgroup.shuffle(self.r8, qd.u32(k))
+                    dot += Lkj * self.r8
+                if k > 9:
+                    Lkj = qd.simt.subgroup.shuffle(self.r9, qd.u32(k))
+                    dot += Lkj * self.r9
+                if k > 10:
+                    Lkj = qd.simt.subgroup.shuffle(self.r10, qd.u32(k))
+                    dot += Lkj * self.r10
+                if k > 11:
+                    Lkj = qd.simt.subgroup.shuffle(self.r11, qd.u32(k))
+                    dot += Lkj * self.r11
+                if k > 12:
+                    Lkj = qd.simt.subgroup.shuffle(self.r12, qd.u32(k))
+                    dot += Lkj * self.r12
+                if k > 13:
+                    Lkj = qd.simt.subgroup.shuffle(self.r13, qd.u32(k))
+                    dot += Lkj * self.r13
+                if k > 14:
+                    Lkj = qd.simt.subgroup.shuffle(self.r14, qd.u32(k))
+                    dot += Lkj * self.r14
+
+                if tid > k:
+                    cur = qd.cast(0.0, dtype)
+                    if k == 0:
+                        cur = self.r0
+                    if k == 1:
+                        cur = self.r1
+                    if k == 2:
+                        cur = self.r2
+                    if k == 3:
+                        cur = self.r3
+                    if k == 4:
+                        cur = self.r4
+                    if k == 5:
+                        cur = self.r5
+                    if k == 6:
+                        cur = self.r6
+                    if k == 7:
+                        cur = self.r7
+                    if k == 8:
+                        cur = self.r8
+                    if k == 9:
+                        cur = self.r9
+                    if k == 10:
+                        cur = self.r10
+                    if k == 11:
+                        cur = self.r11
+                    if k == 12:
+                        cur = self.r12
+                    if k == 13:
+                        cur = self.r13
+                    if k == 14:
+                        cur = self.r14
+                    if k == 15:
+                        cur = self.r15
+                    new_val = (cur - dot) / diag_k
+                    if k == 0:
+                        self.r0 = new_val
+                    if k == 1:
+                        self.r1 = new_val
+                    if k == 2:
+                        self.r2 = new_val
+                    if k == 3:
+                        self.r3 = new_val
+                    if k == 4:
+                        self.r4 = new_val
+                    if k == 5:
+                        self.r5 = new_val
+                    if k == 6:
+                        self.r6 = new_val
+                    if k == 7:
+                        self.r7 = new_val
+                    if k == 8:
+                        self.r8 = new_val
+                    if k == 9:
+                        self.r9 = new_val
+                    if k == 10:
+                        self.r10 = new_val
+                    if k == 11:
+                        self.r11 = new_val
+                    if k == 12:
+                        self.r12 = new_val
+                    if k == 13:
+                        self.r13 = new_val
+                    if k == 14:
+                        self.r14 = new_val
+                    if k == 15:
+                        self.r15 = new_val
+
     # StructType.__call__ already defaults missing args to 0, so Tile()
     # produces a zero-initialized tile without needing default values in the
     # class definition (which @qd.dataclass doesn't support).

--- a/python/quadrants/lang/simt/_tile16.py
+++ b/python/quadrants/lang/simt/_tile16.py
@@ -307,40 +307,85 @@ def _make_tile16x16_class(dtype):
                 self.r15 = 1.0
 
         @qd.func
+        def _get_col(self, k):
+            """Return the value of register (column) k."""
+            val = qd.cast(0.0, dtype)
+            if k == 0:
+                val = self.r0
+            if k == 1:
+                val = self.r1
+            if k == 2:
+                val = self.r2
+            if k == 3:
+                val = self.r3
+            if k == 4:
+                val = self.r4
+            if k == 5:
+                val = self.r5
+            if k == 6:
+                val = self.r6
+            if k == 7:
+                val = self.r7
+            if k == 8:
+                val = self.r8
+            if k == 9:
+                val = self.r9
+            if k == 10:
+                val = self.r10
+            if k == 11:
+                val = self.r11
+            if k == 12:
+                val = self.r12
+            if k == 13:
+                val = self.r13
+            if k == 14:
+                val = self.r14
+            if k == 15:
+                val = self.r15
+            return val
+
+        @qd.func
+        def _set_col(self, k, val):
+            """Set register (column) k to val."""
+            if k == 0:
+                self.r0 = val
+            if k == 1:
+                self.r1 = val
+            if k == 2:
+                self.r2 = val
+            if k == 3:
+                self.r3 = val
+            if k == 4:
+                self.r4 = val
+            if k == 5:
+                self.r5 = val
+            if k == 6:
+                self.r6 = val
+            if k == 7:
+                self.r7 = val
+            if k == 8:
+                self.r8 = val
+            if k == 9:
+                self.r9 = val
+            if k == 10:
+                self.r10 = val
+            if k == 11:
+                self.r11 = val
+            if k == 12:
+                self.r12 = val
+            if k == 13:
+                self.r13 = val
+            if k == 14:
+                self.r14 = val
+            if k == 15:
+                self.r15 = val
+
+        @qd.func
         def _ger_sub(self, a, b):
             """General rank-1 subtract in-place: self -= a @ b^T."""
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(0))
-            self.r0 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(1))
-            self.r1 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(2))
-            self.r2 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(3))
-            self.r3 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(4))
-            self.r4 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(5))
-            self.r5 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(6))
-            self.r6 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(7))
-            self.r7 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(8))
-            self.r8 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(9))
-            self.r9 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(10))
-            self.r10 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(11))
-            self.r11 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(12))
-            self.r12 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(13))
-            self.r13 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(14))
-            self.r14 -= a * bc
-            bc = qd.simt.subgroup.shuffle(b, qd.u32(15))
-            self.r15 -= a * bc
+            for j in range(_TILE):
+                bc = qd.simt.subgroup.shuffle(b, qd.u32(j))
+                self._set_col(j, self._get_col(j) - a * bc)
 
         @qd.func
         def cholesky_(self, eps):
@@ -354,219 +399,25 @@ def _make_tile16x16_class(dtype):
                 diag_val = qd.cast(0.0, dtype)
                 if tid == k:
                     s = qd.cast(0.0, dtype)
-                    if k > 0:
-                        s += self.r0 * self.r0
-                    if k > 1:
-                        s += self.r1 * self.r1
-                    if k > 2:
-                        s += self.r2 * self.r2
-                    if k > 3:
-                        s += self.r3 * self.r3
-                    if k > 4:
-                        s += self.r4 * self.r4
-                    if k > 5:
-                        s += self.r5 * self.r5
-                    if k > 6:
-                        s += self.r6 * self.r6
-                    if k > 7:
-                        s += self.r7 * self.r7
-                    if k > 8:
-                        s += self.r8 * self.r8
-                    if k > 9:
-                        s += self.r9 * self.r9
-                    if k > 10:
-                        s += self.r10 * self.r10
-                    if k > 11:
-                        s += self.r11 * self.r11
-                    if k > 12:
-                        s += self.r12 * self.r12
-                    if k > 13:
-                        s += self.r13 * self.r13
-                    if k > 14:
-                        s += self.r14 * self.r14
-                    cur = qd.cast(0.0, dtype)
-                    if k == 0:
-                        cur = self.r0
-                    if k == 1:
-                        cur = self.r1
-                    if k == 2:
-                        cur = self.r2
-                    if k == 3:
-                        cur = self.r3
-                    if k == 4:
-                        cur = self.r4
-                    if k == 5:
-                        cur = self.r5
-                    if k == 6:
-                        cur = self.r6
-                    if k == 7:
-                        cur = self.r7
-                    if k == 8:
-                        cur = self.r8
-                    if k == 9:
-                        cur = self.r9
-                    if k == 10:
-                        cur = self.r10
-                    if k == 11:
-                        cur = self.r11
-                    if k == 12:
-                        cur = self.r12
-                    if k == 13:
-                        cur = self.r13
-                    if k == 14:
-                        cur = self.r14
-                    if k == 15:
-                        cur = self.r15
-                    diag_val = qd.sqrt(qd.max(cur - s, eps))
-                    if k == 0:
-                        self.r0 = diag_val
-                    if k == 1:
-                        self.r1 = diag_val
-                    if k == 2:
-                        self.r2 = diag_val
-                    if k == 3:
-                        self.r3 = diag_val
-                    if k == 4:
-                        self.r4 = diag_val
-                    if k == 5:
-                        self.r5 = diag_val
-                    if k == 6:
-                        self.r6 = diag_val
-                    if k == 7:
-                        self.r7 = diag_val
-                    if k == 8:
-                        self.r8 = diag_val
-                    if k == 9:
-                        self.r9 = diag_val
-                    if k == 10:
-                        self.r10 = diag_val
-                    if k == 11:
-                        self.r11 = diag_val
-                    if k == 12:
-                        self.r12 = diag_val
-                    if k == 13:
-                        self.r13 = diag_val
-                    if k == 14:
-                        self.r14 = diag_val
-                    if k == 15:
-                        self.r15 = diag_val
+                    for j in range(_TILE):
+                        if k > j:
+                            c = self._get_col(j)
+                            s += c * c
+                    diag_val = qd.sqrt(qd.max(self._get_col(k) - s, eps))
+                    self._set_col(k, diag_val)
 
                 diag_k = qd.simt.subgroup.shuffle(diag_val, qd.u32(k))
 
                 dot = qd.cast(0.0, dtype)
-                if k > 0:
-                    Lkj = qd.simt.subgroup.shuffle(self.r0, qd.u32(k))
-                    dot += Lkj * self.r0
-                if k > 1:
-                    Lkj = qd.simt.subgroup.shuffle(self.r1, qd.u32(k))
-                    dot += Lkj * self.r1
-                if k > 2:
-                    Lkj = qd.simt.subgroup.shuffle(self.r2, qd.u32(k))
-                    dot += Lkj * self.r2
-                if k > 3:
-                    Lkj = qd.simt.subgroup.shuffle(self.r3, qd.u32(k))
-                    dot += Lkj * self.r3
-                if k > 4:
-                    Lkj = qd.simt.subgroup.shuffle(self.r4, qd.u32(k))
-                    dot += Lkj * self.r4
-                if k > 5:
-                    Lkj = qd.simt.subgroup.shuffle(self.r5, qd.u32(k))
-                    dot += Lkj * self.r5
-                if k > 6:
-                    Lkj = qd.simt.subgroup.shuffle(self.r6, qd.u32(k))
-                    dot += Lkj * self.r6
-                if k > 7:
-                    Lkj = qd.simt.subgroup.shuffle(self.r7, qd.u32(k))
-                    dot += Lkj * self.r7
-                if k > 8:
-                    Lkj = qd.simt.subgroup.shuffle(self.r8, qd.u32(k))
-                    dot += Lkj * self.r8
-                if k > 9:
-                    Lkj = qd.simt.subgroup.shuffle(self.r9, qd.u32(k))
-                    dot += Lkj * self.r9
-                if k > 10:
-                    Lkj = qd.simt.subgroup.shuffle(self.r10, qd.u32(k))
-                    dot += Lkj * self.r10
-                if k > 11:
-                    Lkj = qd.simt.subgroup.shuffle(self.r11, qd.u32(k))
-                    dot += Lkj * self.r11
-                if k > 12:
-                    Lkj = qd.simt.subgroup.shuffle(self.r12, qd.u32(k))
-                    dot += Lkj * self.r12
-                if k > 13:
-                    Lkj = qd.simt.subgroup.shuffle(self.r13, qd.u32(k))
-                    dot += Lkj * self.r13
-                if k > 14:
-                    Lkj = qd.simt.subgroup.shuffle(self.r14, qd.u32(k))
-                    dot += Lkj * self.r14
+                for j in range(_TILE):
+                    if k > j:
+                        my_col = self._get_col(j)
+                        Lkj = qd.simt.subgroup.shuffle(my_col, qd.u32(k))
+                        dot += Lkj * my_col
 
                 if tid > k:
-                    cur = qd.cast(0.0, dtype)
-                    if k == 0:
-                        cur = self.r0
-                    if k == 1:
-                        cur = self.r1
-                    if k == 2:
-                        cur = self.r2
-                    if k == 3:
-                        cur = self.r3
-                    if k == 4:
-                        cur = self.r4
-                    if k == 5:
-                        cur = self.r5
-                    if k == 6:
-                        cur = self.r6
-                    if k == 7:
-                        cur = self.r7
-                    if k == 8:
-                        cur = self.r8
-                    if k == 9:
-                        cur = self.r9
-                    if k == 10:
-                        cur = self.r10
-                    if k == 11:
-                        cur = self.r11
-                    if k == 12:
-                        cur = self.r12
-                    if k == 13:
-                        cur = self.r13
-                    if k == 14:
-                        cur = self.r14
-                    if k == 15:
-                        cur = self.r15
-                    new_val = (cur - dot) / diag_k
-                    if k == 0:
-                        self.r0 = new_val
-                    if k == 1:
-                        self.r1 = new_val
-                    if k == 2:
-                        self.r2 = new_val
-                    if k == 3:
-                        self.r3 = new_val
-                    if k == 4:
-                        self.r4 = new_val
-                    if k == 5:
-                        self.r5 = new_val
-                    if k == 6:
-                        self.r6 = new_val
-                    if k == 7:
-                        self.r7 = new_val
-                    if k == 8:
-                        self.r8 = new_val
-                    if k == 9:
-                        self.r9 = new_val
-                    if k == 10:
-                        self.r10 = new_val
-                    if k == 11:
-                        self.r11 = new_val
-                    if k == 12:
-                        self.r12 = new_val
-                    if k == 13:
-                        self.r13 = new_val
-                    if k == 14:
-                        self.r14 = new_val
-                    if k == 15:
-                        self.r15 = new_val
+                    new_val = (self._get_col(k) - dot) / diag_k
+                    self._set_col(k, new_val)
 
     # StructType.__call__ already defaults missing args to 0, so Tile()
     # produces a zero-initialized tile without needing default values in the

--- a/python/quadrants/lang/simt/_tile16.py
+++ b/python/quadrants/lang/simt/_tile16.py
@@ -413,10 +413,10 @@ def _make_tile16x16_class(dtype):
                     if k > j:
                         my_col = self._get_col(j)
                         Lkj = qd.simt.subgroup.shuffle(my_col, qd.u32(k))
-                        dot += Lkj * my_col
+                        dot += Lkj * my_col  # type: ignore[reportOperatorIssue]
 
-                if tid > k:
-                    new_val = (self._get_col(k) - dot) / diag_k
+                if tid > k:  # type: ignore[reportOperatorIssue]
+                    new_val = (self._get_col(k) - dot) / diag_k  # type: ignore[reportOperatorIssue]
                     self._set_col(k, new_val)
 
     # StructType.__call__ already defaults missing args to 0, so Tile()

--- a/quadrants/transforms/type_check.cpp
+++ b/quadrants/transforms/type_check.cpp
@@ -521,11 +521,6 @@ class TypeCheck : public IRVisitor {
     stmt->ret_type.set_is_pointer(true);
   }
 
-  void visit(InternalFuncStmt *stmt) override {
-    // TODO: support return type specification
-    stmt->ret_type = PrimitiveType::i32;
-  }
-
   void visit(BitStructStoreStmt *stmt) override {
     // do nothing
   }

--- a/tests/python/test_tile16.py
+++ b/tests/python/test_tile16.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import scipy.linalg
 
 import quadrants as qd
 from quadrants.lang.simt._tile16 import _TILE, _make_tile16x16
@@ -296,3 +297,71 @@ def test_tile16_make_caching():
     assert a is not c
     d = _make_tile16x16(qd.f64)
     assert c is d
+
+
+def _make_spd(seed: int = 42):
+    """Return a well-conditioned 16x16 symmetric positive-definite matrix."""
+    rng = np.random.RandomState(seed)
+    B = rng.randn(_TILE, _TILE).astype(np.float64)
+    return (B @ B.T + _TILE * np.eye(_TILE)).astype(np.float32)
+
+
+@test_utils.test(arch=qd.gpu)
+def test_tile16_ger_sub():
+    Tile = _make_tile16x16(qd.f32)
+    mat = qd.ndarray(qd.f32, (_TILE, _TILE))
+    vec_a = qd.ndarray(qd.f32, (_TILE,))
+    vec_b = qd.ndarray(qd.f32, (_TILE,))
+    out = qd.ndarray(qd.f32, (_TILE, _TILE))
+
+    @qd.kernel
+    def k1(
+        mat_arr: qd.types.NDArray[qd.f32, 2],
+        a_arr: qd.types.NDArray[qd.f32, 1],
+        b_arr: qd.types.NDArray[qd.f32, 1],
+        out_arr: qd.types.NDArray[qd.f32, 2],
+    ):
+        qd.loop_config(block_dim=_TILE)
+        for _ in range(_TILE):
+            t = Tile()
+            t._load(mat_arr, 0, _TILE, 0, _TILE)
+            tid = qd.simt.subgroup.invocation_id()
+            a_val = a_arr[tid]
+            b_val = b_arr[tid]
+            t._ger_sub(a_val, b_val)
+            t._store(out_arr, 0, _TILE, 0, _TILE)
+
+    M = np.arange(_TILE * _TILE, dtype=np.float32).reshape(_TILE, _TILE)
+    a = np.arange(_TILE, dtype=np.float32) + 1.0
+    b = np.arange(_TILE, dtype=np.float32) + 2.0
+    mat.from_numpy(M)
+    vec_a.from_numpy(a)
+    vec_b.from_numpy(b)
+    k1(mat, vec_a, vec_b, out)
+
+    expected = M - np.outer(a, b)
+    np.testing.assert_allclose(out.to_numpy(), expected, atol=1e-5)
+
+
+@test_utils.test(arch=qd.gpu)
+def test_tile16_cholesky():
+    Tile = _make_tile16x16(qd.f32)
+    src = qd.ndarray(qd.f32, (_TILE, _TILE))
+    dst = qd.ndarray(qd.f32, (_TILE, _TILE))
+
+    @qd.kernel
+    def k1(src_arr: qd.types.NDArray[qd.f32, 2], dst_arr: qd.types.NDArray[qd.f32, 2]):
+        qd.loop_config(block_dim=_TILE)
+        for _ in range(_TILE):
+            t = Tile()
+            t._load(src_arr, 0, _TILE, 0, _TILE)
+            t.cholesky_(qd.f32(1e-6))
+            t._store(dst_arr, 0, _TILE, 0, _TILE)
+
+    A = _make_spd()
+    src.from_numpy(A)
+    k1(src, dst)
+
+    L_gpu = np.tril(dst.to_numpy())
+    L_ref = scipy.linalg.cholesky(A.astype(np.float64), lower=True).astype(np.float32)
+    np.testing.assert_allclose(L_gpu, L_ref, atol=1e-5)

--- a/tests/python/test_tile16.py
+++ b/tests/python/test_tile16.py
@@ -299,27 +299,30 @@ def test_tile16_make_caching():
     assert c is d
 
 
-def _make_spd(seed: int = 42):
+def _make_spd(np_dtype=np.float32, seed: int = 42):
     """Return a well-conditioned 16x16 symmetric positive-definite matrix."""
     rng = np.random.RandomState(seed)
     B = rng.randn(_TILE, _TILE).astype(np.float64)
-    return (B @ B.T + _TILE * np.eye(_TILE)).astype(np.float32)
+    return (B @ B.T + _TILE * np.eye(_TILE)).astype(np_dtype)
 
 
+@pytest.mark.parametrize("qd_dtype", _QD_DTYPES)
 @test_utils.test(arch=qd.gpu)
-def test_tile16_ger_sub():
-    Tile = _make_tile16x16(qd.f32)
-    mat = qd.ndarray(qd.f32, (_TILE, _TILE))
-    vec_a = qd.ndarray(qd.f32, (_TILE,))
-    vec_b = qd.ndarray(qd.f32, (_TILE,))
-    out = qd.ndarray(qd.f32, (_TILE, _TILE))
+def test_tile16_ger_sub(qd_dtype):
+    test_utils.skip_if_f64_unsupported(qd_dtype)
+    np_dtype = _NP_DTYPES[qd_dtype]
+    Tile = _make_tile16x16(qd_dtype)
+    mat = qd.ndarray(qd_dtype, (_TILE, _TILE))
+    vec_a = qd.ndarray(qd_dtype, (_TILE,))
+    vec_b = qd.ndarray(qd_dtype, (_TILE,))
+    out = qd.ndarray(qd_dtype, (_TILE, _TILE))
 
     @qd.kernel
     def k1(
-        mat_arr: qd.types.NDArray[qd.f32, 2],
-        a_arr: qd.types.NDArray[qd.f32, 1],
-        b_arr: qd.types.NDArray[qd.f32, 1],
-        out_arr: qd.types.NDArray[qd.f32, 2],
+        mat_arr: qd.types.NDArray[qd_dtype, 2],
+        a_arr: qd.types.NDArray[qd_dtype, 1],
+        b_arr: qd.types.NDArray[qd_dtype, 1],
+        out_arr: qd.types.NDArray[qd_dtype, 2],
     ):
         qd.loop_config(block_dim=_TILE)
         for _ in range(_TILE):
@@ -331,37 +334,61 @@ def test_tile16_ger_sub():
             t._ger_sub(a_val, b_val)
             t._store(out_arr, 0, _TILE, 0, _TILE)
 
-    M = np.arange(_TILE * _TILE, dtype=np.float32).reshape(_TILE, _TILE)
-    a = np.arange(_TILE, dtype=np.float32) + 1.0
-    b = np.arange(_TILE, dtype=np.float32) + 2.0
+    M = np.arange(_TILE * _TILE, dtype=np_dtype).reshape(_TILE, _TILE)
+    a = np.arange(_TILE, dtype=np_dtype) + 1.0
+    b = np.arange(_TILE, dtype=np_dtype) + 2.0
     mat.from_numpy(M)
     vec_a.from_numpy(a)
     vec_b.from_numpy(b)
     k1(mat, vec_a, vec_b, out)
 
     expected = M - np.outer(a, b)
-    np.testing.assert_allclose(out.to_numpy(), expected, atol=1e-5)
+    atol = 1e-10 if qd_dtype == qd.f64 else 1e-5
+    np.testing.assert_allclose(out.to_numpy(), expected, atol=atol)
 
 
+@pytest.mark.parametrize("dst_delta", [0, 3, 16])
+@pytest.mark.parametrize("src_offset", [0, 5, 32])
+@pytest.mark.parametrize("qd_dtype", _QD_DTYPES)
 @test_utils.test(arch=qd.gpu)
-def test_tile16_cholesky():
-    Tile = _make_tile16x16(qd.f32)
-    src = qd.ndarray(qd.f32, (_TILE, _TILE))
-    dst = qd.ndarray(qd.f32, (_TILE, _TILE))
+def test_tile16_cholesky(qd_dtype, src_offset, dst_delta):
+    test_utils.skip_if_f64_unsupported(qd_dtype)
+    np_dtype = _NP_DTYPES[qd_dtype]
+    GRID = 64
+    Tile = _make_tile16x16(qd_dtype)
+    src = qd.ndarray(qd_dtype, (GRID, GRID))
+    dst = qd.ndarray(qd_dtype, (GRID, GRID))
+
+    dst_offset = src_offset + dst_delta
+    src_row_end = src_offset + _TILE
+    dst_row_end = dst_offset + _TILE
 
     @qd.kernel
-    def k1(src_arr: qd.types.NDArray[qd.f32, 2], dst_arr: qd.types.NDArray[qd.f32, 2]):
+    def k1(src_arr: qd.types.NDArray[qd_dtype, 2], dst_arr: qd.types.NDArray[qd_dtype, 2]):
         qd.loop_config(block_dim=_TILE)
         for _ in range(_TILE):
             t = Tile()
-            t._load(src_arr, 0, _TILE, 0, _TILE)
-            t.cholesky_(qd.f32(1e-6))
-            t._store(dst_arr, 0, _TILE, 0, _TILE)
+            t._load(src_arr, src_offset, src_row_end, src_offset, src_row_end)
+            if qd.static(qd_dtype == qd.f64):
+                t.cholesky_(qd.f64(1e-12))
+            else:
+                t.cholesky_(qd.f32(1e-6))
+            t._store(dst_arr, dst_offset, dst_row_end, dst_offset, dst_row_end)
 
-    A = _make_spd()
-    src.from_numpy(A)
+    A = _make_spd(np_dtype)
+    src_np = np.zeros((GRID, GRID), dtype=np_dtype)
+    src_np[src_offset : src_offset + _TILE, src_offset : src_offset + _TILE] = A
+    src.from_numpy(src_np)
+    dst.from_numpy(np.full((GRID, GRID), -1.0, dtype=np_dtype))
     k1(src, dst)
 
-    L_gpu = np.tril(dst.to_numpy())
-    L_ref = scipy.linalg.cholesky(A.astype(np.float64), lower=True).astype(np.float32)
-    np.testing.assert_allclose(L_gpu, L_ref, atol=1e-5)
+    result = dst.to_numpy()
+    L_gpu = np.tril(result[dst_offset : dst_offset + _TILE, dst_offset : dst_offset + _TILE])
+    L_ref = scipy.linalg.cholesky(A.astype(np.float64), lower=True).astype(np_dtype)
+    atol = 1e-10 if qd_dtype == qd.f64 else 1e-5
+    np.testing.assert_allclose(L_gpu, L_ref, atol=atol)
+    untouched = np.full((GRID, GRID), -1.0, dtype=np_dtype)
+    untouched[dst_offset : dst_offset + _TILE, dst_offset : dst_offset + _TILE] = result[
+        dst_offset : dst_offset + _TILE, dst_offset : dst_offset + _TILE
+    ]
+    np.testing.assert_allclose(result, untouched)


### PR DESCRIPTION
Issue: #

### Brief Summary

  PR 2a: Rank-1 update and Cholesky factorization for Tile16x16

  What it adds to `_tile16.py`:
  • _get_col(k) / _set_col(k, val) — register access helpers that encapsulate the 16-way if k == N dispatch, eliminating repetition in all downstream methods
  • _ger_sub(a, b) — in-place rank-1 subtract (self -= a @ b^T) via subgroup shuffles
  • cholesky_(eps) — in-place 16x16 Cholesky factorization (A = L @ L^T), diagonal clamped to sqrt(max(value, eps)) for numerical stability

  Tests added:
  • test_tile16_ger_sub — parametrized over f32/f64
  • test_tile16_cholesky — parametrized over f32/f64, 3 source offsets (0, 5, 32), and 3 src-dst deltas (0, 3, 16); verifies both correctness against scipy.linalg.cholesky and
    that untouched dst regions are preserved

  Good points:
  • _get_col/_set_col helpers make _ger_sub (4 lines) and cholesky_ (22 lines) very readable compared to the raw 16-way unrolled form
  • These helpers pay forward — PR 2b's _trsm and any future tile operations can reuse them
  • Cholesky test has strong coverage: multiple offsets exercise the load/store boundary logic, f64 tests catch precision regressions, and the untouched-region check catches OOB
     writes
  • All internal — no public API surface, nothing to break for users

  Bad points:
  • _get_col/_set_col are themselves still 16-line boilerplate each; this is inherent to the struct-field approach but could theoretically be code-generated
  • The existing PR 1 methods (_eye_, _load, _store, _load3d, _store3d) still use raw self.rN access — they'd benefit from the same helpers but refactoring them would change PR
    1's diff
  • cholesky_ epsilon must be explicitly typed (qd.f32(1e-6) or qd.f64(1e-12)) to match the tile dtype; a mismatched type would likely cause a compile error, but there's no
    explicit validation or dtype-inference convenience


PR 2a walkthrough (relative to PR 1)



  The challenge

  PR 1 gave us a register-resident 16x16 tile that can load, store, and initialize to zero or identity. But a tile that can only shuttle data to and from memory isn't useful yet
   — we need it to compute. The immediate goal is blocked Cholesky factorization, which requires two operations: rank-1 updates and the factorization itself.


  What this PR adds

  Two new computational methods on the tile, plus two helper methods that make them readable.


  Register access helpers: `_get_col` and `_set_col`

  The tile's 16 columns live in named fields r0–r15. You can't index them by variable — self.r[k] doesn't work because they're struct fields, not an array. So any operation that
   needs "read/write column k" requires a 16-way if k == 0: ... if k == 1: ... dispatch.
  PR 1's _load, _store, and _eye_ each hardcode their own version of this pattern. Rather than repeat it again for every new method, this PR extracts it into two @qd.func
  helpers:
  • _get_col(self, k) — returns the value of register k
  • _set_col(self, k, val) — sets register k to val

  Each is 16 if branches — the only place this boilerplate lives now. Every subsequent method uses these instead of touching r0–r15 directly.


  Rank-1 subtract: `_ger_sub`

  _ger_sub(self, a, b) computes self -= a @ b^T in-place. Each thread provides its element of vectors a and b. The outer product is computed column by column: for each column j,
   broadcast b[j] from thread j to all threads via subgroup.shuffle, then subtract a * b[j] from column j.
  With the helpers, this is 4 lines:

  for j in range(_TILE):
      bc = qd.simt.subgroup.shuffle(b, qd.u32(j))
      self._set_col(j, self._get_col(j) - a * bc)

  This is used in blocked Cholesky for diagonal block updates (A_kk -= L_k @ L_k^T) and off-diagonal block updates (A_ik -= L_i @ L_k^T).


  Cholesky factorization: `cholesky_`

  cholesky_(self, eps) factorizes the tile in-place: replaces the lower triangle with L such that A ≈ L @ L^T. It processes one column k at a time, for k = 0..15:
  1. Diagonal element (only thread k executes this): compute s = sum(L[k,j]^2 for j < k) using _get_col, then set L[k,k] = sqrt(max(A[k,k] - s, eps)). The eps clamp prevents
     sqrt of negative for near-singular matrices.
  2. Broadcast diagonal: shuffle(diag_val, k) sends L[k,k] from thread k to all threads.
  3. Cross-thread dot product (all threads execute this, required for uniform shuffle): compute dot = sum(L[i,j] * L[k,j] for j < k). Each thread reads its own L[i,j] via
     _get_col(j), and gets L[k,j] by shuffling from thread k.
  4. Off-diagonal elements (threads with tid > k): set L[i,k] = (A[i,k] - dot) / L[k,k].

  With the helpers, this is 22 lines instead of the ~224 it would take with raw register access.


  Tests

  `test_tile16_ger_sub` — loads a matrix and two vectors, runs _ger_sub, verifies against numpy.outer. Parametrized over f32 (atol=1e-5) and f64 (atol=1e-10).
  `test_tile16_cholesky` — generates a well-conditioned 16x16 SPD matrix (B @ B^T + 16*I), runs cholesky_, compares the lower triangle against scipy.linalg.cholesky.
  Parametrized over:
  • dtype: f32 and f64 (with appropriate epsilon: 1e-6 vs 1e-12, and tolerance: 1e-5 vs 1e-10)
  • src_offset: 0, 5, 32 — where in a 64x64 array the SPD matrix sits, exercising the load/store offset logic
  • dst_delta: 0, 3, 16 — difference between load and store positions, verifying that store writes only the target region

copilot:summary

### Walkthrough

copilot:walkthrough
