### PR TITLE
[Misc] Fix purity checker to allow accessing constants from quadrants modules

### DIFF
--- a/python/quadrants/lang/ast/ast_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformer.py
@@ -40,6 +40,9 @@ from quadrants.lang.field import Field
 from quadrants.lang.matrix import Matrix, MatrixType
 from quadrants.lang.snode import append, deactivate, length
 from quadrants.lang.struct import Struct, StructType
+from quadrants.lang.util import (
+    is_from_quadrants_module as _is_from_quadrants_module,
+)
 from quadrants.types import primitive_types
 from quadrants.types.utils import is_integral
 
@@ -614,8 +617,6 @@ class ASTTransformer(Builder):
         # whether it is a method of Dynamic SNode and build the expression if it is by calling
         # build_attribute_if_is_dynamic_snode_method. If we find that it is not a method of Dynamic SNode,
         # we continue to process it as a normal attribute node.
-        from quadrants import math as qd_math  # pylint: disable=import-outside-toplevel
-
         try:
             build_stmt(ctx, node.value)
         except Exception as e:
@@ -672,8 +673,9 @@ class ASTTransformer(Builder):
                     violation = True
                     if violation and isinstance(node.ptr, enum.Enum):
                         violation = False
-                    if violation and node.value.ptr in [qd_math, math, np]:
-                        # ignore this built-in module
+                    if violation and node.value.ptr in [math, np]:
+                        violation = False
+                    if violation and _is_from_quadrants_module(node.value.ptr):
                         violation = False
                     if violation:
                         message = f"[PURE.VIOLATION] WARNING: Accessing global var {node.attr} from outside function scope within pure kernel {node.value.violates_pure_reason}"

--- a/python/quadrants/lang/ast/ast_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformer.py
@@ -42,8 +42,6 @@ from quadrants.lang.snode import append, deactivate, length
 from quadrants.lang.struct import Struct, StructType
 from quadrants.lang.util import (
     is_from_quadrants_module as _is_from_quadrants_module,
-)
-from quadrants.lang.util import (
     is_quadrants_internal_file as _is_quadrants_internal_file,
 )
 from quadrants.types import primitive_types

--- a/python/quadrants/lang/ast/ast_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformer.py
@@ -43,6 +43,9 @@ from quadrants.lang.struct import Struct, StructType
 from quadrants.lang.util import (
     is_from_quadrants_module as _is_from_quadrants_module,
 )
+from quadrants.lang.util import (
+    is_quadrants_internal_file as _is_quadrants_internal_file,
+)
 from quadrants.types import primitive_types
 from quadrants.types.utils import is_integral
 

--- a/python/quadrants/lang/ast/ast_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformer.py
@@ -42,6 +42,8 @@ from quadrants.lang.snode import append, deactivate, length
 from quadrants.lang.struct import Struct, StructType
 from quadrants.lang.util import (
     is_from_quadrants_module as _is_from_quadrants_module,
+)
+from quadrants.lang.util import (
     is_quadrants_internal_file as _is_quadrants_internal_file,
 )
 from quadrants.types import primitive_types

--- a/python/quadrants/lang/util.py
+++ b/python/quadrants/lang/util.py
@@ -362,10 +362,11 @@ def is_from_quadrants_module(obj: object) -> bool:
     import types  # pylint: disable=C0415
 
     if isinstance(obj, types.ModuleType):
-        return getattr(obj, "__name__", "").startswith("quadrants")
+        name = getattr(obj, "__name__", "")
+        return name == "quadrants" or name.startswith("quadrants.")
     if isinstance(obj, type):
         mod = getattr(obj, "__module__", None)
-        return mod is not None and mod.startswith("quadrants")
+        return mod is not None and (mod == "quadrants" or mod.startswith("quadrants."))
     return False
 
 

--- a/python/quadrants/lang/util.py
+++ b/python/quadrants/lang/util.py
@@ -353,4 +353,20 @@ def is_qd_template(annotation: Any) -> bool:
     return annotation is Template or type(annotation) is Template
 
 
+def is_from_quadrants_module(obj: object) -> bool:
+    """Return True if obj is a quadrants module or class (not an instance).
+
+    This is intentionally restricted to modules and classes so that mutable
+    instance attributes are still flagged as purity violations.
+    """
+    import types  # pylint: disable=C0415
+
+    if isinstance(obj, types.ModuleType):
+        return getattr(obj, "__name__", "").startswith("quadrants")
+    if isinstance(obj, type):
+        mod = getattr(obj, "__module__", None)
+        return mod is not None and mod.startswith("quadrants")
+    return False
+
+
 __all__ = []

--- a/tests/python/quadrants/lang/fast_caching/test_pure_validation.py
+++ b/tests/python/quadrants/lang/fast_caching/test_pure_validation.py
@@ -251,3 +251,34 @@ def test_pure_validation_actual_violation_warning():
 
     with pytest.warns(UserWarning, match=r"\[PURE\.VIOLATION\]"):
         assert k2() == 23
+
+
+@test_utils.test()
+def test_pure_validation_quadrants_module_attribute_allowed():
+    """Accessing a float constant from the quadrants package should not trigger a purity violation."""
+
+    @qd.kernel(pure=True)
+    def k1() -> qd.f32:
+        return qd.math.pi
+
+    assert int(k1() * 100) == 314
+
+
+@test_utils.test()
+def test_pure_validation_non_quadrants_attribute_warns():
+    """Accessing an int attribute on a non-quadrants object should still warn/error."""
+    assert qd.lang is not None
+    arch = qd.lang.impl.current_cfg().arch
+    qd.init(arch=arch, offline_cache=False)
+
+    class Config:
+        SIZE = 32
+
+    cfg = Config()
+
+    @qd.kernel(pure=True)
+    def k1() -> qd.i32:
+        return cfg.SIZE
+
+    with pytest.warns(UserWarning, match=r"\[PURE\.VIOLATION\]"):
+        assert k1() == 32

--- a/tests/python/quadrants/lang/fast_caching/test_pure_validation.py
+++ b/tests/python/quadrants/lang/fast_caching/test_pure_validation.py
@@ -257,7 +257,7 @@ def test_pure_validation_actual_violation_warning():
 def test_pure_validation_quadrants_module_attribute_allowed():
     """Accessing a float constant from the quadrants package should not trigger a purity violation."""
 
-    @qd.kernel(pure=True)
+    @qd.kernel(fastcache=True)
     def k1() -> qd.f32:
         return qd.math.pi
 
@@ -276,7 +276,7 @@ def test_pure_validation_non_quadrants_attribute_warns():
 
     cfg = Config()
 
-    @qd.kernel(pure=True)
+    @qd.kernel(fastcache=True)
     def k1() -> qd.i32:
         return cfg.SIZE
 


### PR DESCRIPTION
The purity checker was special-casing qd.math via a local import. Replace with a general is_from_quadrants_module() check that covers any quadrants module/class/instance, and remove the qd_math special case.

Add tests for both the allowed case (qd.math.pi) and the rejected case (non-quadrants object attribute).

Issue: #

### Brief Summary

  What this PR does:
  The purity checker in build_Attribute previously special-cased qd.math (via a local from quadrants import math as qd_math import) to suppress false-positive PURE.VIOLATION
  warnings when pure kernels accessed constants like qd.math.pi. This PR replaces that narrow special-case with a general is_from_quadrants_module() check that allows accessing
  attributes on any quadrants module or class without triggering purity violations. This is needed for things like qd.simt.Tile16x16.SIZE in the tiles work.
  Changes:
  • util.py: Add is_from_quadrants_module() — returns True for quadrants modules and classes, but not instances
  • ast_transformer.py: Replace the qd_math special-case with is_from_quadrants_module(), remove the now-unused qd_math import
  • test_pure_validation.py: Add two tests — one verifying quadrants module constants are allowed (qd.math.pi), one verifying non-quadrants object attributes still warn

  Good:
  • Generalizes correctly: any quadrants module/class constant (e.g. qd.simt.Tile16x16.SIZE, qd.math.pi) is allowed without needing per-module special cases
  • Restricted to modules and classes — instances are still flagged, so mutable runtime state can't silently bypass purity
  • Exact package name matching (== "quadrants" or .startswith("quadrants.")) avoids false matches on hypothetical third-party packages
  • Removes dead-weight qd_math import that ran on every build_Attribute call
  • Compile-time only, zero runtime performance impact

  Bad / caveats:
  • Mutable class-level attributes (e.g. SomeQdClass.counter = 0 modified at runtime) would be incorrectly suppressed. This is unlikely in practice but not impossible.
  • The qd.math.pi test overlaps with the existing test_pure_validation_builtin_values_qd_pi test — though that test was previously covered by the qd_math special-case, not by
    is_from_quadrants_module, so it does exercise a different code path now.

copilot:summary

### Walkthrough

copilot:walkthrough
