### PR TITLE
[AMDGPU] Scope hsaco tmp dir per-user to avoid collisions.

### DIFF
--- a/quadrants/runtime/amdgpu/jit_amdgpu.h
+++ b/quadrants/runtime/amdgpu/jit_amdgpu.h
@@ -95,7 +95,7 @@ class JITSessionAMDGPU : public JITSession {
       : JITSession(tlctx, config), data_layout(data_layout) {
     random_num_ = get_random_num();
     char *env_dir = std::getenv("QD_TMP_DIR");
-    tmp_dir_ = "/tmp/quadrants_hsaco/";
+    tmp_dir_ = "/tmp/quadrants_hsaco_" + std::to_string(getuid()) + "/";
     if (env_dir) {
       tmp_dir_ = env_dir;
       if (tmp_dir_[tmp_dir_.size() - 1] != '/') {

--- a/quadrants/runtime/amdgpu/jit_amdgpu.h
+++ b/quadrants/runtime/amdgpu/jit_amdgpu.h
@@ -96,9 +96,10 @@ class JITSessionAMDGPU : public JITSession {
     random_num_ = get_random_num();
     char *env_dir = std::getenv("QD_TMP_DIR");
     tmp_dir_ = "/tmp/quadrants_hsaco_" + std::to_string(getuid()) + "/";
-    if (env_dir) {
+    // Treat an empty QD_TMP_DIR the same as unset, so the per-user default below is used.
+    if (env_dir && env_dir[0] != '\0') {
       tmp_dir_ = env_dir;
-      if (tmp_dir_[tmp_dir_.size() - 1] != '/') {
+      if (tmp_dir_.back() != '/') {
         tmp_dir_ += '/';
       }
     }


### PR DESCRIPTION
## Description

Scopes the AMDGPU JIT's hsaco temp directory per user (`/tmp/quadrants_hsaco_<uid>/` instead of `/tmp/quadrants_hsaco/`), so the first user on a shared host doesn't lock everyone else out with a `Permission denied` when creating subdirectories. Also treats an empty
`QD_TMP_DIR` env var the same as unset, removing a pre-existing UB (`tmp_dir_[SIZE_MAX]`) the first commit was sitting next to.

## Good points

- Fixes a real shared-host footgun: previously a single `mkdir /tmp/quadrants_hsaco/` by user A made `qd.init(arch=qd.amdgpu)` crash for every other user on the box until someone `chmod`'d or removed the directory.
- The empty-env-var path is now well-defined (falls back to the per-user default) instead of indexing past the end of an empty string.
- Minimal change: one line for the path, three for the env-var guard. No behavior change for users who already set `QD_TMP_DIR` to a real path.

## Bad points

- `getuid()` is POSIX-only, so the patch is Linux-only by construction. `cmake/QuadrantsCore.cmake` already forces `QD_WITH_AMDGPU` off on Windows and macOS, so this matches the existing build matrix rather than narrowing it.