### PR TITLE
[AutoDiff] Autodiff 6: Adstack regression tests

### DIFF
--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -321,10 +321,13 @@ def test_adstack_nan_propagation_f64(op_name, x_val):
     assert math.isnan(x.grad[None])
 
 
-def _run_basic_gradient(qd_dtype, n_iter, rel_tol, approx=test_utils.approx):
+def _run_basic_gradient(qd_dtype, n_iter, rel_tol, approx=test_utils.approx, abs_tol=None):
     # Builds the kernel, runs forward + backward, and asserts a correct gradient. `approx` defaults to
     # `test_utils.approx` which is correct for f32 (its backend-specific floor kicks in); f64 callers must pass
     # `pytest.approx` to honor a tight `rel_tol=1e-14` that `test_utils.approx` would otherwise floor to 1e-6.
+    # `abs_tol` is forwarded as `abs=` to the approx; f64 callers must pass `abs_tol=0` because pytest.approx's
+    # default `abs=1e-12` would otherwise dominate for the expected magnitudes here (~0.6-0.95), making the
+    # effective tolerance ~1e-12 absolute rather than 1e-14 relative and missing f32-narrowing regressions.
     # The adstack is structurally required here so the backward compiler can reverse the dynamic `range(n_iter)`
     # at all; the companion `test_adstack_basic_gradient_negative` pins that disabling the adstack raises
     # `QuadrantsCompilationError("non static range")`. Value-correctness of the per-iteration `v` spilled on the
@@ -356,8 +359,11 @@ def _run_basic_gradient(qd_dtype, n_iter, rel_tol, approx=test_utils.approx):
     # `v = v * 0.95 + 0.01` iterated n_iter times gives v_final = 0.95**n_iter * x[i] + const, so
     # dv_final/dx[i] == 0.95**n_iter independent of x[i], and dy/dx[i] equals the same quantity.
     expected = 0.95**n_iter
+    approx_kwargs = {"rel": rel_tol}
+    if abs_tol is not None:
+        approx_kwargs["abs"] = abs_tol
     for i in range(n):
-        assert x.grad[i] == approx(expected, rel=rel_tol)
+        assert x.grad[i] == approx(expected, **approx_kwargs)
 
 
 @pytest.mark.parametrize("n_iter", [1, 3, 10])
@@ -383,10 +389,12 @@ def test_adstack_basic_gradient(n_iter):
 @pytest.mark.parametrize("n_iter", [1, 3, 10])
 @test_utils.test(require=[qd.extension.adstack, qd.extension.data64], default_fp=qd.f64)
 def test_adstack_basic_gradient_f64(n_iter):
-    # f64 counterpart of `test_adstack_basic_gradient`. Uses `pytest.approx` so the tight `rel_tol=1e-14` is
-    # honored; `test_utils.approx` would floor it to `get_rel_eps()` (typically 1e-6) and silently pass an
-    # f32-precision regression.
-    _run_basic_gradient(qd.f64, n_iter=n_iter, rel_tol=1e-14, approx=pytest.approx)
+    # f64 counterpart of `test_adstack_basic_gradient`. Uses `pytest.approx` so the tight `rel_tol=1e-14` is honored;
+    # `test_utils.approx` would floor it to `get_rel_eps()` (typically 1e-6) and silently pass an f32-precision
+    # regression. `abs_tol=0` disables pytest.approx's default `abs=1e-12` floor, which would otherwise dominate for
+    # the expected magnitudes `0.95**n_iter in [~0.6, 0.95]` and make the effective tolerance ~1e-12 absolute rather
+    # than 1e-14 relative; that is still ~100x looser than f64 roundoff and would miss an f32-narrowing regression.
+    _run_basic_gradient(qd.f64, n_iter=n_iter, rel_tol=1e-14, approx=pytest.approx, abs_tol=0)
 
 
 @pytest.mark.parametrize("n_iter", [1, 3, 10])
@@ -419,7 +427,9 @@ def test_adstack_basic_gradient_negative(n_iter):
         compute.grad()
 
 
-def _run_sum_linear(qd_dtype, use_static_loop, use_varying_coeff, n_iter, rel_tol, approx=test_utils.approx):
+def _run_sum_linear(
+    qd_dtype, use_static_loop, use_varying_coeff, n_iter, rel_tol, approx=test_utils.approx, abs_tol=None
+):
     n = 4
     x = qd.field(qd_dtype, shape=n, needs_grad=True)
     y = qd.field(qd_dtype, shape=(), needs_grad=True)
@@ -445,8 +455,11 @@ def _run_sum_linear(qd_dtype, use_static_loop, use_varying_coeff, n_iter, rel_to
     compute.grad()
 
     expected = sum(a + 1 for a in range(n_iter)) if use_varying_coeff else float(n_iter)
+    approx_kwargs = {"rel": rel_tol}
+    if abs_tol is not None:
+        approx_kwargs["abs"] = abs_tol
     for i in range(n):
-        assert x.grad[i] == approx(expected, rel=rel_tol)
+        assert x.grad[i] == approx(expected, **approx_kwargs)
 
 
 @pytest.mark.parametrize("n_iter", [1, 3, 10])
@@ -476,5 +489,12 @@ def test_adstack_sum_linear(use_static_loop, use_varying_coeff, n_iter):
 @pytest.mark.parametrize("use_varying_coeff", [True, False])
 @test_utils.test(require=[qd.extension.adstack, qd.extension.data64], default_fp=qd.f64)
 def test_adstack_sum_linear_f64(use_static_loop, use_varying_coeff, n_iter):
-    # f64 counterpart uses `pytest.approx` so the tight rel_tol is not floored by `test_utils.approx`.
-    _run_sum_linear(qd.f64, use_static_loop, use_varying_coeff, n_iter, rel_tol=1e-14, approx=pytest.approx)
+    # f64 counterpart uses `pytest.approx` so the tight rel_tol is not floored by `test_utils.approx`, and
+    # `abs_tol=0` disables pytest.approx's default `abs=1e-12` floor so the 1e-14 relative tolerance is actually
+    # honored. Note: the expected gradients here are integers in `{1, 3, 6, 10, 55}` which are exactly representable
+    # in both f32 and f64, so this test cannot catch an f32-narrowing regression of the backward pass regardless of
+    # tolerance - the value coverage comes from `test_adstack_basic_gradient_f64` whose non-integer expected values
+    # genuinely exercise the f64 precision floor. Kept here to preserve the shape coverage (static/dynamic inner
+    # loop x varying/constant coefficient) at f64 since a future type-narrowing bug that depends on shape might
+    # still surface through compile-time / structural differences between f32 and f64 codegen paths.
+    _run_sum_linear(qd.f64, use_static_loop, use_varying_coeff, n_iter, rel_tol=1e-14, approx=pytest.approx, abs_tol=0)

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -319,3 +319,162 @@ def test_adstack_nan_propagation_f64(op_name, x_val):
     compute.grad()
 
     assert math.isnan(x.grad[None])
+
+
+def _run_basic_gradient(qd_dtype, n_iter, rel_tol, approx=test_utils.approx):
+    # Builds the kernel, runs forward + backward, and asserts a correct gradient. `approx` defaults to
+    # `test_utils.approx` which is correct for f32 (its backend-specific floor kicks in); f64 callers must pass
+    # `pytest.approx` to honor a tight `rel_tol=1e-14` that `test_utils.approx` would otherwise floor to 1e-6.
+    # The adstack is structurally required here so the backward compiler can reverse the dynamic `range(n_iter)`
+    # at all; the companion `test_adstack_basic_gradient_negative` pins that disabling the adstack raises
+    # `QuadrantsCompilationError("non static range")`. Value-correctness of the per-iteration `v` spilled on the
+    # adstack is NOT exercised by the linear body `v = v * 0.95 + 0.01` - see `test_adstack_basic_gradient`'s
+    # docstring for the details.
+    n = 4
+    x = qd.field(qd_dtype, shape=n, needs_grad=True)
+    y = qd.field(qd_dtype, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i in x:
+            v = x[i]
+            for _ in range(n_iter):
+                v = v * 0.95 + 0.01
+            y[None] += v
+
+    x_vals = [0.1, 0.3, 0.5, 0.8]
+    for i, v in enumerate(x_vals):
+        x[i] = v
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    for i in range(n):
+        x.grad[i] = 0.0
+
+    compute.grad()
+
+    # `v = v * 0.95 + 0.01` iterated n_iter times gives v_final = 0.95**n_iter * x[i] + const, so
+    # dv_final/dx[i] == 0.95**n_iter independent of x[i], and dy/dx[i] equals the same quantity.
+    expected = 0.95**n_iter
+    for i in range(n):
+        assert x.grad[i] == approx(expected, rel=rel_tol)
+
+
+@pytest.mark.parametrize("n_iter", [1, 3, 10])
+@test_utils.test(require=qd.extension.adstack)
+def test_adstack_basic_gradient(n_iter):
+    # Smallest possible "does reverse-mode AD through a for-loop work at all" check. The kernel runs `n_iter`
+    # iterations of `v = v * 0.95 + 0.01` per element and asserts that `dy/dx[i]` matches the analytical gradient
+    # `0.95 ** n_iter` for every element.
+    #
+    # Internal details: the adstack is structurally required here so the backward compiler can reverse the
+    # dynamic `range(n_iter)` at all - the companion `test_adstack_basic_gradient_negative` pins that disabling
+    # the adstack raises `QuadrantsCompilationError` in exactly this kernel shape. Value-correctness of the
+    # stored v, on the other hand, is NOT exercised: the loop body `v = v * 0.95 + 0.01` is linear, so the
+    # backward chain `adj(v_prev) = 0.95 * adj(v_next)` only uses the compile-time constant 0.95 and never reads
+    # v from the adstack. A broken push/load/pop that returned garbage for v would still produce the same exact
+    # gradient. For push/load/pop value-correctness coverage, see `test_adstack_unary_loop_carried` (non-linear
+    # unary ops in the loop body). `n_iter = 1` exercises the single-push adstack code path; `n_iter = 10`
+    # exercises repeated push/pop under one forward invocation; multi-element coverage (n = 4) guards against
+    # per-element accumulation bugs that a single-element variant would miss.
+    _run_basic_gradient(qd.f32, n_iter=n_iter, rel_tol=1e-6)
+
+
+@pytest.mark.parametrize("n_iter", [1, 3, 10])
+@test_utils.test(require=[qd.extension.adstack, qd.extension.data64], default_fp=qd.f64)
+def test_adstack_basic_gradient_f64(n_iter):
+    # f64 counterpart of `test_adstack_basic_gradient`. Uses `pytest.approx` so the tight `rel_tol=1e-14` is
+    # honored; `test_utils.approx` would floor it to `get_rel_eps()` (typically 1e-6) and silently pass an
+    # f32-precision regression.
+    _run_basic_gradient(qd.f64, n_iter=n_iter, rel_tol=1e-14, approx=pytest.approx)
+
+
+@pytest.mark.parametrize("n_iter", [1, 3, 10])
+@test_utils.test(ad_stack_experimental_enabled=False)
+def test_adstack_basic_gradient_negative(n_iter):
+    # Negative counterpart of `test_adstack_basic_gradient`: with the adstack disabled the backward compiler
+    # cannot reverse a dynamic `range(n_iter)`, so `compute.grad()` raises `QuadrantsCompilationError("Cannot use
+    # non static range in Backwards mode")` deterministically for every `n_iter`. Inlined rather than reusing
+    # `_run_basic_gradient` because the shall-not-pass path never reaches the gradient assertion, so a shared
+    # helper would carry a dead `rel_tol` argument down this branch.
+    n = 4
+    x = qd.field(qd.f32, shape=n, needs_grad=True)
+    y = qd.field(qd.f32, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i in x:
+            v = x[i]
+            for _ in range(n_iter):
+                v = v * 0.95 + 0.01
+            y[None] += v
+
+    x_vals = [0.1, 0.3, 0.5, 0.8]
+    for i, v in enumerate(x_vals):
+        x[i] = v
+    y[None] = 0.0
+    compute()
+
+    with pytest.raises(qd.QuadrantsCompilationError, match=r"non static range"):
+        compute.grad()
+
+
+def _run_sum_linear(qd_dtype, use_static_loop, use_varying_coeff, n_iter, rel_tol, approx=test_utils.approx):
+    n = 4
+    x = qd.field(qd_dtype, shape=n, needs_grad=True)
+    y = qd.field(qd_dtype, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i in x:
+            v = x[i]
+            for a in qd.static(range(n_iter)) if qd.static(use_static_loop) else range(n_iter):
+                if qd.static(use_varying_coeff):
+                    y[None] += v * qd.cast(a + 1, qd_dtype)
+                else:
+                    y[None] += v
+
+    x_vals = [0.1, 0.3, 0.5, 0.8]
+    for i, v in enumerate(x_vals):
+        x[i] = v
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    for i in range(n):
+        x.grad[i] = 0.0
+    compute.grad()
+
+    expected = sum(a + 1 for a in range(n_iter)) if use_varying_coeff else float(n_iter)
+    for i in range(n):
+        assert x.grad[i] == approx(expected, rel=rel_tol)
+
+
+@pytest.mark.parametrize("n_iter", [1, 3, 10])
+@pytest.mark.parametrize("use_static_loop", [True, False])
+@pytest.mark.parametrize("use_varying_coeff", [True, False])
+@test_utils.test(require=qd.extension.adstack)
+def test_adstack_sum_linear(use_static_loop, use_varying_coeff, n_iter):
+    # Linear accumulation `y = sum_j v * coeff_j` across all four combinations of (static-unrolled vs dynamic loop)
+    # x (constant coefficient vs loop-index-varying coefficient), at three loop lengths. Replaces the earlier three
+    # separate tests (`test_adstack_sum_fixed_coeff`, `test_adstack_sum_constant_coeffs`,
+    # `test_adstack_sum_static_loop_correct`) with a single parametrized version so every branch of that truth
+    # table is covered at each trip count.
+    #
+    # Internal details: this test deliberately does not mutate `v` inside the loop, so the reverse pass does not
+    # require adstack replay of `v` to compute the right gradient - `v`'s per-iteration value is the same `x[i]`.
+    # The point of this test is therefore not to stress the adstack (that is `test_adstack_basic_gradient`'s job)
+    # but to prove that enabling the adstack extension does not silently regress linear reverse-mode AD for either
+    # unrolled or dynamic loop shapes. No negative counterpart is included: for `use_static_loop=True` the inner
+    # loop is unrolled and the backward kernel contains no dynamic range, so the adstack option does not change
+    # the gradient; for `use_static_loop=False` disabling the adstack would raise `QuadrantsCompilationError`
+    # (same compile-time rejection covered by `test_adstack_basic_gradient_negative`), which is out of scope here.
+    _run_sum_linear(qd.f32, use_static_loop, use_varying_coeff, n_iter, rel_tol=1e-6)
+
+
+@pytest.mark.parametrize("n_iter", [1, 3, 10])
+@pytest.mark.parametrize("use_static_loop", [True, False])
+@pytest.mark.parametrize("use_varying_coeff", [True, False])
+@test_utils.test(require=[qd.extension.adstack, qd.extension.data64], default_fp=qd.f64)
+def test_adstack_sum_linear_f64(use_static_loop, use_varying_coeff, n_iter):
+    # f64 counterpart uses `pytest.approx` so the tight rel_tol is not floored by `test_utils.approx`.
+    _run_sum_linear(qd.f64, use_static_loop, use_varying_coeff, n_iter, rel_tol=1e-14, approx=pytest.approx)


### PR DESCRIPTION
# Adstack regression tests

> Test-only PR. Pins baseline reverse-mode AD behaviour through dynamic and static for-loops with the adstack extension. Complements Autodiff 1's unary-op test with coverage of the linear-kernel path, which has a different failure signature and different structural invariants.

## TL;DR

Three structural tests, each with an f32 and an f64 variant:

1. **`test_adstack_basic_gradient(_f64)`** — loop-carried state mutation. `v = v * 0.95 + 0.01` iterated `n_iter ∈ {1, 3, 10}` times. Gradient `dy/dx[i] = 0.95**n_iter`, independent of `x[i]`, so a broken push/load/pop pattern would still happen to produce the right answer (the backward chain `adj(v_prev) = 0.95 * adj(v_next)` only uses the compile-time constant 0.95). What this test pins is structural: the backward compiler must successfully reverse a dynamic `range(n_iter)`.

2. **`test_adstack_basic_gradient_negative`** — the negative counterpart. Decorated with `@test_utils.test(ad_stack_experimental_enabled=False)`; asserts `compute.grad()` raises `qd.QuadrantsCompilationError("Cannot use non static range in Backwards mode")` deterministically. Pins the exact compile-time rejection.

3. **`test_adstack_sum_linear(_f64)`** — 2×2×3 parametrize matrix: `(static vs dynamic loop) × (constant vs loop-varying coefficient) × (n_iter ∈ {1, 3, 10})`. Linear accumulation `y = sum_j v * coeff_j`; `v` is loop-invariant. Proves that enabling the adstack extension does not silently regress linear reverse-mode AD in any of the four shape combinations.

## Why

Autodiff 1 pins reverse-mode AD for *nonlinear* unary ops in dynamic loops — the shape where the per-iteration operand has to be replayed from the adstack. The class of bugs it catches: a unary op missing from `unary_collections` → operand falls back to a single spill slot → last-iteration value read for every backward step.

This PR pins the orthogonal shape: *linear* loop bodies. The failure modes here are different:

- The adstack is structurally required to reverse a dynamic range at all — without it, the backward compiler flat-out refuses to build the kernel. That's what `test_adstack_basic_gradient_negative` pins.
- Once the adstack enables the reversal, value-correctness of the spilled state depends on push/load/pop timing relative to the loop control flow. The linear-body tests do not exercise per-iteration value correctness of the stored `v` (the coefficients are compile-time constants), but they catch structural bugs that would stop the backward kernel from running at all — mis-sized slab, wrong iteration direction, off-by-one in the pop count on the reversed loop, and similar.

Both classes of test are needed: a unary-ops regression would slip past the linear tests, and a structural regression (e.g. an off-by-one that nonetheless happens to produce the right gradient for non-linear unary ops through compensation) would slip past the unary tests.

## The f64 design

Each test is a thin wrapper around a helper that takes `qd_dtype` and `rel_tol`:

```python
def _run_basic_gradient(qd_dtype, n_iter, rel_tol, shall_not_pass): ...
def _run_sum_linear(qd_dtype, use_static_loop, use_varying_coeff, n_iter, rel_tol): ...
```

The f32 and f64 tests decorate with different `@test_utils.test(...)` modes:

- f32: `@test_utils.test(require=qd.extension.adstack)`, `rel=1e-6` (tight for a strictly linear kernel; catches a new fp op introduced in the backward).
- f64: `@test_utils.test(require=[qd.extension.adstack, qd.extension.data64], default_fp=qd.f64)`, `rel=1e-14`.

`default_fp=qd.f64` at decorator time is load-bearing: Python float literals in the kernel body (`0.95`, `0.01`, etc.) get baked at whatever `default_fp` says, so `0.95` becomes an f32-quantized constant if the decorator uses the default `default_fp=qd.f32`, and the resulting gradient is not actually f64-precision. Splitting into two tests with different decorators is the only way to get truly tight f64 tolerance; the shared body lives in the helper.

## Coverage matrix

| Test                                       | Dynamic loop | Static loop | Loop-carried state | Check |
|--------------------------------------------|:-:|:-:|:-:|---|
| `test_adstack_basic_gradient`              | ✓ |   | ✓ | value match against `0.95**n_iter` |
| `test_adstack_basic_gradient_negative`     | ✓ |   | ✓ | compile-time rejection |
| `test_adstack_sum_linear[static, const]`   |   | ✓ |   | value match against `n_iter` |
| `test_adstack_sum_linear[static, varying]` |   | ✓ |   | value match against `sum(a+1 for a)` |
| `test_adstack_sum_linear[dyn, const]`      | ✓ |   |   | same |
| `test_adstack_sum_linear[dyn, varying]`    | ✓ |   |   | same |

## Stack

Autodiff 6 of 13. Based on #496 (alloca placement). Followed by #534 (header size).
