### PR TITLE
[AMDGPU] Enable HIP memory pool and surface pool-exhaustion errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ On Genesis simulator (Linux + NVIDIA 5090):
 ## Prerequisites
 - Python 3.10-3.13
 - Mac OS 14, 15, Windows, or Ubuntu 22.04-24.04 or compatible
+- ROCm 5.2 or newer for AMD GPU support
 
 ## Procedure
 ```

--- a/quadrants/rhi/amdgpu/amdgpu_context.cpp
+++ b/quadrants/rhi/amdgpu/amdgpu_context.cpp
@@ -77,6 +77,25 @@ AMDGPUContext::AMDGPUContext() : driver_(AMDGPUDriver::get_instance_without_cont
   std::free(hip_device_prop);
 
   QD_TRACE("Emitting AMDGPU code for {}", mcpu_);
+
+  // Probe async memory-pool support (hipMallocAsync / hipFreeAsync) so the LLVM executor can skip the fixed-size
+  // device_memory_GB preallocation, the same way the CUDA backend does via cuMemAllocAsync. This feature requires
+  // ROCm >= 5.2; earlier runtimes are not supported by quadrants. Use the non-throwing .call() variant so a future
+  // hipDeviceAttribute_t reshuffle degrades to "no pool" rather than aborting init.
+  int device_supports_mem_pool = 0;
+  uint32 attr_err = driver_.device_get_attribute.call(
+      &device_supports_mem_pool, HIP_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED, 0 /*device ordinal*/);
+
+  if (attr_err == HIP_SUCCESS && device_supports_mem_pool) {
+    supports_mem_pool_ = true;
+    void *default_mem_pool = nullptr;
+    driver_.device_get_default_mem_pool(&default_mem_pool, 0 /*device ordinal*/);
+    // Match CUDAContext: keep up to 128 MiB cached in the pool between alloc cycles. Larger workloads are served by the
+    // pool growing on demand.
+    constexpr uint64 kMemPoolReleaseThreshold = 128ull * 1024 * 1024;
+    driver_.mem_pool_set_attribute(default_mem_pool, HIP_MEMPOOL_ATTR_RELEASE_THRESHOLD,
+                                   (void *)&kMemPoolReleaseThreshold);
+  }
 }
 
 std::size_t AMDGPUContext::get_total_memory() {

--- a/quadrants/rhi/amdgpu/amdgpu_context.h
+++ b/quadrants/rhi/amdgpu/amdgpu_context.h
@@ -23,6 +23,7 @@ class AMDGPUContext {
   KernelProfilerBase *profiler_{nullptr};
   AMDGPUDriver &driver_;
   bool debug_{false};
+  bool supports_mem_pool_{false};
   std::vector<void *> kernel_arg_pointer_;
 
  public:
@@ -81,6 +82,10 @@ class AMDGPUContext {
 
   int get_compute_capability() const {
     return compute_capability_;
+  }
+
+  bool supports_mem_pool() const {
+    return supports_mem_pool_;
   }
 
   ~AMDGPUContext();

--- a/quadrants/rhi/amdgpu/amdgpu_device.cpp
+++ b/quadrants/rhi/amdgpu/amdgpu_device.cpp
@@ -53,16 +53,25 @@ DeviceAllocation AmdgpuDevice::allocate_memory_runtime(const LlvmRuntimeAllocPar
   info.size = quadrants::iroundup(params.size, quadrants_page_size);
   if (params.host_read || params.host_write) {
     QD_NOT_IMPLEMENTED
+  } else if (info.size == 0) {
+    info.ptr = nullptr;
+  } else if (params.use_memory_pool) {
+    // Grow-on-demand path (HIP memory pool). Matches CudaDevice::allocate_memory_runtime; the fixed-size
+    // device_memory_GB preallocation is skipped entirely upstream when the device supports pools.
+    AMDGPUDriver::get_instance().malloc_async((void **)&info.ptr, info.size, nullptr);
   } else {
     info.ptr =
         DeviceMemoryPool::get_instance(Arch::amdgpu, false /*merge_upon_release*/).allocate_with_cache(this, params);
     QD_ASSERT(info.ptr != nullptr);
-
-    AMDGPUDriver::get_instance().memset((void *)info.ptr, 0, info.size);
   }
+
+  if (info.ptr)
+    AMDGPUDriver::get_instance().memset((void *)info.ptr, 0, info.size);
+
   info.is_imported = false;
   info.use_cached = true;
   info.use_preallocated = true;
+  info.use_memory_pool = params.use_memory_pool;
 
   DeviceAllocation alloc;
   alloc.alloc_id = allocations_.size();
@@ -73,11 +82,20 @@ DeviceAllocation AmdgpuDevice::allocate_memory_runtime(const LlvmRuntimeAllocPar
 }
 
 uint64_t *AmdgpuDevice::allocate_llvm_runtime_memory_jit(const LlvmRuntimeAllocParams &params) {
+  // The device-side runtime_memory_allocate_aligned fires quadrants_assert_runtime on pool exhaustion, which stops
+  // the kernel without writing to *result. To detect that here, zero the slot first so a null readback unambiguously
+  // means "allocation failed" and we can surface a helpful host-side message instead of letting the downstream
+  // hipMemset trip on the stale pointer with a cryptic hipErrorInvalidValue.
+  uint64 zero = 0;
+  AMDGPUDriver::get_instance().memcpy_host_to_device(params.result_buffer, &zero, sizeof(uint64));
   params.runtime_jit->call<void *, std::size_t, std::size_t>("runtime_memory_allocate_aligned", params.runtime,
                                                              params.size, quadrants_page_size, params.result_buffer);
   AMDGPUDriver::get_instance().stream_synchronize(nullptr);
   uint64 *ret{nullptr};
   AMDGPUDriver::get_instance().memcpy_device_to_host(&ret, params.result_buffer, sizeof(uint64));
+  QD_ERROR_IF(ret == nullptr,
+              "Out of AMDGPU pre-allocated memory. Consider using ti.init(device_memory_fraction=0.9) or "
+              "ti.init(device_memory_GB=N) to allocate more GPU memory.");
   return ret;
 }
 
@@ -89,11 +107,17 @@ void AmdgpuDevice::dealloc_memory(DeviceAllocation handle) {
 
   validate_device_alloc(handle);
   AllocInfo &info = allocations_[handle.alloc_id];
+
+  if (info.size == 0) {
+    return;
+  }
   if (info.ptr == nullptr) {
     QD_ERROR("the DeviceAllocation is already deallocated");
   }
   QD_ASSERT(!info.is_imported);
-  if (info.use_cached) {
+  if (info.use_memory_pool) {
+    AMDGPUDriver::get_instance().mem_free_async(info.ptr, nullptr);
+  } else if (info.use_cached) {
     DeviceMemoryPool::get_instance(Arch::amdgpu, false /*merge_upon_release*/)
         .release(info.size, (uint64_t *)info.ptr, false);
   } else if (!info.use_preallocated) {

--- a/quadrants/rhi/amdgpu/amdgpu_device.h
+++ b/quadrants/rhi/amdgpu/amdgpu_device.h
@@ -53,6 +53,7 @@ class AmdgpuDevice : public LlvmDevice {
     bool is_imported{false};
     bool use_preallocated{true};
     bool use_cached{false};
+    bool use_memory_pool{false};
     void *mapped{nullptr};
   };
 

--- a/quadrants/rhi/amdgpu/amdgpu_driver.cpp
+++ b/quadrants/rhi/amdgpu/amdgpu_driver.cpp
@@ -75,5 +75,21 @@ AMDGPUDriver &AMDGPUDriver::get_instance() {
   return get_instance_without_context();
 }
 
+void AMDGPUDriver::malloc_async(void **dev_ptr, size_t size, void *stream) {
+  if (AMDGPUContext::get_instance().supports_mem_pool()) {
+    malloc_async_impl(dev_ptr, size, stream);
+  } else {
+    malloc(dev_ptr, size);
+  }
+}
+
+void AMDGPUDriver::mem_free_async(void *dev_ptr, void *stream) {
+  if (AMDGPUContext::get_instance().supports_mem_pool()) {
+    mem_free_async_impl(dev_ptr, stream);
+  } else {
+    mem_free(dev_ptr);
+  }
+}
+
 }  // namespace lang
 }  // namespace quadrants

--- a/quadrants/rhi/amdgpu/amdgpu_driver.h
+++ b/quadrants/rhi/amdgpu/amdgpu_driver.h
@@ -14,6 +14,12 @@ constexpr uint32 HIP_MEM_ATTACH_GLOBAL = 0x1;
 constexpr uint32 HIP_MEM_ADVISE_SET_PREFERRED_LOCATION = 3;
 constexpr uint32 HIP_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X = 26;
 constexpr uint32 HIP_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT = 63;
+// hipDeviceAttributeMemoryPoolsSupported from the hipDeviceAttribute_t enum in
+// ROCm/clr hipamd/include/hip/hip_runtime_api.h.
+constexpr uint32 HIP_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED = 88;
+// hipMemPoolAttrReleaseThreshold from the hipMemPoolAttr enum in
+// ROCm/clr hipamd/include/hip/hip_runtime_api.h.
+constexpr uint32 HIP_MEMPOOL_ATTR_RELEASE_THRESHOLD = 4;
 // sizeof(hipDeviceProperties_t) in ROCm 6.
 // ROCm 5.7.1 is 792 and ROCm 6 is 1472, so to make both work we use whichever
 // is larger.
@@ -120,6 +126,11 @@ class AMDGPUDriver : protected AMDGPUDriverBase {
   static AMDGPUDriver &get_instance();
 
   static AMDGPUDriver &get_instance_without_context();
+
+  // Thin wrappers that transparently fall back to the synchronous hipMalloc / hipFree when the device does not
+  // advertise memory-pool support. Mirrors CUDADriver::{malloc_async, mem_free_async}.
+  void malloc_async(void **dev_ptr, size_t size, void *stream);
+  void mem_free_async(void *dev_ptr, void *stream);
 
  private:
   AMDGPUDriver();

--- a/quadrants/rhi/amdgpu/amdgpu_driver_functions.inc.h
+++ b/quadrants/rhi/amdgpu/amdgpu_driver_functions.inc.h
@@ -27,9 +27,13 @@ PER_AMDGPU_FUNCTION(memcpy_async, hipMemcpyAsync, void *, void *, std::size_t, u
 PER_AMDGPU_FUNCTION(memcpy_host_to_device_async, hipMemcpyHtoDAsync, void *, void *, std::size_t, void *);
 PER_AMDGPU_FUNCTION(memcpy_device_to_host_async, hipMemcpyDtoHAsync, void *, void *, std::size_t, void *);
 PER_AMDGPU_FUNCTION(malloc, hipMalloc, void **, std::size_t);
+PER_AMDGPU_FUNCTION(malloc_async_impl, hipMallocAsync, void **, std::size_t, void *);
 PER_AMDGPU_FUNCTION(malloc_managed, hipMallocManaged, void **, std::size_t, uint32);
 PER_AMDGPU_FUNCTION(memset, hipMemset, void *, uint8, std::size_t);
 PER_AMDGPU_FUNCTION(mem_free, hipFree, void *);
+PER_AMDGPU_FUNCTION(mem_free_async_impl, hipFreeAsync, void *, void *);
+PER_AMDGPU_FUNCTION(device_get_default_mem_pool, hipDeviceGetDefaultMemPool, void **, int);
+PER_AMDGPU_FUNCTION(mem_pool_set_attribute, hipMemPoolSetAttribute, void *, uint32, void *);
 PER_AMDGPU_FUNCTION(mem_get_info, hipMemGetInfo, std::size_t *, std::size_t *);
 PER_AMDGPU_FUNCTION(mem_get_attribute, hipPointerGetAttribute, void *, uint32, void *);
 PER_AMDGPU_FUNCTION(mem_get_attributes, hipPointerGetAttributes, void *, void *);

--- a/quadrants/rhi/cuda/cuda_device.cpp
+++ b/quadrants/rhi/cuda/cuda_device.cpp
@@ -73,11 +73,19 @@ DeviceAllocation CudaDevice::allocate_memory_runtime(const LlvmRuntimeAllocParam
 }
 
 uint64_t *CudaDevice::allocate_llvm_runtime_memory_jit(const LlvmRuntimeAllocParams &params) {
+  // Zero the slot before the JIT call so that a null readback unambiguously signals pool exhaustion (see the
+  // AmdgpuDevice counterpart for why). The existing __assertfail hard-halt on the device side still runs, but we
+  // no longer rely on it to stop the host from dereferencing a stale pointer.
+  uint64 zero = 0;
+  CUDADriver::get_instance().memcpy_host_to_device(params.result_buffer, &zero, sizeof(uint64));
   params.runtime_jit->call<void *, std::size_t, std::size_t>("runtime_memory_allocate_aligned", params.runtime,
                                                              params.size, quadrants_page_size, params.result_buffer);
   CUDADriver::get_instance().stream_synchronize(nullptr);
   uint64 *ret{nullptr};
   CUDADriver::get_instance().memcpy_device_to_host(&ret, params.result_buffer, sizeof(uint64));
+  QD_ERROR_IF(ret == nullptr,
+              "Out of CUDA pre-allocated memory. Consider using ti.init(device_memory_fraction=0.9) or "
+              "ti.init(device_memory_GB=N) to allocate more GPU memory.");
   return ret;
 }
 

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -64,6 +64,7 @@ LlvmRuntimeExecutor::LlvmRuntimeExecutor(CompileConfig &config, KernelProfilerBa
       config.arch = host_arch();
     } else {
       // AMDGPU runtime created successfully
+      use_device_memory_pool_ = AMDGPUContext::get_instance().supports_mem_pool();
     }
 #else
     QD_WARN("Quadrants is not compiled with AMDGPU.");

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -357,7 +357,10 @@ void LlvmRuntimeExecutor::initialize_llvm_runtime_snodes(const LlvmOfflineCache:
     }
   }
 
-  if (config_.arch == Arch::cuda && use_device_memory_pool() && !all_dense) {
+  if ((config_.arch == Arch::cuda || config_.arch == Arch::amdgpu) && use_device_memory_pool() && !all_dense) {
+    // Sparse SNode trees allocate runtime state via runtime_memory_allocate_aligned during snode_initialize.
+    // When the device memory pool is active, the eager preallocate_runtime_memory() in materialize_runtime is
+    // skipped, so the bump allocator is only wired up lazily here when a sparse tree actually needs it.
     preallocate_runtime_memory();
   }
 

--- a/tests/python/test_memory.py
+++ b/tests/python/test_memory.py
@@ -19,6 +19,20 @@ def test_memory_allocate():
         x[i] = i
 
 
+@pytest.mark.run_in_serial
+@test_utils.test()
+def test_ndarray_exceeds_default_device_memory_gb():
+    # Allocate an ndarray larger than the default device_memory_GB (1 GiB) to exercise that on-demand growth works
+    # without user-side pool tuning. On AMDGPU this path goes through hipMallocAsync since ROCm 5.2+; CUDA uses
+    # cuMemAllocAsync; CPU/Vulkan/Metal are unaffected by device_memory_GB. The check is that the allocation and its
+    # zero-fill both succeed.
+    n = (1 << 30) // 4 + 1
+    arr = qd.ndarray(qd.i32, shape=(n,))
+    assert arr[0] == 0
+    assert arr[n // 2] == 0
+    assert arr[n - 1] == 0
+
+
 @test_utils.test(arch=get_host_arch_list())
 def test_oop_memory_leak():
     @qd.data_oriented

--- a/tests/python/test_memory.py
+++ b/tests/python/test_memory.py
@@ -22,15 +22,32 @@ def test_memory_allocate():
 @pytest.mark.run_in_serial
 @test_utils.test()
 def test_ndarray_exceeds_default_device_memory_gb():
-    # Allocate an ndarray larger than the default device_memory_GB (1 GiB) to exercise that on-demand growth works
-    # without user-side pool tuning. On AMDGPU this path goes through hipMallocAsync since ROCm 5.2+; CUDA uses
-    # cuMemAllocAsync; CPU/Vulkan/Metal are unaffected by device_memory_GB. The check is that the allocation and its
-    # zero-fill both succeed.
+    # device_memory_GB defaults to 1, so allocate an ndarray whose byte size exceeds 1 GiB to exercise that
+    # on-demand growth works without user-side pool tuning. On AMDGPU this path goes through hipMallocAsync since
+    # ROCm 5.2+; CUDA uses cuMemAllocAsync; CPU/Vulkan/Metal are unaffected by device_memory_GB.
     n = (1 << 30) // 4 + 1
     arr = qd.ndarray(qd.i32, shape=(n,))
     assert arr[0] == 0
     assert arr[n // 2] == 0
     assert arr[n - 1] == 0
+
+
+@test_utils.test(require=qd.extension.sparse)
+def test_sparse_field_with_device_memory_pool():
+    # With the device memory pool active on CUDA / AMDGPU, the eager preallocate_runtime_memory() in
+    # materialize_runtime is skipped. Sparse (non-dense) SNode trees depend on a lazy fallback in
+    # initialize_llvm_runtime_snodes to wire up the device-side bump allocator; exercise that path.
+    x = qd.field(qd.i32)
+    qd.root.pointer(qd.i, 32).dense(qd.i, 8).place(x)
+
+    @qd.kernel
+    def write():
+        x[0] = 42
+        x[255] = 7
+
+    write()
+    assert x[0] == 42
+    assert x[255] == 7
 
 
 @test_utils.test(arch=get_host_arch_list())


### PR DESCRIPTION
## Summary

Brings the AMDGPU backend in line with CUDA so that `device_memory_GB` is no longer required for allocations past the default 1 GiB preallocation, and converts the cryptic `hipErrorInvalidValue while calling memset` symptom from
[Genesis-Embodied-AI/Genesis#2434](https://github.com/Genesis-Embodied-AI/Genesis/issues/2434) into a clear pool-exhaustion error.

## Motivation

The reported bug looked like a 1 GiB size cliff in `hipMemset` / `hipMemsetD32`, but a direct HIP probe (`hipMalloc` + `hipMemset` past 1 GiB on a fresh block) shows the runtime itself is fine. The real cause is on the AMDGPU allocation path:

- `AmdgpuDevice::allocate_memory_runtime` always routes through the fixed-size preallocated pool, unlike CUDA which uses `cuMemAllocAsync` to grow on demand when the device supports memory pools.
- When the pool exhausts, the device-side `allocate_from_reserved_memory` fires `quadrants_assert_runtime`; the CUDA branch hard-halts via `__assertfail`, but AMDGPU has no equivalent. The kernel returns without writing `*result_buffer`, the host reads a stale pointer,
and the subsequent `hipMemset` trips `hipErrorInvalidValue` — masking pool exhaustion as a memset bug.

## Changes

- Wire `hipMallocAsync` and related APIs into the AMDGPU backend, matching the CUDA memory-pool path; the fixed-size `device_memory_GB` preallocation is skipped on modern ROCm devices and kept as a fallback.
- In `allocate_llvm_runtime_memory_jit` (AMDGPU + CUDA), surface pool exhaustion as a clear host-side `Out of pre-allocated memory...` error instead of letting a downstream memset fail on a stale pointer.
- Document the ROCm 5.2+ requirement in the README.
- Add a regression test that allocates an ndarray past the default 1 GiB preallocation across all backends.

## Good points

- AMDGPU users no longer need to tune `device_memory_GB` by hand; workloads that outgrow the old 1 GiB default now just work. Directly addresses Genesis-Embodied-AI/Genesis#2434.
- The AMDGPU backend is now structurally symmetric with CUDA (same `use_memory_pool` branching in `allocate_memory_runtime` / `dealloc_memory`, same sparse-SNode preallocation guard), which cuts the divergence maintainers have to reason about.
- The cryptic HIP driver error on pool exhaustion is replaced with an actionable "Out of pre-allocated memory. Consider using ti.init(device_memory_fraction=0.9) or ti.init(device_memory_GB=N)..." message on both backends. Saves the next person a multi-hour debugging
session.

## Bad points

- HIP enum values (`hipDeviceAttributeMemoryPoolsSupported = 88`, `hipMemPoolAttrReleaseThreshold = 4`) are hardcoded in `amdgpu_driver.h` rather than pulled from a HIP header. A future ROCm ABI reshuffle could break the probe. Mitigated by using the non-throwing
`.call()` variant so a wrong value degrades to "no pool" instead of aborting `qd.init`, but this is a latent fragility.
- The CUDA device-side `__assertfail` hard-halt on pool exhaustion is kept alongside the new host-side propagation for defense in depth, so there are now two mechanisms handling the same failure mode. Arguably the device-side one could be removed later, but doing it in this PR would widen the scope into CUDA behavior.

## Verification

- AMDGPU (ROCm 7, gfx1100): `qd.ndarray(qd.i32, shape=(2**28 + 1,))` succeeds with default `qd.init(arch=qd.amdgpu)`, no `device_memory_GB` override.
- With `device_memory_GB=1` forced, the former `hipErrorInvalidValue` becomes a clean `Out of AMDGPU pre-allocated memory...` error.
- Test passes locally on `arch=arm64`; AMDGPU / CUDA / Vulkan / Metal coverage via CI.

## Notes

ROCm < 5.2 is no longer supported (`hipMallocAsync` is a hard prerequisite). Stated in the README prerequisites. It was released in May 2022 so I think it is reasonable.

Resolves https://github.com/Genesis-Embodied-AI/Genesis/issues/2434