### PR TITLE
[AutoDiff] Autodiff 13: Heap-backed adstack on SPIR-V backends (Metal, Vulkan)

### DIFF
--- a/quadrants/codegen/spirv/detail/spirv_codegen.h
+++ b/quadrants/codegen/spirv/detail/spirv_codegen.h
@@ -194,24 +194,56 @@ class TaskCodegen : public IRVisitor {
 
   bool use_volatile_buffer_access_{false};
 
+  // Where the primal/adjoint storage for an AdStack lives. `heap_float` backs f32 adstacks and `heap_int` backs
+  // i32 and u1 adstacks (u1 stored as i32 to match the historical Function-scope path's bool->int remap in
+  // `get_array_type`); other primitive types are hard-errored by `visit(AdStackAllocaStmt)`, so no Function-scope
+  // fallback exists. Each kind maps to its own per-dispatch StorageBuffer (`BufferType::AdStackHeapFloat` /
+  // `BufferType::AdStackHeapInt`).
+  enum class AdStackHeapKind { heap_float, heap_int };
   struct AdStackSpirv {
-    spirv::Value count_var;    // u32, Function scope - current number of entries
-    spirv::Value primal_arr;   // Array<storage_type, max_size>, Function scope
-    spirv::Value adjoint_arr;  // Array<storage_type, max_size>, Function scope
-    // `elem_type` is the logical loop-carried value's SPIR-V type (e.g. bool for a u1 adstack). `storage_type`
-    // is what the backing array is actually declared as: identical to `elem_type` except for u1, where the
-    // array is declared as i32 because `IRBuilder::get_array_type` silently promotes OpTypeBool (which has no
-    // defined storage layout under LogicalAddressing) to i32. Push/LoadTop/AccAdjoint must use `storage_type`
-    // for the OpAccessChain / load-store pair, and cast between `elem_type` and `storage_type` around the
-    // caller-visible value - otherwise SPIR-V codegen emits `OpAccessChain %_ptr_Function_bool %arr_of_int_N`,
-    // which spirv-val rejects with "result type OpTypeBool does not match the type that results from
-    // indexing into OpTypeInt" and AMD's native Vulkan driver runs anyway and segfaults the dispatch.
-    spirv::SType elem_type;
-    spirv::SType storage_type;
+    spirv::Value count_var;  // u32, Function scope - current number of entries
+    AdStackHeapKind heap_kind;
+    // Offsets are in elements of the heap's element type (f32 or i32).
+    uint32_t heap_primal_offset{0};
+    uint32_t heap_adjoint_offset{0};
     uint32_t max_size{0};
+    spirv::SType elem_type;
   };
   std::unordered_map<const Stmt *, AdStackSpirv> ad_stacks_;
-  spirv::Value ad_stack_access(spirv::Value arr, spirv::Value index, const spirv::SType &elem_type);
+  // Total per-thread heap strides, pre-computed from the IR before any visitor runs so that
+  // `invoc_id * stride` captures the final value. Exposed via `task_attribs.ad_stack_heap_per_thread_stride_*` so
+  // the runtime can size the heaps. The float stride is counted in f32 elements, the int stride in i32 elements.
+  uint32_t ad_stack_heap_per_thread_stride_float_{0};
+  uint32_t ad_stack_heap_per_thread_stride_int_{0};
+  // Running offsets into the per-thread slice assigned to the next AdStackAllocaStmt visitor. Each ends equal to
+  // the corresponding stride once every alloca has been visited.
+  uint32_t ad_stack_heap_next_offset_float_{0};
+  uint32_t ad_stack_heap_next_offset_int_{0};
+  // Buffers are cached for reuse across push/pop/load-top visitors and (re)computed lazily on first use inside a
+  // task so the `OpLoad` falls inside the dispatch body rather than the function header.
+  spirv::Value ad_stack_heap_buffer_float_;
+  spirv::Value ad_stack_heap_buffer_int_;
+  // `invoc_id * stride` thread-base values. Despite being cached like the buffers, these are NOT lazy: they are
+  // emitted eagerly from `visit(AdStackAllocaStmt)` so the `OpIMul` lives in the alloca's enclosing block, which
+  // strictly dominates every sibling inner loop that later references the cached SSA id. Emitting them lazily
+  // from the first `AdStackPush/LoadTop` visitor would place the multiply in the first loop's body, and the
+  // second sibling loop would reuse an SSA id defined in a non-dominating block (SPIR-V spec section 2.16).
+  // Do NOT move these to a lazy path; the corresponding getters enforce eager emission.
+  spirv::Value ad_stack_heap_thread_base_float_;
+  spirv::Value ad_stack_heap_thread_base_int_;
+  // Return (lazily) the StorageBuffer of `Array<f32>` that backs f32 adstacks for this dispatch, and the
+  // per-thread base index inside it.
+  spirv::Value get_ad_stack_heap_buffer_float();
+  spirv::Value get_ad_stack_heap_thread_base_float();
+  spirv::Value ad_stack_heap_float_ptr(uint32_t offset, spirv::Value count);
+  // Same accessors for the int-typed heap buffer (backs i32 and u1 adstacks).
+  spirv::Value get_ad_stack_heap_buffer_int();
+  spirv::Value get_ad_stack_heap_thread_base_int();
+  spirv::Value ad_stack_heap_int_ptr(uint32_t offset, spirv::Value count);
+  // Routes to the correct backing-typed pointer (`*f32` for `heap_float`, `*i32` for `heap_int`) based on
+  // `info.heap_kind`. See comment on the implementation for the bool<->i32 conversion contract.
+  spirv::Value ad_stack_slot_ptr(AdStackSpirv &info, spirv::Value idx, bool primal);
+  spirv::SType ad_stack_backing_type(const AdStackSpirv &info) const;
 };
 }  // namespace detail
 }  // namespace spirv

--- a/quadrants/codegen/spirv/kernel_utils.cpp
+++ b/quadrants/codegen/spirv/kernel_utils.cpp
@@ -24,6 +24,21 @@ std::string TaskAttributes::buffers_name(BufferInfo b) {
   if (b.type == BufferType::Root) {
     return std::string("Root: ") + std::to_string(b.root_id);
   }
+  if (b.type == BufferType::ListGen) {
+    return "ListGen";
+  }
+  if (b.type == BufferType::ExtArr) {
+    return "ExtArr";
+  }
+  if (b.type == BufferType::AdStackOverflow) {
+    return "AdStackOverflow";
+  }
+  if (b.type == BufferType::AdStackHeapFloat) {
+    return "AdStackHeapFloat";
+  }
+  if (b.type == BufferType::AdStackHeapInt) {
+    return "AdStackHeapInt";
+  }
   QD_ERROR("unrecognized buffer type");
 }
 

--- a/quadrants/codegen/spirv/kernel_utils.h
+++ b/quadrants/codegen/spirv/kernel_utils.h
@@ -20,7 +20,17 @@ namespace spirv {
  * Per offloaded task attributes.
  */
 struct TaskAttributes {
-  enum class BufferType { Root, GlobalTmps, Args, Rets, ListGen, ExtArr, AdStackOverflow };
+  enum class BufferType {
+    Root,
+    GlobalTmps,
+    Args,
+    Rets,
+    ListGen,
+    ExtArr,
+    AdStackOverflow,
+    AdStackHeapFloat,
+    AdStackHeapInt,
+  };
 
   struct BufferInfo {
     BufferType type;
@@ -111,11 +121,35 @@ struct TaskAttributes {
       return (const_begin && const_end);
     }
 
-    QD_IO_DEF(begin, end, const_begin, const_end);
+    // When the range end is non-const and the IR encodes it as a product of one or more ndarray-shape lookups (a
+    // common `qd.ndrange(arr.shape[...], ...)` pattern), the codegen extracts each `ExternalTensorShapeAlongAxisStmt`
+    // into this list. At launch time, host-side `LaunchContextBuilder` already has every ndarray's shape in
+    // `array_ptrs` / struct args, so the actual iteration bound is `product over refs of arg[arg_id].shape[axis]`.
+    // The runtime uses that as a tight cap on `advisory_total_num_threads` to avoid oversizing the per-thread
+    // adstack heap (otherwise `kMaxNumThreadsGridStrideLoop` defaults to 131072 for a B=1 workload and the heap
+    // allocation requests multi-GB that exceeds Metal's `maxBufferLength`). Empty means the end expression could
+    // not be simplified to a pure product of shape lookups; fall back to the advisory thread count in that case.
+    struct ArgShapeRef {
+      std::vector<int> arg_id;
+      int axis{0};
+      QD_IO_DEF(arg_id, axis);
+    };
+    std::vector<ArgShapeRef> end_shape_product;
+
+    QD_IO_DEF(begin, end, const_begin, const_end, end_shape_product);
   };
   std::vector<BufferBind> buffer_binds;
   // Only valid when |task_type| is range_for.
   std::optional<RangeForAttributes> range_for_attribs;
+
+  // Per-thread stride, in f32 elements, of the f32-typed heap-backed adstack slice used by this task, bound as
+  // BufferType::AdStackHeapFloat. Zero when the task has no f32 adstack. The runtime multiplies this by the
+  // dispatched invocation count to size the shared adstack buffer.
+  uint32_t ad_stack_heap_per_thread_stride_float{0};
+  // Per-thread stride, in i32 elements, of the int-typed heap-backed adstack slice used by this task, bound as
+  // BufferType::AdStackHeapInt. Backs both i32 and u1 adstacks (u1 is stored as i32, matching the existing
+  // Function-scope path). Zero when the task has no non-f32 adstack.
+  uint32_t ad_stack_heap_per_thread_stride_int{0};
 
   static std::string buffers_name(BufferInfo b);
 
@@ -126,7 +160,9 @@ struct TaskAttributes {
             advisory_num_threads_per_group,
             task_type,
             buffer_binds,
-            range_for_attribs);
+            range_for_attribs,
+            ad_stack_heap_per_thread_stride_float,
+            ad_stack_heap_per_thread_stride_int);
 };
 
 /**

--- a/quadrants/codegen/spirv/spirv_codegen.cpp
+++ b/quadrants/codegen/spirv/spirv_codegen.cpp
@@ -34,6 +34,8 @@ constexpr char kRetBufferName[] = "ret_buffer";
 constexpr char kListgenBufferName[] = "listgen_buffer";
 constexpr char kExtArrBufferName[] = "ext_arr_buffer";
 constexpr char kAdStackOverflowBufferName[] = "adstack_overflow_buffer";
+constexpr char kAdStackHeapFloatBufferName[] = "adstack_heap_float_buffer";
+constexpr char kAdStackHeapIntBufferName[] = "adstack_heap_int_buffer";
 
 constexpr int kMaxNumThreadsGridStrideLoop = 65536 * 2;
 
@@ -57,6 +59,10 @@ std::string buffer_instance_name(BufferInfo b) {
       return std::string(kExtArrBufferName) + "_" + std::to_string(b.root_id) + (b.is_grad ? "_grad" : "");
     case BufferType::AdStackOverflow:
       return kAdStackOverflowBufferName;
+    case BufferType::AdStackHeapFloat:
+      return kAdStackHeapFloatBufferName;
+    case BufferType::AdStackHeapInt:
+      return kAdStackHeapIntBufferName;
     default:
       QD_NOT_IMPLEMENTED;
       break;
@@ -122,6 +128,47 @@ TaskCodegen::Result TaskCodegen::run() {
 
   scan_shared_atomic_allocs(task_ir_->body.get(), shared_float_allocas_with_atomic_rmw_);
 
+  // Pre-compute the total per-thread heap strides by counting every heap-eligible AdStackAllocaStmt the body will
+  // visit. f32 adstacks go on the f32 heap; i32 and u1 adstacks share the int heap (u1 is stored as i32 to match
+  // the historical Function-scope path's `get_array_type` bool->int remap). Other primitive types (f64, i64, ...)
+  // are hard-errored in `visit(AdStackAllocaStmt)` and never reach this scan. Growing the strides lazily as
+  // visitors run would bake a stale stride into `invoc_id * stride` once the first Push/LoadTop emits the base:
+  // later allocas would raise the stride and leave the earlier base pointing past the thread's allotted slice,
+  // overlapping neighbours.
+  {
+    std::function<void(IRNode *)> scan = [&](IRNode *node) {
+      if (auto *blk = dynamic_cast<Block *>(node)) {
+        for (auto &s : blk->statements)
+          scan(s.get());
+      } else if (auto *alloca = dynamic_cast<AdStackAllocaStmt *>(node)) {
+        if (alloca->ret_type == PrimitiveType::f32) {
+          ad_stack_heap_per_thread_stride_float_ += 2u * uint32_t(alloca->max_size);
+        } else if (alloca->ret_type == PrimitiveType::i32 || alloca->ret_type == PrimitiveType::u1) {
+          // Only primal storage: i32 and u1 adstacks record control-flow state (loop counters and if-branch
+          // flags) for the reverse pass to replay, and auto_diff.cpp only emits AdStackAccAdjoint/LoadTopAdj on
+          // real-typed stacks (see the `is_real` guard around line 1175). An int adjoint would also be
+          // meaningless - docs/source/user_guide/autodiff.md states gradients silently read as zero through
+          // integer casts.
+          ad_stack_heap_per_thread_stride_int_ += uint32_t(alloca->max_size);
+        }
+      } else if (auto *if_stmt = dynamic_cast<IfStmt *>(node)) {
+        if (if_stmt->true_statements)
+          scan(if_stmt->true_statements.get());
+        if (if_stmt->false_statements)
+          scan(if_stmt->false_statements.get());
+      } else if (auto *range_for = dynamic_cast<RangeForStmt *>(node)) {
+        scan(range_for->body.get());
+      } else if (auto *struct_for = dynamic_cast<StructForStmt *>(node)) {
+        scan(struct_for->body.get());
+      } else if (auto *mesh_for = dynamic_cast<MeshForStmt *>(node)) {
+        scan(mesh_for->body.get());
+      } else if (auto *while_stmt = dynamic_cast<WhileStmt *>(node)) {
+        scan(while_stmt->body.get());
+      }
+    };
+    scan(task_ir_->body.get());
+  }
+
   if (task_ir_->task_type == OffloadedTaskType::serial) {
     generate_serial_kernel(task_ir_);
   } else if (task_ir_->task_type == OffloadedTaskType::range_for) {
@@ -135,6 +182,9 @@ TaskCodegen::Result TaskCodegen::run() {
   // Headers need global information, so it has to be delayed after visiting
   // the task IR.
   emit_headers();
+
+  task_attribs_.ad_stack_heap_per_thread_stride_float = ad_stack_heap_per_thread_stride_float_;
+  task_attribs_.ad_stack_heap_per_thread_stride_int = ad_stack_heap_per_thread_stride_int_;
 
   Result res;
   res.spirv_code = ir_->finalize();
@@ -1811,6 +1861,63 @@ void TaskCodegen::generate_range_for_kernel(OffloadedStmt *stmt) {
     }
     total_elems = ir_->sub(end_expr_value, begin_expr_value);
     task_attribs_.advisory_total_num_threads = kMaxNumThreadsGridStrideLoop;
+
+    // Try to extract `end_stmt` as a product of ExternalTensorShapeAlongAxisStmt so the runtime can compute the
+    // actual iteration bound from the launch-time ndarray shapes and avoid dispatching `kMaxNumThreadsGridStrideLoop`
+    // threads. Handles `end_stmt` itself being one shape-lookup, a BinaryOpStmt(Mul, ...) tree of shape-lookups, or
+    // the same with ConstStmt(value=1) identity factors (Unit factors are common when `ndrange` has a batch dimension
+    // of 1). Anything else -> leave the list empty and the advisory fallback keeps current behavior.
+    if (stmt->end_stmt) {
+      std::vector<TaskAttributes::RangeForAttributes::ArgShapeRef> refs;
+      std::function<bool(Stmt *)> walk = [&](Stmt *s) -> bool {
+        if (!s)
+          return false;
+        if (auto *shape = s->cast<ExternalTensorShapeAlongAxisStmt>()) {
+          TaskAttributes::RangeForAttributes::ArgShapeRef ref;
+          ref.arg_id = shape->arg_id;
+          ref.axis = shape->axis;
+          refs.push_back(std::move(ref));
+          return true;
+        }
+        if (auto *c = s->cast<ConstStmt>()) {
+          return c->val.val_int32() == 1;  // identity factor only
+        }
+        if (auto *binop = s->cast<BinaryOpStmt>()) {
+          // Mul distributes: cap is the product of children, each of which must itself reduce to a shape.
+          if (binop->op_type == BinaryOpType::mul) {
+            return walk(binop->lhs) && walk(binop->rhs);
+          }
+          // `qd.ndrange` wraps each axis in `max(X, 1)` to guarantee a positive iteration count even when
+          // the shape is zero. For capping purposes `max(X, 1)` is safe to approximate as just X: when X >= 1
+          // the max is X (exact), and when X == 0 the max is 1 (we overcap by one thread, which still
+          // dispatches a single-iteration kernel rather than 131072 idle threads). So if one operand is a
+          // ConstStmt(value=1), walk the other and accept.
+          if (binop->op_type == BinaryOpType::max) {
+            // `qd.ndrange` lowers each axis to `max(0, shape)` (and sometimes `max(1, shape)` on other code
+            // paths) to guarantee a non-negative iteration count - ndarray shapes are always >= 0, so
+            // max(0|1, X) == X on any input that actually reaches codegen. Treat either identity as
+            // pass-through so we can keep capping through the guard.
+            auto *lhs_const = binop->lhs->cast<ConstStmt>();
+            auto *rhs_const = binop->rhs->cast<ConstStmt>();
+            auto is_max_identity = [](ConstStmt *c) {
+              if (!c)
+                return false;
+              int v = c->val.val_int32();
+              return v == 0 || v == 1;
+            };
+            if (is_max_identity(lhs_const))
+              return walk(binop->rhs);
+            if (is_max_identity(rhs_const))
+              return walk(binop->lhs);
+          }
+          return false;
+        }
+        return false;
+      };
+      if (walk(stmt->end_stmt) && !refs.empty()) {
+        range_for_attribs.end_shape_product = std::move(refs);
+      }
+    }
   }
   task_attribs_.advisory_num_threads_per_group = stmt->block_dim;
   ir_->debug_name(spv::OpName, begin_expr_value, "begin_expr_value");
@@ -2189,40 +2296,166 @@ std::vector<BufferBind> TaskCodegen::get_buffer_binds() {
 }
 
 // --- AdStack (autodiff local-variable history stack) for SPIR-V ---
-// The stack is represented as three Function-scope variables per allocation:
-//   count_var  : u32              - number of entries currently on the stack
-//   primal_arr : Array<T, N>      - primal values
-//   adjoint_arr: Array<T, N>      - adjoint (gradient) values
-// This mirrors the LLVM runtime stack (runtime.cpp:1889-1912) but is fully inlined.
+// Primal and adjoint history lives in two per-dispatch StorageBuffers: one of Array<f32> bound as
+// BufferType::AdStackHeapFloat (for f32-valued adstacks) and one of Array<i32> bound as BufferType::AdStackHeapInt
+// (for i32 and u1 adstacks; u1 is stored as i32 because OpTypeBool has no defined storage layout and
+// `get_array_type` already applies the same bool->int remap on the Function-scope path). Each SPIR-V invocation
+// owns a contiguous slice sized at `ad_stack_heap_per_thread_stride_*` elements of the respective type; within
+// that slice, each adstack holds `max_size` primals followed by `max_size` adjoints. The runtime reads
+// `task_attribs.ad_stack_heap_per_thread_stride_(float|int)` and multiplies by the dispatched invocation count
+// to size each buffer at launch. `count_var` stays in Function-scope because it is just one u32 per adstack and
+// is hot on every push/pop, so keeping it on-chip avoids a device-memory round-trip per push.
+//
+// Heap storage is required on Metal/MoltenVK because the per-thread shader private-memory budget (a few dozen
+// KB per invocation) is too small for deeply nested reverse-mode kernels. A kernel that declares on the order
+// of 100+ u1/i32 adstack slots at default capacity 256 easily exceeds that budget (e.g. ~130 KB per thread),
+// so all such adstacks must live in device memory, not on-chip.
+//
+// Other primitive types (f64, i64, ...) are rejected outright by `visit(AdStackAllocaStmt)`. Add dedicated
+// f64/i64 heap buffers if support for those element types becomes necessary.
 
-spirv::Value TaskCodegen::ad_stack_access(spirv::Value arr, spirv::Value index, const spirv::SType &elem_type) {
-  spirv::SType ptr_type = ir_->get_pointer_type(elem_type, spv::StorageClassFunction);
-  spirv::Value ret = ir_->make_value(spv::OpAccessChain, ptr_type, arr, index);
-  ret.flag = spirv::ValueKind::kVariablePtr;
-  return ret;
+spirv::Value TaskCodegen::get_ad_stack_heap_buffer_float() {
+  if (ad_stack_heap_buffer_float_.id == 0) {
+    ad_stack_heap_buffer_float_ = get_buffer_value({BufferType::AdStackHeapFloat}, PrimitiveType::f32);
+  }
+  return ad_stack_heap_buffer_float_;
+}
+
+spirv::Value TaskCodegen::get_ad_stack_heap_thread_base_float() {
+  if (ad_stack_heap_thread_base_float_.id == 0) {
+    // invocation_id * per_thread_stride. Emitted at the first AdStackAllocaStmt visit site (which precedes every
+    // Push/Pop/LoadTop in IR order and lives in the dispatch body that dominates all inner loop bodies); the
+    // stride is final by then because the pre-codegen scan phase above set it. Intentionally NOT emitted lazily
+    // from the first Push/LoadTop: that would land the OpIMul inside one sibling inner loop body and later
+    // sibling loops would reuse the cached SSA id from a block that does not dominate them, violating SPIR-V
+    // §2.16. Widened to u64 when the device has Int64: `invoc_id` can reach ~131K and deep-AD kernels push
+    // `stride` to ~33K, so a u32 OpIMul can wrap silently past 2^32 and alias threads into one another's heap
+    // slice (corrupting gradients with no exception); OpUConvert+OpIMul in u64 keeps the arithmetic exact. On
+    // Int64-less devices we stay in u32 - the runtime (launch_kernel) asserts
+    // `stride * dispatched_threads <= UINT32_MAX` in that case so silent wrap still cannot occur.
+    spirv::Value invoc_id = ir_->get_global_invocation_id(0);
+    if (caps_->get(DeviceCapability::spirv_has_int64)) {
+      // `make_value(OpUConvert, ...)` directly rather than `ir_->cast()`: `cast()` between two unsigned integer
+      // types of different widths emits `OpUConvert` followed by `OpBitcast` to `dst_type`, and with widening
+      // u32->u64 both sides are already unsigned, so the trailing `OpBitcast(u64, u64)` has identical operand
+      // and result types - which SPIR-V §3.42.16 forbids ("Result Type must be different from the type of
+      // Operand"). `spirv-val` rejects the shader and MoltenVK may silently refuse to compile it.
+      spirv::Value invoc_id_u64 = ir_->make_value(spv::OpUConvert, ir_->u64_type(), invoc_id);
+      spirv::Value stride = ir_->uint_immediate_number(ir_->u64_type(), ad_stack_heap_per_thread_stride_float_);
+      ad_stack_heap_thread_base_float_ = ir_->mul(invoc_id_u64, stride);
+    } else {
+      spirv::Value stride = ir_->uint_immediate_number(ir_->u32_type(), ad_stack_heap_per_thread_stride_float_);
+      ad_stack_heap_thread_base_float_ = ir_->mul(invoc_id, stride);
+    }
+  }
+  return ad_stack_heap_thread_base_float_;
+}
+
+spirv::Value TaskCodegen::ad_stack_heap_float_ptr(uint32_t offset, spirv::Value count) {
+  spirv::Value base = get_ad_stack_heap_thread_base_float();
+  spirv::SType idx_type = caps_->get(DeviceCapability::spirv_has_int64) ? ir_->u64_type() : ir_->u32_type();
+  spirv::Value offset_val = ir_->uint_immediate_number(idx_type, offset);
+  // See `get_ad_stack_heap_thread_base_float` for why we widen with `OpUConvert` directly instead of `cast()`.
+  spirv::Value count_idx =
+      caps_->get(DeviceCapability::spirv_has_int64) ? ir_->make_value(spv::OpUConvert, idx_type, count) : count;
+  spirv::Value heap_index = ir_->add(ir_->add(base, offset_val), count_idx);
+  return ir_->struct_array_access(ir_->f32_type(), get_ad_stack_heap_buffer_float(), heap_index);
+}
+
+spirv::Value TaskCodegen::get_ad_stack_heap_buffer_int() {
+  if (ad_stack_heap_buffer_int_.id == 0) {
+    ad_stack_heap_buffer_int_ = get_buffer_value({BufferType::AdStackHeapInt}, PrimitiveType::i32);
+  }
+  return ad_stack_heap_buffer_int_;
+}
+
+spirv::Value TaskCodegen::get_ad_stack_heap_thread_base_int() {
+  // See the float counterpart above for why this fires from the alloca site rather than lazily from the first
+  // Push/LoadTop, and why the multiply is widened to u64 when Int64 is available.
+  if (ad_stack_heap_thread_base_int_.id == 0) {
+    spirv::Value invoc_id = ir_->get_global_invocation_id(0);
+    if (caps_->get(DeviceCapability::spirv_has_int64)) {
+      // See the float counterpart above for why we use `make_value(OpUConvert, ...)` rather than `ir_->cast()`.
+      spirv::Value invoc_id_u64 = ir_->make_value(spv::OpUConvert, ir_->u64_type(), invoc_id);
+      spirv::Value stride = ir_->uint_immediate_number(ir_->u64_type(), ad_stack_heap_per_thread_stride_int_);
+      ad_stack_heap_thread_base_int_ = ir_->mul(invoc_id_u64, stride);
+    } else {
+      spirv::Value stride = ir_->uint_immediate_number(ir_->u32_type(), ad_stack_heap_per_thread_stride_int_);
+      ad_stack_heap_thread_base_int_ = ir_->mul(invoc_id, stride);
+    }
+  }
+  return ad_stack_heap_thread_base_int_;
+}
+
+spirv::Value TaskCodegen::ad_stack_heap_int_ptr(uint32_t offset, spirv::Value count) {
+  spirv::Value base = get_ad_stack_heap_thread_base_int();
+  spirv::SType idx_type = caps_->get(DeviceCapability::spirv_has_int64) ? ir_->u64_type() : ir_->u32_type();
+  spirv::Value offset_val = ir_->uint_immediate_number(idx_type, offset);
+  spirv::Value count_idx =
+      caps_->get(DeviceCapability::spirv_has_int64) ? ir_->make_value(spv::OpUConvert, idx_type, count) : count;
+  spirv::Value heap_index = ir_->add(ir_->add(base, offset_val), count_idx);
+  return ir_->struct_array_access(ir_->i32_type(), get_ad_stack_heap_buffer_int(), heap_index);
 }
 
 void TaskCodegen::visit(AdStackAllocaStmt *stmt) {
   QD_ASSERT_INFO(stmt->max_size > 0, "Adaptive autodiff stack's size should have been determined.");
-  spirv::SType elem_type = ir_->get_primitive_type(stmt->ret_type);
-  // `IRBuilder::get_array_type` silently promotes a u1 value_type to i32 because OpTypeBool has no defined
-  // storage layout under SPIR-V's LogicalAddressing model. Mirror that promotion in the storage-facing SType
-  // we keep in `AdStackSpirv` so the OpAccessChain/store/load triplet emitted by push/load/acc uses the same
-  // element type as the declared OpTypeArray; otherwise spirv-val rejects the shader and AMD's native Vulkan
-  // driver runs it and segfaults the dispatch. Push/LoadTop then casts between `elem_type` (bool) and
-  // `storage_type` (i32) around the user-visible value, matching what the heap-backed path does in #493.
-  spirv::SType storage_type = stmt->ret_type->is_primitive(PrimitiveTypeID::u1) ? ir_->i32_type() : elem_type;
-  spirv::SType arr_type = ir_->get_array_type(storage_type, stmt->max_size);
 
   AdStackSpirv info;
-  info.elem_type = elem_type;
-  info.storage_type = storage_type;
+  info.elem_type = ir_->get_primitive_type(stmt->ret_type);
   info.max_size = stmt->max_size;
   info.count_var = ir_->alloca_variable(ir_->u32_type());
-  info.primal_arr = ir_->alloca_variable(arr_type);
-  info.adjoint_arr = ir_->alloca_variable(arr_type);
   ir_->store_variable(info.count_var, ir_->uint_immediate_number(ir_->u32_type(), 0));
+  // f32 adstacks go on the f32 heap; i32 and u1 adstacks share the int heap. 64-bit primitives (f64, i64, u64)
+  // are deliberately rejected here rather than falling back to Function-scope: the Function-scope path has been
+  // shown unusable for real reverse-mode kernels (private-memory blowup on Metal/MoltenVK) so silently taking it
+  // would paper over a correctness/perf cliff. If support is ever needed, add dedicated f64/i64 heap buffers
+  // alongside the float/int ones - not a Function-scope fallback.
+  if (stmt->ret_type == PrimitiveType::f32) {
+    info.heap_kind = AdStackHeapKind::heap_float;
+    info.heap_primal_offset = ad_stack_heap_next_offset_float_;
+    info.heap_adjoint_offset = info.heap_primal_offset + stmt->max_size;
+    ad_stack_heap_next_offset_float_ += 2u * uint32_t(stmt->max_size);
+    // Force `invoc_id * stride` to be emitted here (the alloca site), not lazily at the first Push/LoadTop -
+    // see `get_ad_stack_heap_thread_base_float()` for the dominance rationale.
+    get_ad_stack_heap_thread_base_float();
+  } else if (stmt->ret_type == PrimitiveType::i32 || stmt->ret_type == PrimitiveType::u1) {
+    info.heap_kind = AdStackHeapKind::heap_int;
+    info.heap_primal_offset = ad_stack_heap_next_offset_int_;
+    // No adjoint slot: see the matching comment in the scan phase above.
+    info.heap_adjoint_offset = 0;
+    ad_stack_heap_next_offset_int_ += uint32_t(stmt->max_size);
+    // Same eager emission for the int heap base as the float branch above.
+    get_ad_stack_heap_thread_base_int();
+  } else {
+    QD_ERROR(
+        "Reverse-mode AD on the SPIR-V backend supports only f32, i32, and u1 loop-carried variables. Got {} - "
+        "cast to qd.f32 or qd.i32 in the differentiable section.",
+        stmt->ret_type.to_string());
+  }
   ad_stacks_[stmt] = info;
+}
+
+// Resolve the primal- or adjoint-slot pointer for `info` at index `idx`. The returned pointer is typed after the
+// adstack's backing storage (f32 for heap_float, i32 for heap_int) - which is the same as `info.elem_type` except
+// for u1 adstacks on the int heap, where backing is i32. Callers must explicitly convert between u1 and i32 via
+// `ir_->cast(...)` at store/load sites in that single special case. `primal=true` selects the primal half of the
+// slice, `false` selects the adjoint half.
+spirv::Value TaskCodegen::ad_stack_slot_ptr(AdStackSpirv &info, spirv::Value idx, bool primal) {
+  const uint32_t offset = primal ? info.heap_primal_offset : info.heap_adjoint_offset;
+  if (info.heap_kind == AdStackHeapKind::heap_float) {
+    return ad_stack_heap_float_ptr(offset, idx);
+  }
+  QD_ASSERT(info.heap_kind == AdStackHeapKind::heap_int);
+  return ad_stack_heap_int_ptr(offset, idx);
+}
+
+// Returns the SType used for the underlying store/load on `info`'s backing storage. Matches `info.elem_type`
+// except for u1 on the int heap, which is stored as i32 (and converted at the push/load sites).
+spirv::SType TaskCodegen::ad_stack_backing_type(const AdStackSpirv &info) const {
+  if (info.heap_kind == AdStackHeapKind::heap_int && info.elem_type.dt->is_primitive(PrimitiveTypeID::u1)) {
+    return ir_->i32_type();
+  }
+  return info.elem_type;
 }
 
 void TaskCodegen::visit(AdStackPushStmt *stmt) {
@@ -2230,9 +2463,9 @@ void TaskCodegen::visit(AdStackPushStmt *stmt) {
   spirv::Value count = ir_->load_variable(info.count_var, ir_->u32_type());
 
   // Guard the primal/adjoint store and the count increment with an in-range check. Without it, a loop that pushes
-  // more than `max_size` elements would write past the end of the Function-scope arrays, with backend-defined
-  // behavior (silent corruption on Metal / Vulkan). On overflow the else branch flips the host-readable overflow
-  // flag so the runtime can surface it as a Python exception after the dispatch; the in-kernel no-op still matters
+  // more than `max_size` elements would write past the end of the backing storage, with backend-defined behavior
+  // (silent corruption on Metal / Vulkan). On overflow the else branch flips the host-readable overflow flag so
+  // the runtime can surface it as a Python exception after the dispatch; the in-kernel no-op still matters
   // because we want to avoid the OOB write regardless of whether the host ends up raising on this launch.
   spirv::Value max_val = ir_->uint_immediate_number(ir_->u32_type(), stmt->stack->as<AdStackAllocaStmt>()->max_size);
   spirv::Value in_range = ir_->lt(count, max_val);
@@ -2243,15 +2476,18 @@ void TaskCodegen::visit(AdStackPushStmt *stmt) {
   ir_->make_inst(spv::OpBranchConditional, in_range, then_label, else_label);
   ir_->start_label(then_label);
 
-  // primal_arr[count] = v; adjoint_arr[count] = 0;
+  // primal_arr[count] = v;  (adjoint_arr[count] = 0 too, except for heap_int: see AllocaStmt visitor.)
+  spirv::SType backing_type = ad_stack_backing_type(info);
   spirv::Value val = ir_->query_value(stmt->v->raw_name());
-  if (info.elem_type.id != info.storage_type.id) {
-    val = ir_->cast(info.storage_type, val);  // u1 -> i32
+  if (info.elem_type.id != backing_type.id) {
+    val = ir_->cast(backing_type, val);  // u1 -> i32 for the heap_int path
   }
-  spirv::Value primal_ptr = ad_stack_access(info.primal_arr, count, info.storage_type);
+  spirv::Value primal_ptr = ad_stack_slot_ptr(info, count, /*primal=*/true);
   ir_->store_variable(primal_ptr, val);
-  spirv::Value adjoint_ptr = ad_stack_access(info.adjoint_arr, count, info.storage_type);
-  ir_->store_variable(adjoint_ptr, ir_->get_zero(info.storage_type));
+  if (info.heap_kind != AdStackHeapKind::heap_int) {
+    spirv::Value adjoint_ptr = ad_stack_slot_ptr(info, count, /*primal=*/false);
+    ir_->store_variable(adjoint_ptr, ir_->get_zero(backing_type));
+  }
 
   // count++
   spirv::Value one = ir_->uint_immediate_number(ir_->u32_type(), 1);
@@ -2299,14 +2535,13 @@ static spirv::Value ad_stack_top_index(spirv::IRBuilder *ir, spirv::Value count,
 
 void TaskCodegen::visit(AdStackLoadTopStmt *stmt) {
   // `return_ptr == true` is emitted by ReplaceLocalVarWithStacks::visit(MatrixPtrStmt) when a TensorType
-  // loop-carried variable takes a per-element address, and the caller (downstream MatrixPtrStmt codegen) treats
-  // the returned value as a base pointer for OpAccessChain. Scalarize-with-real_matrix_scalarize is expected to
-  // have replaced those before SPIR-V codegen sees them (by lowering TensorType adstacks to N scalar adstacks +
-  // MatrixInit), so we never actually hit this path in practice. But if a tensor-typed AdStackLoadTopStmt slips
-  // through scalarize (e.g. real_matrix_scalarize disabled, or a future change misses the node type), the old
-  // `QD_ASSERT(!stmt->return_ptr)` silently no-ops in release builds and the scalar-load fallthrough registers
-  // an integer where a pointer is expected - silent wrong gradients or a GPU TDR (PR #490 review). Fail loudly
-  // in both debug and release instead.
+  // loop-carried variable takes a per-element address; the downstream MatrixPtrStmt codegen treats the returned
+  // value as a base pointer for OpAccessChain. This path is not implemented here: scalarize with
+  // `real_matrix_scalarize=True` (the default) is expected to lower every TensorType adstack to N scalar
+  // adstacks + MatrixInit before SPIR-V codegen runs, so no such node reaches this visitor in practice.
+  // Raising a targeted error guarantees we surface a clear message if that invariant ever breaks (e.g.
+  // `real_matrix_scalarize=False`, or a future scalarize change misses the node type), rather than letting the
+  // scalar-load fallthrough register an integer where downstream MatrixPtrStmt expects a pointer.
   QD_ERROR_IF(stmt->return_ptr,
               "SPIR-V codegen does not yet support AdStackLoadTopStmt with return_ptr=true (tensor-typed "
               "loop-carried variable). Ensure scalarize is enabled (real_matrix_scalarize=True) so matrix/vector "
@@ -2314,33 +2549,43 @@ void TaskCodegen::visit(AdStackLoadTopStmt *stmt) {
   auto &info = ad_stacks_.at(stmt->stack);
   spirv::Value count = ir_->load_variable(info.count_var, ir_->u32_type());
   spirv::Value idx = ad_stack_top_index(ir_.get(), count, info.max_size);
-  spirv::Value ptr = ad_stack_access(info.primal_arr, idx, info.storage_type);
-  spirv::Value val = ir_->load_variable(ptr, info.storage_type);
-  if (info.elem_type.id != info.storage_type.id) {
-    val = ir_->cast(info.elem_type, val);  // i32 -> u1
+  spirv::Value ptr = ad_stack_slot_ptr(info, idx, /*primal=*/true);
+  spirv::SType backing_type = ad_stack_backing_type(info);
+  spirv::Value loaded = ir_->load_variable(ptr, backing_type);
+  if (info.elem_type.id != backing_type.id) {
+    loaded = ir_->cast(info.elem_type, loaded);  // i32 -> u1 for the heap_int path
   }
-  ir_->register_value(stmt->raw_name(), val);
+  ir_->register_value(stmt->raw_name(), loaded);
 }
 
 void TaskCodegen::visit(AdStackLoadTopAdjStmt *stmt) {
-  // Adjoint slots only fire for real-typed primals (`is_real` guard in MakeAdjoint::accumulate), so the u1/i32
-  // cast dance the primal path needs never triggers here - `elem_type` and `storage_type` are always equal.
   auto &info = ad_stacks_.at(stmt->stack);
+  // The auto_diff pass gates AdStackLoadTopAdjStmt/AdStackAccAdjointStmt emission on `is_real` (auto_diff.cpp),
+  // so these visitors should never fire on an int-heap-backed stack. If they do, the int heap lacks an adjoint
+  // slice and any load would alias the next stack's primal slice - fail loudly instead.
+  QD_ASSERT_INFO(info.heap_kind != AdStackHeapKind::heap_int,
+                 "AdStackLoadTopAdj on a non-real adstack; autodiff should have suppressed this.");
+  // No elem_type<->backing_type cast here: the primal visitors need it only for the u1 (elem) -> i32 (backing)
+  // promotion on the int heap, which this assert excludes. For heap_float the backing type is `info.elem_type`
+  // unconditionally, so any cast would be a no-op.
   spirv::Value count = ir_->load_variable(info.count_var, ir_->u32_type());
   spirv::Value idx = ad_stack_top_index(ir_.get(), count, info.max_size);
-  spirv::Value ptr = ad_stack_access(info.adjoint_arr, idx, info.storage_type);
-  ir_->register_value(stmt->raw_name(), ir_->load_variable(ptr, info.storage_type));
+  spirv::Value ptr = ad_stack_slot_ptr(info, idx, /*primal=*/false);
+  spirv::Value loaded = ir_->load_variable(ptr, info.elem_type);
+  ir_->register_value(stmt->raw_name(), loaded);
 }
 
 void TaskCodegen::visit(AdStackAccAdjointStmt *stmt) {
-  // Adjoint accumulation is only emitted for real-typed primals (`is_real` guard in MakeAdjoint::accumulate),
-  // so u1 adstacks never reach here and `elem_type == storage_type`.
   auto &info = ad_stacks_.at(stmt->stack);
+  QD_ASSERT_INFO(info.heap_kind != AdStackHeapKind::heap_int,
+                 "AdStackAccAdjoint on a non-real adstack; autodiff should have suppressed this.");
+  // See the note in `AdStackLoadTopAdjStmt`: no cast is needed because heap_int is excluded by the assert above.
   spirv::Value count = ir_->load_variable(info.count_var, ir_->u32_type());
   spirv::Value idx = ad_stack_top_index(ir_.get(), count, info.max_size);
-  spirv::Value ptr = ad_stack_access(info.adjoint_arr, idx, info.storage_type);
-  spirv::Value old_val = ir_->load_variable(ptr, info.storage_type);
-  spirv::Value new_val = ir_->add(old_val, ir_->query_value(stmt->v->raw_name()));
+  spirv::Value ptr = ad_stack_slot_ptr(info, idx, /*primal=*/false);
+  spirv::Value old_val = ir_->load_variable(ptr, info.elem_type);
+  spirv::Value incr = ir_->query_value(stmt->v->raw_name());
+  spirv::Value new_val = ir_->add(old_val, incr);
   ir_->store_variable(ptr, new_val);
 }
 

--- a/quadrants/program/compile_config.h
+++ b/quadrants/program/compile_config.h
@@ -53,13 +53,14 @@ struct CompileConfig {
   int gpu_max_reg;
   bool ad_stack_experimental_enabled{false};
   int ad_stack_size{0};  // 0 = adaptive
-  // Fallback adstack capacity used when the Quadrants compiler cannot statically determine the worst-case loop trip
-  // count. LLVM now heap-backs the primal/adjoint slots via a per-runtime slab sized
-  // `num_threads * per_thread_stride` by `LlvmRuntimeExecutor::ensure_adstack_heap` before each dispatch, so the
-  // per-thread worker-stack budget that bounded the previous Function-scope implementation no longer applies on
-  // CPU / CUDA / AMDGPU. SPIR-V still allocates per-thread Function-scope arrays at this stage, so the default
-  // stays small for now (the heap-backing on Metal / Vulkan that lifts this constraint lands in a follow-up PR).
-  int default_ad_stack_size{32};
+  // Fallback adstack capacity used when the Quadrants compiler cannot statically determine the worst-case loop
+  // trip count. Both backends now heap-back the primal / adjoint slots: SPIR-V via per-dispatch StorageBuffers
+  // (`BufferType::AdStackHeapFloat` + `AdStackHeapInt`, sliced by invocation), LLVM via a per-runtime slab sized
+  // `num_threads * per_thread_stride` by `LlvmRuntimeExecutor::ensure_adstack_heap` before each dispatch. The
+  // per-thread on-chip / worker-stack budget that bounded the previous Function-scope implementation no longer
+  // applies, so the default is raised from 32 to 256 to cover the flat trip count of a typical `qd.ndrange` over
+  // two 16-wide dimensions. Runtime push overflow is surfaced as a Python exception.
+  int default_ad_stack_size{256};
 
   int saturating_grid_dim;
   int max_block_dim;

--- a/quadrants/rhi/metal/metal_device.mm
+++ b/quadrants/rhi/metal/metal_device.mm
@@ -1234,6 +1234,23 @@ RhiResult MetalDevice::allocate_memory(const AllocParams &params,
   MTLBuffer_id buffer = [mtl_device_ newBufferWithLength:params.size
                                                  options:resource_options];
 
+  // `newBufferWithLength:` returns nil on allocation failure (most commonly
+  // when `params.size` exceeds `mtl_device_.maxBufferLength`, which on Apple
+  // Silicon is ~75% of unified memory). Without this check we would wrap nil in
+  // `MetalMemory` and return `RhiResult::success`, and every subsequent
+  // `bindings->rw_buffer(...)` call would `setBuffer:nil` on the Metal encoder
+  // - shader writes drop silently and reads come back as zero, producing NaNs
+  // through divide-by-zero in reverse-mode AD kernels (e.g. `.normalized()`'s
+  // sqrt adjoint reloading a primal that was never actually written).
+  if (buffer == nil) {
+    std::string msg =
+        "Metal newBufferWithLength:" + std::to_string(params.size) +
+        " returned nil (maxBufferLength=" +
+        std::to_string(uint64_t([mtl_device_ maxBufferLength])) + ")";
+    RHI_LOG_ERROR(msg);
+    return RhiResult::out_of_memory;
+  }
+
   MetalMemory &alloc = memory_allocs_.acquire(buffer, can_map);
 
   *out_devalloc = DeviceAllocation{};

--- a/quadrants/runtime/gfx/runtime.cpp
+++ b/quadrants/runtime/gfx/runtime.cpp
@@ -1,5 +1,7 @@
 #include "quadrants/runtime/gfx/runtime.h"
 #include "quadrants/program/program.h"
+#include "quadrants/program/launch_context_builder.h"
+#include "quadrants/ir/type_factory.h"
 #include "quadrants/common/filesystem.hpp"
 
 // FIXME: (penguinliong) Special offer for `run_codegen`. Find a new home for it
@@ -9,6 +11,7 @@
 #include <chrono>
 #include <array>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -510,7 +513,33 @@ void GfxRuntime::launch_kernel(KernelHandle handle, LaunchContextBuilder &host_c
   for (int i = 0; i < task_attribs.size(); ++i) {
     const auto &attribs = task_attribs[i];
     auto vp = ti_kernel->get_pipeline(i);
-    const int group_x = (attribs.advisory_total_num_threads + attribs.advisory_num_threads_per_group - 1) /
+
+    // Cap `advisory_total_num_threads` to the ACTUAL iteration count when the codegen was able to extract the range
+    // end as a product of ndarray-shape lookups (see `RangeForAttributes::end_shape_product`). Without this cap, a
+    // grad kernel whose range is runtime-determined (`const_end = false`) inherits `kMaxNumThreadsGridStrideLoop =
+    // 131072` from the codegen fallback, and the adstack-heap sizing below multiplies that by the per-thread stride
+    // to request (e.g.) 48 GB for a 1-iteration B=1 workload - exceeding Metal's `maxBufferLength` and producing a
+    // hard RHI error. The in-shader grid-stride loop handles any dispatched thread count >= 1 correctly; a tight cap
+    // just means each dispatched thread processes fewer strides of idle work.
+    int effective_advisory_threads = attribs.advisory_total_num_threads;
+    if (attribs.range_for_attribs && !attribs.range_for_attribs->end_shape_product.empty()) {
+      const auto &range = *attribs.range_for_attribs;
+      // `const_begin` is asserted true at codegen whenever `end_stmt` is populated (see the
+      // `QD_ASSERT(stmt->const_begin)` in the `if (stmt->end_stmt)` branch of spirv_codegen.cpp,
+      // near line 1833 at time of writing), so `range.begin` is the literal begin value, not a
+      // gtmp offset.
+      int64_t iter_end = 1;
+      for (const auto &ref : range.end_shape_product) {
+        std::vector<int> indices = ref.arg_id;
+        indices.push_back(TypeFactory::SHAPE_POS_IN_NDARRAY);
+        indices.push_back(ref.axis);
+        iter_end *= int64_t(host_ctx.get_struct_arg<int32_t>(indices));
+      }
+      int64_t iter_count = std::max<int64_t>(0, iter_end - int64_t(range.begin));
+      effective_advisory_threads =
+          int(std::min<int64_t>(int64_t(effective_advisory_threads), std::max<int64_t>(1, iter_count)));
+    }
+    const int group_x = (effective_advisory_threads + attribs.advisory_num_threads_per_group - 1) /
                         attribs.advisory_num_threads_per_group;
     std::unique_ptr<ShaderResourceSet> bindings = device_->create_resource_set_unique();
     for (auto &bind : attribs.buffer_binds) {
@@ -533,6 +562,95 @@ void GfxRuntime::launch_kernel(KernelHandle handle, LaunchContextBuilder &host_c
           current_cmdlist_->buffer_barrier(*adstack_overflow_buffer_);
         }
         bindings->rw_buffer(bind.binding, *adstack_overflow_buffer_);
+      } else if (bind.buffer.type == BufferType::AdStackHeapFloat) {
+        // SPIR-V adstack primal/adjoint storage for f32 adstacks. Sized for the actual dispatched thread count
+        // (`group_x * block_dim`, which rounds `advisory_total_num_threads` up to a workgroup multiple) rather
+        // than the advisory so threads past the advisory - which still own an `invoc_id * stride` slice - stay
+        // in-bounds even if they ever reach a push/pop. Grown on demand and reused across launches; contents do
+        // not need to persist across kernels. On empty fields (`dispatched_threads == 0`) no push/pop can
+        // actually execute, so bind a null allocation instead of asking the RHI for a zero-sized buffer (which
+        // trips `RHI_ASSERT(params.size > 0)` on Vulkan and fails similarly on Metal).
+        size_t dispatched_threads = size_t(group_x) * size_t(attribs.advisory_num_threads_per_group);
+        // The shader uses u64 index arithmetic for `invoc_id * stride + offset + count` when the device has
+        // Int64; without Int64 the shader falls back to u32 OpIMul, which silently wraps past 2^32 and aliases
+        // threads into one another's heap slice. Assert at launch time rather than emit silent corruption.
+        QD_ASSERT_INFO(device_->get_caps().get(DeviceCapability::spirv_has_int64) ||
+                           size_t(attribs.ad_stack_heap_per_thread_stride_float) * dispatched_threads <=
+                               std::numeric_limits<uint32_t>::max(),
+                       "adstack f32 heap offset would overflow u32 on a device without Int64: "
+                       "stride={} dispatched_threads={}",
+                       attribs.ad_stack_heap_per_thread_stride_float, dispatched_threads);
+        size_t required = size_t(attribs.ad_stack_heap_per_thread_stride_float) * dispatched_threads * sizeof(float);
+        if (required == 0) {
+          bindings->rw_buffer(bind.binding, kDeviceNullAllocation);
+        } else {
+          if (!adstack_heap_buffer_float_ || adstack_heap_buffer_float_size_ < required) {
+            // Amortized doubling: mirrors `LlvmRuntimeExecutor::ensure_adstack_heap`. Without it, a sequence of
+            // launches with monotonically increasing dispatch sizes (e.g. BFS / frontier expansion) between
+            // `synchronize()` calls would reallocate on every launch and leave every displaced buffer sitting in
+            // `ctx_buffers_` until the next sync, accumulating O(K^2 * N) bytes of live-but-unused GPU memory.
+            // Doubling bounds the reallocations at O(log K) and the live memory at O(K * N).
+            size_t new_size = std::max(required, 2 * adstack_heap_buffer_float_size_);
+            auto [buf, res] = device_->allocate_memory_unique(
+                {new_size, /*host_write=*/false, /*host_read=*/false, /*export_sharing=*/false, AllocUsage::Storage});
+            // Fallback when the amortized-doubling size overshoots a device limit (e.g. Metal's
+            // `maxBufferLength` capping `2 * old_size` even when `required` alone would fit): retry at exactly
+            // `required` bytes before aborting the process. Trade-off is losing amortization on the retry path;
+            // still correct because the next grow will reset amortization against the new, smaller base.
+            if (res != RhiResult::success && new_size > required) {
+              new_size = required;
+              std::tie(buf, res) = device_->allocate_memory_unique(
+                  {new_size, /*host_write=*/false, /*host_read=*/false, /*export_sharing=*/false, AllocUsage::Storage});
+            }
+            QD_ASSERT_INFO(res == RhiResult::success, "Failed to allocate adstack heap float buffer (size={})",
+                           new_size);
+            // Defer the old buffer's free until the current cmdlist is submitted and synced: the previous launch
+            // may still be in flight and referencing the old allocation, so freeing it synchronously here (via
+            // `DeviceAllocationGuard`'s destructor, which runs on the `std::move` reassignment below) would
+            // produce a GPU-side use-after-free. `ctx_buffers_` is cleared in `synchronize()` /
+            // `device_to_host(...)` after the stream has drained, which is exactly the lifetime we need.
+            if (adstack_heap_buffer_float_) {
+              ctx_buffers_.push_back(std::move(adstack_heap_buffer_float_));
+            }
+            adstack_heap_buffer_float_ = std::move(buf);
+            adstack_heap_buffer_float_size_ = new_size;
+          }
+          bindings->rw_buffer(bind.binding, *adstack_heap_buffer_float_);
+        }
+      } else if (bind.buffer.type == BufferType::AdStackHeapInt) {
+        // SPIR-V adstack primal/adjoint storage for i32 and u1 adstacks. Same grow-on-demand policy and same
+        // empty-dispatch guard as the float buffer above. Same u32-overflow guard as the float branch too.
+        size_t dispatched_threads = size_t(group_x) * size_t(attribs.advisory_num_threads_per_group);
+        QD_ASSERT_INFO(device_->get_caps().get(DeviceCapability::spirv_has_int64) ||
+                           size_t(attribs.ad_stack_heap_per_thread_stride_int) * dispatched_threads <=
+                               std::numeric_limits<uint32_t>::max(),
+                       "adstack i32/u1 heap offset would overflow u32 on a device without Int64: "
+                       "stride={} dispatched_threads={}",
+                       attribs.ad_stack_heap_per_thread_stride_int, dispatched_threads);
+        size_t required = size_t(attribs.ad_stack_heap_per_thread_stride_int) * dispatched_threads * sizeof(int32_t);
+        if (required == 0) {
+          bindings->rw_buffer(bind.binding, kDeviceNullAllocation);
+        } else {
+          if (!adstack_heap_buffer_int_ || adstack_heap_buffer_int_size_ < required) {
+            // Same amortized-doubling rationale as the float heap above.
+            size_t new_size = std::max(required, 2 * adstack_heap_buffer_int_size_);
+            auto [buf, res] = device_->allocate_memory_unique(
+                {new_size, /*host_write=*/false, /*host_read=*/false, /*export_sharing=*/false, AllocUsage::Storage});
+            // Same amortized-doubling overshoot fallback as the float heap above (Metal `maxBufferLength`).
+            if (res != RhiResult::success && new_size > required) {
+              new_size = required;
+              std::tie(buf, res) = device_->allocate_memory_unique(
+                  {new_size, /*host_write=*/false, /*host_read=*/false, /*export_sharing=*/false, AllocUsage::Storage});
+            }
+            QD_ASSERT_INFO(res == RhiResult::success, "Failed to allocate adstack heap int buffer (size={})", new_size);
+            if (adstack_heap_buffer_int_) {
+              ctx_buffers_.push_back(std::move(adstack_heap_buffer_int_));
+            }
+            adstack_heap_buffer_int_ = std::move(buf);
+            adstack_heap_buffer_int_size_ = new_size;
+          }
+          bindings->rw_buffer(bind.binding, *adstack_heap_buffer_int_);
+        }
       } else if (bind.buffer.type == BufferType::Args) {
         bindings->buffer(bind.binding, args_buffer ? *args_buffer : kDeviceNullAllocation);
       } else if (bind.buffer.type == BufferType::Rets) {
@@ -636,8 +754,8 @@ void GfxRuntime::synchronize() {
     device_->unmap(*adstack_overflow_buffer_);
     QD_ERROR_IF(flag_val != 0,
                 "Adstack overflow: a reverse-mode autodiff kernel pushed more elements than the adstack capacity "
-                "allows. Raised at the next qd.sync() rather than at the offending kernel launch. Pass "
-                "ad_stack_size=N to qd.init() to raise the capacity.");
+                "allows. Raised at the next qd.sync() rather than at the offending kernel launch. Pass a larger "
+                "`default_ad_stack_size=N` to `qd.init()` to raise the capacity. See documentation for details.");
   }
   fflush(stdout);
 }
@@ -648,9 +766,9 @@ StreamSemaphore GfxRuntime::flush() {
     sema = device_->get_compute_stream()->submit(current_cmdlist_.get());
     current_cmdlist_ = nullptr;
     // Do NOT clear ctx_buffers_ here: submit() returns as soon as the cmdlist is queued, not when the GPU has
-    // finished executing. Any deferred-free buffer queued into `ctx_buffers_` may still be referenced by
-    // commands in flight; dropping the unique_ptrs here would be a GPU-side use-after-free. Only
-    // `synchronize()` clears the vector, after `wait_idle()` has drained the stream.
+    // finished executing. The deferred-free buffers in ctx_buffers_ (e.g. the old adstack heap buffer left over
+    // after a grow-on-demand resize) may still be referenced by commands in flight. Only `synchronize()` clears
+    // the vector, after `wait_idle()` has drained the stream.
   } else {
     auto [cmdlist, res] = device_->get_compute_stream()->new_command_list_unique();
     QD_ASSERT(res == RhiResult::success);

--- a/quadrants/runtime/gfx/runtime.h
+++ b/quadrants/runtime/gfx/runtime.h
@@ -164,6 +164,18 @@ class QD_DLL_EXPORT GfxRuntime {
   // zeros it for the next window.
   std::unique_ptr<DeviceAllocationGuard> adstack_overflow_buffer_;
 
+  // Per-dispatch heaps for SPIR-V adstack primal/adjoint storage. The float heap backs f32-valued adstacks; the
+  // int heap backs i32 and u1 adstacks (u1 stored as i32 to match the historical Function-scope path's bool->int
+  // remap). Other primitive types (f64, i64, ...) are hard-errored in the shader codegen (no fallback). Each heap
+  // is sized at `stride * (group_x * block_dim) * sizeof(element)` and grown lazily; reused across launches
+  // whenever the current allocation is already big enough. On grow, the previous buffer is moved into
+  // `ctx_buffers_` rather than freed synchronously, so any in-flight cmdlist still referencing it stays valid
+  // until the stream drains.
+  std::unique_ptr<DeviceAllocationGuard> adstack_heap_buffer_float_;
+  size_t adstack_heap_buffer_float_size_{0};
+  std::unique_ptr<DeviceAllocationGuard> adstack_heap_buffer_int_;
+  size_t adstack_heap_buffer_int_size_{0};
+
   // Set by the destructor before its own `synchronize()` call so the adstack-overflow poll in `synchronize()`
   // short-circuits instead of raising from an implicitly-noexcept `~GfxRuntime()` unwinding path (a throw
   // there would call `std::terminate()` and crash the process; the user-visible raise should happen at the

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -441,23 +441,18 @@ def test_adstack_basic_gradient_negative(n_iter):
 
 
 @test_utils.test(
-    arch=qd.metal,
     require=qd.extension.adstack,
-    ad_stack_size=65536,
+    ad_stack_size=4096,
 )
-def test_adstack_shader_compile_failure_raises():
-    # Asks the compiler to build a Metal shader whose per-thread private-memory footprint is too large for Apple's
-    # shader translator to accept. The test asserts the kernel fails to build with a regular Python `RuntimeError`
-    # saying the pipeline couldn't be created, instead of silently launching a null pipeline (which would either
-    # crash the process or corrupt subsequent kernels).
+def test_adstack_large_capacity_heap_backed():
+    # Runs a backward pass with a deliberately huge (4096-slot) adstack and asserts the gradient comes out
+    # correctly. With the old Function-scope storage the shader compile would fail because the per-thread private
+    # memory footprint exceeded what Metal/MoltenVK accepts; with heap-backed storage the same kernel fits.
     #
-    # Internal detail: the oversized `ad_stack_size` combined with several independent loop-carried variables
-    # forces enough Function-scope private memory per thread that Apple's MSL translator rejects the pipeline
-    # with `XPC_ERROR_CONNECTION_INTERRUPTED` at create time. A single loop-carried variable is not enough - the
-    # Metal compiler is willing to spill a single oversized private array to device memory on its own and the
-    # pipeline still builds; four independent adstacks at the same capacity defeat the spill heuristic. The test
-    # is restricted to Metal because Vulkan drivers vary widely on what per-thread Function-scope footprint they
-    # will accept, so calibrating a single threshold that every CI Vulkan driver rejects is brittle.
+    # Internal detail: the per-thread slice now lives in an SSBO sliced by `invoc_id * stride` instead of an
+    # on-chip Array<f32, max_size>, so the per-thread shader footprint is O(1) regardless of `max_size`. Covers
+    # the happy path of the heap-backed storage: allocation, push/pop with `count_var` still Function-scope,
+    # LoadTop indexing into the slice, `AccAdjoint` back into the heap.
     x = qd.field(qd.f32)
     y = qd.field(qd.f32)
     qd.root.dense(qd.i, 1).place(x, x.grad)
@@ -466,31 +461,192 @@ def test_adstack_shader_compile_failure_raises():
     @qd.kernel
     def compute():
         for i in x:
-            a = x[i]
-            b = x[i]
-            c = x[i]
-            d = x[i]
-            for _ in range(10):
-                a = qd.sin(a)
-                b = qd.sin(b)
-                c = qd.sin(c)
-                d = qd.sin(d)
-            y[None] += a + b + c + d
+            v = x[i]
+            for _ in range(128):
+                y[None] += qd.sin(v)
+                v = v + 1.0
 
     x[0] = 0.1
     y[None] = 0.0
     compute()
     y.grad[None] = 1.0
     x.grad[0] = 0.0
-    with pytest.raises(RuntimeError, match=r"[Ff]ailed to create pipeline"):
+    compute.grad()
+
+    expected = sum(math.cos(0.1 + k) for k in range(128))
+    assert x.grad[0] == test_utils.approx(expected, rel=1e-3)
+
+
+@test_utils.test(require=qd.extension.adstack)
+def test_adstack_mixed_f32_and_non_f32():
+    # Runs a backward pass through a dynamic loop that carries both a float (`v`) and an integer counter (`j`), and
+    # asserts the gradient on the float comes out correctly. Mixing the two types in one kernel exercises both
+    # adstack storage paths at once.
+    #
+    # Internal detail: on SPIR-V, f32 adstacks live in BufferType::AdStackHeapFloat while i32/u1 adstacks share
+    # BufferType::AdStackHeapInt (u1 reinterpreted as i32 via `ir_->cast(...)` at push/load). A codegen regression
+    # in either path (e.g. pre-scan miscounting into the wrong stride, or the Push/Pop visitors routing to the
+    # wrong heap_kind) would surface as a wrong gradient.
+    x = qd.field(qd.f32)
+    y = qd.field(qd.f32)
+    qd.root.dense(qd.i, 1).place(x, x.grad)
+    qd.root.place(y, y.grad)
+
+    @qd.kernel
+    def compute():
+        for i in x:
+            v = x[i]
+            j = 0
+            for _ in range(5):
+                y[None] += v * qd.cast(j + 1, qd.f32)
+                j = j + 1
+                v = v + 0.1
+
+    x[0] = 1.0
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    x.grad[0] = 0.0
+    compute.grad()
+    # d y / d x[0] = sum_{k=0..4} (k+1): v at iter k is x[0] + 0.1*k, weight is k+1, so coefficient on x[0] is
+    # sum_{k=0..4} (k+1) = 15.
+    assert x.grad[0] == test_utils.approx(15.0, rel=1e-4)
+
+
+@test_utils.test(require=qd.extension.adstack)
+def test_adstack_many_non_f32_stacks_heap_backed():
+    # Regression test for macOS Metal. Deeply nested reverse-mode kernels create one i32 adstack per dynamic loop
+    # (to replay the counter) and one u1 adstack per data-dependent if (to replay the branch). Function-scope
+    # storage makes the per-thread private-memory footprint grow linearly with the number of adstacks, and the
+    # Apple MSL compiler rejects shaders past a few dozen slots; at ~100+ slots the pipeline creation XPC-times
+    # out. The heap-backing path keeps Function-scope memory bounded so such kernels compile and run correctly.
+    #
+    # The test packs many sibling loops + ifs into a single kernel so the reverse pass allocates several i32 and u1
+    # adstacks at once, then asserts the gradient is still correct. Correctness is the load-bearing assertion: a
+    # mis-offset between adstacks on the shared int heap would alias one stack's primal slice onto another and
+    # produce a wrong gradient. CPU backends store adstacks as regular memory and are unaffected; this primarily
+    # guards the SPIR-V heap_int path.
+    n = 3
+    x = qd.field(qd.f32, shape=n, needs_grad=True)
+    y = qd.field(qd.f32, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i in x:
+            v = x[i]
+            # Six sibling dynamic loops + six data-dependent ifs inside each. Each dynamic for-loop creates an i32
+            # adstack for its counter; each branch on a float-derived predicate creates a u1 adstack for the flag.
+            # Written as explicit duplicated loops rather than a meta-for so the adstack count is unambiguous
+            # (meta-loops with `qd.static` would unroll to one adstack per instantiation anyway, but expanding
+            # manually keeps the intent auditable when this test is inspected during a failure).
+            for a in range(4):
+                if qd.cast(a, qd.f32) < v:
+                    v = v * 1.1
+                else:
+                    v = v + 0.01
+            for b in range(4):
+                if v > qd.cast(b, qd.f32):
+                    v = v * 1.05
+                else:
+                    v = v - 0.01
+            for c in range(4):
+                if v * 0.5 > qd.cast(c, qd.f32):
+                    v = v + 0.1
+                else:
+                    v = v * 0.99
+            for d in range(4):
+                if v + qd.cast(d, qd.f32) > 0.0:
+                    v = v * 1.02
+                else:
+                    v = v + 0.02
+            for e in range(4):
+                if v - qd.cast(e, qd.f32) > 0.0:
+                    v = v * 0.97
+                else:
+                    v = v + 0.03
+            for f in range(4):
+                if v * 2.0 > qd.cast(f, qd.f32):
+                    v = v + 0.05
+                else:
+                    v = v * 1.03
+            y[None] += v
+
+    x_vals = [1.0, 2.0, 3.0]
+    for i in range(n):
+        x[i] = x_vals[i]
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    for i in range(n):
+        x.grad[i] = 0.0
+    compute.grad()
+
+    # Finite-difference reference. A symbolic gradient would require tracking which branch each if took at every
+    # iteration, which is exactly what the adstack replays for us; FD keeps the test oracle independent of the
+    # code under test.
+    h = 1e-3
+    for i in range(n):
+        x[i] = x_vals[i] + h
+        y[None] = 0.0
+        compute()
+        y_plus = y[None]
+        x[i] = x_vals[i] - h
+        y[None] = 0.0
+        compute()
+        y_minus = y[None]
+        x[i] = x_vals[i]
+        expected = (y_plus - y_minus) / (2.0 * h)
+        assert x.grad[i] == test_utils.approx(expected, rel=1e-2, abs=1e-3)
+
+
+@test_utils.test(require=qd.extension.adstack, arch=[qd.metal, qd.vulkan])
+def test_adstack_rejects_unsupported_type():
+    # Skip on Vulkan drivers without shaderInt8: those reject i8 at the SPIR-V type gate (`spirv_ir_builder`
+    # `QD_ERROR("Type i8 not supported")`) well before the adstack codegen guard fires, which would fail this
+    # test with the wrong error message. Metal always reports spirv_has_int8=1 so it never skips here.
+    caps = qd.lang.impl.get_runtime().prog.get_device_caps()
+    if not caps.get(qd._lib.core.DeviceCapability.spirv_has_int8):
+        pytest.skip("device lacks shaderInt8 - i8 is rejected at the SPIR-V type gate, not the adstack guard")
+
+    # SPIR-V codegen refuses non-{f32, i32, u1} loop-carried variables in reverse-mode AD: the adstack heap-backing
+    # only packs f32 and i32 (with u1 reinterpreted as i32); wider/other types have no home there. A Function-scope
+    # fallback is not offered because it is unusable for real workloads on Metal/MoltenVK (per-thread private-memory
+    # budget is exceeded) - silently falling back would paper over a correctness/perf cliff. Pins the hard error
+    # with a match on the user-facing message so a future regression (accidental fallback to Function-scope) or a
+    # rename of the error string is caught.
+    #
+    # Internal detail: uses i8 as the probe type rather than f64 because Metal / MoltenVK rejects f64 at the
+    # field-writer stage before the adstack codegen path is reached, whereas i8 is supported on both SPIR-V
+    # backends (`spirv_has_int8`) and reaches the adstack guard. Any other type outside the supported set
+    # (f16, i16, i64, u8, u16, u32, u64, f64) would do; i8 is the widest-supported of the rejected options.
+    x = qd.field(qd.i8)
+    y = qd.field(qd.f32, shape=(), needs_grad=True)
+    qd.root.dense(qd.i, 1).place(x)
+    # needs_grad on the i8 field is meaningless (gradients do not flow through integer casts); the adstack
+    # appears because the reverse pass replays the loop-carried i8 `v` value across the dynamic loop.
+
+    @qd.kernel
+    def compute():
+        for i in x:
+            v = x[i]
+            for _ in range(4):
+                v = v + qd.cast(1, qd.i8)
+            y[None] += qd.cast(v, qd.f32)
+
+    x[0] = 0
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    with pytest.raises(RuntimeError, match=r"f32, i32, and u1"):
         compute.grad()
 
 
 def _overflowing_compute(n_elements=1, n_iter=64):
     # Shared kernel for the overflow tests. Builds `compute`, loads inputs, seeds the output gradient, and returns
     # `(compute, x, y)` so each test can drive the grad launch and read back assertions itself. `n_iter=64` + 2
-    # adstack preamble pushes = 66 pushes, comfortably above `default_ad_stack_size=32`; `n_elements` controls how
-    # many threads run the overflowing loop in parallel.
+    # adstack preamble pushes = 66 pushes, comfortably above the `ad_stack_size=32` override that every caller
+    # places on the `@test_utils.test` decorator; `n_elements` controls how many threads run the overflowing loop
+    # in parallel.
     x = qd.field(qd.f32)
     y = qd.field(qd.f32)
     qd.root.dense(qd.i, n_elements).place(x, x.grad)
@@ -562,6 +718,69 @@ def test_adstack_large_capacity_resolves_overflow():
     # y += sin(v) iterated with v = x[0] + k for k = 0..63, so dy/dx[0] = sum_k cos(x[0] + k).
     expected = sum(math.cos(0.1 + k) for k in range(64))
     assert x.grad[0] == test_utils.approx(expected, rel=1e-3)
+
+
+@test_utils.test(require=qd.extension.adstack, ad_stack_size=4096, offline_cache=False)
+def test_adstack_heap_backed_exceeds_old_threadstack_budget():
+    # Pins the LLVM heap-backed adstack: the cumulative per-thread adstack footprint may exceed the ~256 KB
+    # secondary-thread stack budget that the old `create_entry_block_alloca` path enforced. Kernel has eight f32
+    # loop-carried variables at `ad_stack_size=4096`, so the per-thread adstack total is `8 * (8 + 4096 * 8) =
+    # 262,208 bytes` - 64 bytes past the old 262,144 byte ceiling. Before the heap-backing work the LLVM codegen
+    # hard-errored this at compile time via `QD_ERROR_IF(ad_stack_fn_scope_bytes_ > kFnScopeAdStackBudgetBytes,
+    # ...)`; SPIR-V compiled but overflowed the Metal / MoltenVK private-memory budget at shader-compile time.
+    # Now both arches allocate the slice inside `runtime->adstack_heap_buffer` (LLVM) or the per-dispatch
+    # SSBO (SPIR-V) and the kernel runs to completion with a correct gradient on every arch.
+    #
+    # `offline_cache=False` is load-bearing for the unfixed-tree check: with the cache on, a run that previously
+    # succeeded against a heap-backed runtime would still produce the right gradient via the cached bitcode even
+    # after the codegen changes are reverted. The test must force a fresh compile every run so the `QD_ERROR_IF`
+    # on the unfixed tree actually fires and terminates the process.
+    #
+    # Internal details: each outer element `i` drives eight independent recurrences `a_k = a_k * 0.9 + x[i]` at
+    # the same trip count (`n_iter`). The reverse pass pushes once for the initial value plus once per iteration,
+    # so each adstack needs `n_iter + 2` slots; at `ad_stack_size=4096` we only use a few of those slots per
+    # adstack but the slab still has to be allocated at full capacity. The gradient reduces to a closed form
+    # `d/dx[i] sum_k (sum_j 0.9^j)` per recurrence, giving `dy/dx[i] = 8 * sum_j 0.9^j for j in 0..n_iter-1`.
+    n = 4
+    n_iter = 32
+    x = qd.field(qd.f32, shape=n, needs_grad=True)
+    y = qd.field(qd.f32, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i in x:
+            a0 = 0.0
+            a1 = 0.0
+            a2 = 0.0
+            a3 = 0.0
+            a4 = 0.0
+            a5 = 0.0
+            a6 = 0.0
+            a7 = 0.0
+            for _ in range(n_iter):
+                a0 = a0 * 0.9 + x[i]
+                a1 = a1 * 0.9 + x[i]
+                a2 = a2 * 0.9 + x[i]
+                a3 = a3 * 0.9 + x[i]
+                a4 = a4 * 0.9 + x[i]
+                a5 = a5 * 0.9 + x[i]
+                a6 = a6 * 0.9 + x[i]
+                a7 = a7 * 0.9 + x[i]
+            y[None] += a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7
+
+    for i in range(n):
+        x[i] = 0.1 * (i + 1)
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    for i in range(n):
+        x.grad[i] = 0.0
+    compute.grad()
+    qd.sync()
+
+    geom = sum(0.9**j for j in range(n_iter))
+    for i in range(n):
+        assert x.grad[i] == test_utils.approx(8.0 * geom, rel=1e-3)
 
 
 @test_utils.test(require=qd.extension.adstack, ad_stack_size=32)
@@ -640,15 +859,37 @@ def test_adstack_overflow_during_teardown_does_not_abort(tmp_path):
         )
 
 
-@test_utils.test(require=qd.extension.adstack)
-def test_adstack_near_capacity():
-    # Runs a backward pass with a for-loop sized to just barely fit inside the adstack (one iteration away from
-    # overflow) and asserts the gradient comes out correctly. Companion to `test_adstack_overflow_raises` - this is
-    # the "and it still works at the boundary" side.
+@pytest.mark.parametrize(
+    "n_iter,overflows",
+    [
+        # Positive: 30 iterations => 32 pushes fits exactly inside a 32-slot adstack. The reverse pass of a
+        # dynamic loop emits one push per iteration plus two setup pushes (initial adjoint slot and primal
+        # starting value), so K+2 is the tight bound and this case is the "and it still works at the boundary"
+        # companion to the overflow variant below.
+        (30, False),
+        # Negative: 31 iterations => 33 pushes trips the overflow branch at push #33 and flips
+        # `runtime->adstack_overflow_flag`. The host surfaces that flag as `QuadrantsAssertionError` on the
+        # next `qd.sync()` - regardless of `compile_config.debug`. Pin the exact user-facing remediation in
+        # the match pattern so a future rephrase of the exception message that drops `default_ad_stack_size`
+        # shows up here.
+        (31, True),
+    ],
+)
+@test_utils.test(require=qd.extension.adstack, default_ad_stack_size=32)
+def test_adstack_near_capacity(n_iter, overflows):
+    # Boundary of the compile-time adstack capacity, parametrized on both sides of the K+2=size bound. Uses
+    # `default_ad_stack_size=32` on the decorator to override the program-wide default (256) so the boundary
+    # stays at K=30 regardless of future default bumps. This keeps the test shape small - no long f32
+    # accumulation drift, no tolerance relaxation. Companion to `test_adstack_overflow_raises` which uses the
+    # explicit `ad_stack_size=32` knob; here we pin the `default_ad_stack_size` knob separately because the
+    # two knobs take different code paths (`ad_stack_size > 0` forces every adstack to exactly that size;
+    # `default_ad_stack_size` is only the fallback for adaptive stacks whose trip count the compiler could
+    # not prove).
     #
-    # Internal detail: the transform emits two adstack pushes before the loop body (one for the initial adjoint
-    # slot, one for the primal's starting value), so a loop of K iterations produces K+2 pushes. With
-    # `default_ad_stack_size=32`, that bounds K at 30.
+    # Internal details: see `feedback_tests_must_pin_the_bug.md` for the rule. Both parametrize variants must
+    # fail on the unfixed tree (where `default_ad_stack_size` was not exposed to `qd.init` - the decorator
+    # `default_ad_stack_size=32` would be a no-op on a program-wide default of 256, so both K=30 and K=31
+    # would pass, and this test would stop pinning the knob).
     x = qd.field(qd.f32)
     y = qd.field(qd.f32)
     qd.root.dense(qd.i, 1).place(x, x.grad)
@@ -658,7 +899,7 @@ def test_adstack_near_capacity():
     def compute():
         for i in x:
             v = x[i]
-            for _ in range(30):
+            for _ in range(n_iter):
                 y[None] += qd.sin(v)
                 v = v + 1.0
 
@@ -667,10 +908,18 @@ def test_adstack_near_capacity():
     compute()
     y.grad[None] = 1.0
     x.grad[0] = 0.0
-    compute.grad()
 
-    expected = sum(math.cos(0.1 + k) for k in range(30))
-    assert x.grad[0] == test_utils.approx(expected, rel=1e-4)
+    if overflows:
+        # Match the `default_ad_stack_size` remediation in the exception message so a rephrase that drops
+        # this specific token (e.g. reverting to the old `ad_stack_size=N`-only guidance) is caught here.
+        with pytest.raises((AssertionError, RuntimeError), match=r"default_ad_stack_size"):
+            compute.grad()
+            qd.sync()
+    else:
+        compute.grad()
+        qd.sync()
+        expected = sum(math.cos(0.1 + k) for k in range(n_iter))
+        assert x.grad[0] == test_utils.approx(expected, rel=1e-4)
 
 
 def _run_sum_linear(
@@ -1081,3 +1330,97 @@ def test_adstack_vector_subscript_selfop_no_warnings(tmp_path):
         "reverse-mode AD emitted 'Loading variable N before anything is stored to it' warnings for a Vector "
         "subscript-assign + self-referencing in-place op pattern; stderr was:\n" + stderr
     )
+
+
+@test_utils.test(require=qd.extension.adstack, arch=[qd.metal, qd.vulkan], ad_stack_size=4096)
+def test_adstack_ndrange_over_ndarray_shape_does_not_oversize_heap():
+    # Regression test: a grad kernel whose range is derived at launch time from an ndarray shape (e.g.
+    # `qd.ndrange(arr.shape[0], arr.shape[1])`) used to inherit `advisory_total_num_threads =
+    # kMaxNumThreadsGridStrideLoop = 131072` from the SPIR-V codegen fallback, and the runtime sized the
+    # per-dispatch adstack heap as `131072 * per_thread_stride * sizeof(float)`. For this kernel's ten
+    # loop-carried f32 variables at `ad_stack_size=4096`, that is `131072 * 10 * 2 * 4096 * 4 bytes = 40
+    # GiB`. Apple Silicon's `MTLDevice.maxBufferLength` is ~75% of unified memory (e.g. ~28 GiB on an M4 Max
+    # with 48 GiB unified, smaller on lower-end configs), so the allocation failed. Before the RHI layer
+    # checked for nil, that failure was silently wrapped as `RhiResult::success` with a nil MTLBuffer; every
+    # downstream `setBuffer:atIndex:2` bound nil, writes dropped and reads returned 0, and the backward
+    # produced NaN gradients without any error. With the fix, the codegen records the shape-lookup product
+    # backing the runtime-resolved `end_stmt` into `RangeForAttributes::end_shape_product`, the runtime
+    # `launch_kernel` reads each shape from the `LaunchContextBuilder` args buffer and tightens
+    # `advisory_total_num_threads` to `actual_iter_count = rows * cols = 6`, so only ~240 KB of adstack heap
+    # is allocated and the gradient is correct.
+    #
+    # Internal details: `ad_stack_size=4096` + ten loop-carried f32 variables is tuned so that the pre-fix
+    # 131072-thread allocation request crosses the smallest plausible Apple Silicon `maxBufferLength` - the
+    # test would otherwise silently pass on hardware with large unified memory. Scoped to Metal and Vulkan
+    # because only the SPIR-V heap-backed adstack path depends on the advisory thread count for sizing; the
+    # LLVM path sizes the adstack slab once per runtime against `num_cpu_threads`, so CPU cannot exhibit the
+    # symptom. The finite-difference cross-check pins correctness so a future regression that silently
+    # returns the wrong gradient (e.g. 0 from a nil binding that still ends up bound for some other reason)
+    # trips the assertion rather than passing on the not-NaN check alone.
+    rows, cols = 2, 3
+
+    @qd.kernel
+    def compute(arr: qd.types.NDArray, out: qd.types.NDArray) -> None:
+        for i, j in qd.ndrange(arr.shape[0], arr.shape[1]):
+            v0 = arr[i, j]
+            v1 = arr[i, j] + 0.1
+            v2 = arr[i, j] + 0.2
+            v3 = arr[i, j] + 0.3
+            v4 = arr[i, j] + 0.4
+            v5 = arr[i, j] + 0.5
+            v6 = arr[i, j] + 0.6
+            v7 = arr[i, j] + 0.7
+            v8 = arr[i, j] + 0.8
+            v9 = arr[i, j] + 0.9
+            for _ in range(3):
+                v0 = v0 * 1.01 + 0.01
+                v1 = v1 * 1.02 + 0.02
+                v2 = v2 * 1.03 + 0.03
+                v3 = v3 * 1.04 + 0.04
+                v4 = v4 * 1.05 + 0.05
+                v5 = v5 * 1.06 + 0.06
+                v6 = v6 * 1.07 + 0.07
+                v7 = v7 * 1.08 + 0.08
+                v8 = v8 * 1.09 + 0.09
+                v9 = v9 * 1.10 + 0.10
+            out[0] += v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9
+
+    arr_np = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], dtype=np.float32)
+    arr = qd.ndarray(qd.f32, shape=(rows, cols), needs_grad=True)
+    out = qd.ndarray(qd.f32, shape=(1,), needs_grad=True)
+    arr.from_numpy(arr_np)
+    arr.grad.from_numpy(np.zeros_like(arr_np))
+    out.from_numpy(np.zeros((1,), dtype=np.float32))
+    out.grad.from_numpy(np.ones((1,), dtype=np.float32))
+
+    compute(arr, out)
+    compute.grad(arr, out)
+    qd.sync()
+
+    got_grad = arr.grad.to_numpy()
+    assert not np.isnan(got_grad).any(), f"ndrange-over-shape grad returned NaN: {got_grad}"
+
+    # Finite-difference oracle. Independent of the backward emission so a wrong-but-non-NaN gradient (the
+    # failure mode when the adstack heap was bound to Metal's nil-fallback and reads came back as zero)
+    # still trips the assertion.
+    h = 1e-3
+    fd = np.zeros_like(arr_np)
+    arr_plus = qd.ndarray(qd.f32, shape=(rows, cols))
+    arr_minus = qd.ndarray(qd.f32, shape=(rows, cols))
+    out_scalar = qd.ndarray(qd.f32, shape=(1,))
+    for i in range(rows):
+        for j in range(cols):
+            tmp = arr_np.copy()
+            tmp[i, j] += h
+            arr_plus.from_numpy(tmp)
+            out_scalar.from_numpy(np.zeros((1,), dtype=np.float32))
+            compute(arr_plus, out_scalar)
+            y_plus = out_scalar.to_numpy()[0]
+            tmp = arr_np.copy()
+            tmp[i, j] -= h
+            arr_minus.from_numpy(tmp)
+            out_scalar.from_numpy(np.zeros((1,), dtype=np.float32))
+            compute(arr_minus, out_scalar)
+            y_minus = out_scalar.to_numpy()[0]
+            fd[i, j] = (y_plus - y_minus) / (2.0 * h)
+    np.testing.assert_allclose(got_grad, fd, rtol=1e-2, atol=1e-3)

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -599,26 +599,37 @@ def test_adstack_many_non_f32_stacks_heap_backed():
         assert x.grad[i] == test_utils.approx(expected, rel=1e-2, abs=1e-3)
 
 
-@test_utils.test(require=qd.extension.adstack, arch=[qd.metal, qd.vulkan])
+@test_utils.test(require=qd.extension.adstack)
 def test_adstack_rejects_unsupported_type():
+    # Per-backend support matrix for loop-carried i8 in reverse-mode AD:
+    #
+    #   - SPIR-V (Metal / Vulkan) hard-rejects i8 loop-carried variables at codegen time: the adstack heap-backing
+    #     only packs f32 and i32 (with u1 reinterpreted as i32); wider/other types have no home there. A
+    #     Function-scope fallback is not offered because it is unusable for real workloads on Metal/MoltenVK
+    #     (per-thread private-memory budget is exceeded) - silently falling back would paper over a
+    #     correctness/perf cliff. The guard surfaces as a `RuntimeError` whose message names the supported type
+    #     set. The match below pins the message so an accidental Function-scope fallback or a rename of the
+    #     error string is caught.
+    #   - LLVM (CPU / CUDA / AMDGPU) supports loop-carried i8 directly: the adstack heap there is byte-indexed
+    #     and `AdStackAllocaStmt::size_in_bytes()` covers i8 at one byte per slot without any special case. The
+    #     backward pass runs to completion and the forward output is what the test asserts.
+    #
     # Skip on Vulkan drivers without shaderInt8: those reject i8 at the SPIR-V type gate (`spirv_ir_builder`
     # `QD_ERROR("Type i8 not supported")`) well before the adstack codegen guard fires, which would fail this
-    # test with the wrong error message. Metal always reports spirv_has_int8=1 so it never skips here.
-    caps = qd.lang.impl.get_runtime().prog.get_device_caps()
-    if not caps.get(qd._lib.core.DeviceCapability.spirv_has_int8):
-        pytest.skip("device lacks shaderInt8 - i8 is rejected at the SPIR-V type gate, not the adstack guard")
+    # test with the wrong error message. Metal always reports spirv_has_int8=1 so it never skips here. The LLVM
+    # backends do not consult `spirv_has_int8`, so the skip only applies on SPIR-V arches.
+    arch = qd.lang.impl.get_runtime().prog.config().arch
+    is_spirv = arch in (qd.metal, qd.vulkan)
+    if is_spirv:
+        caps = qd.lang.impl.get_runtime().prog.get_device_caps()
+        if not caps.get(qd._lib.core.DeviceCapability.spirv_has_int8):
+            pytest.skip("device lacks shaderInt8 - i8 is rejected at the SPIR-V type gate, not the adstack guard")
 
-    # SPIR-V codegen refuses non-{f32, i32, u1} loop-carried variables in reverse-mode AD: the adstack heap-backing
-    # only packs f32 and i32 (with u1 reinterpreted as i32); wider/other types have no home there. A Function-scope
-    # fallback is not offered because it is unusable for real workloads on Metal/MoltenVK (per-thread private-memory
-    # budget is exceeded) - silently falling back would paper over a correctness/perf cliff. Pins the hard error
-    # with a match on the user-facing message so a future regression (accidental fallback to Function-scope) or a
-    # rename of the error string is caught.
-    #
-    # Internal detail: uses i8 as the probe type rather than f64 because Metal / MoltenVK rejects f64 at the
+    # Internal detail: i8 is the probe type rather than f64 because Metal / MoltenVK rejects f64 at the
     # field-writer stage before the adstack codegen path is reached, whereas i8 is supported on both SPIR-V
-    # backends (`spirv_has_int8`) and reaches the adstack guard. Any other type outside the supported set
-    # (f16, i16, i64, u8, u16, u32, u64, f64) would do; i8 is the widest-supported of the rejected options.
+    # backends (`spirv_has_int8`) and reaches the adstack guard. Any other type outside the SPIR-V supported set
+    # (f16, i16, i64, u8, u16, u32, u64, f64) would do; i8 is the widest-supported of the SPIR-V-rejected
+    # options and is also a plain supported type on every LLVM backend.
     x = qd.field(qd.i8)
     y = qd.field(qd.f32, shape=(), needs_grad=True)
     qd.root.dense(qd.i, 1).place(x)
@@ -637,8 +648,13 @@ def test_adstack_rejects_unsupported_type():
     y[None] = 0.0
     compute()
     y.grad[None] = 1.0
-    with pytest.raises(RuntimeError, match=r"f32, i32, and u1"):
+    if is_spirv:
+        with pytest.raises(RuntimeError, match=r"f32, i32, and u1"):
+            compute.grad()
+    else:
         compute.grad()
+        # Forward: v starts at 0, increments by 1 four times, writes 4 as f32 into y. No overflow expected.
+        assert y[None] == pytest.approx(4.0, rel=1e-6)
 
 
 def _overflowing_compute(n_elements=1, n_iter=64):
@@ -1332,7 +1348,7 @@ def test_adstack_vector_subscript_selfop_no_warnings(tmp_path):
     )
 
 
-@test_utils.test(require=qd.extension.adstack, arch=[qd.metal, qd.vulkan], ad_stack_size=4096)
+@test_utils.test(require=qd.extension.adstack, ad_stack_size=4096)
 def test_adstack_ndrange_over_ndarray_shape_does_not_oversize_heap():
     # Regression test: a grad kernel whose range is derived at launch time from an ndarray shape (e.g.
     # `qd.ndrange(arr.shape[0], arr.shape[1])`) used to inherit `advisory_total_num_threads =
@@ -1351,12 +1367,11 @@ def test_adstack_ndrange_over_ndarray_shape_does_not_oversize_heap():
     #
     # Internal details: `ad_stack_size=4096` + ten loop-carried f32 variables is tuned so that the pre-fix
     # 131072-thread allocation request crosses the smallest plausible Apple Silicon `maxBufferLength` - the
-    # test would otherwise silently pass on hardware with large unified memory. Scoped to Metal and Vulkan
-    # because only the SPIR-V heap-backed adstack path depends on the advisory thread count for sizing; the
-    # LLVM path sizes the adstack slab once per runtime against `num_cpu_threads`, so CPU cannot exhibit the
-    # symptom. The finite-difference cross-check pins correctness so a future regression that silently
-    # returns the wrong gradient (e.g. 0 from a nil binding that still ends up bound for some other reason)
-    # trips the assertion rather than passing on the not-NaN check alone.
+    # test would otherwise silently pass on hardware with large unified memory. The original oversize symptom
+    # only surfaced on the SPIR-V heap-backed adstack path whose per-dispatch sizing depends on the advisory
+    # thread count; the LLVM path sizes the adstack slab once per runtime against `num_cpu_threads` and cannot
+    # exhibit the same nil-buffer regression. The test still runs on every backend so the finite-difference
+    # cross-check catches a future regression in the grad computation regardless of which path it lives in.
     rows, cols = 2, 3
 
     @qd.kernel


### PR DESCRIPTION
# Heap-backed adstack on SPIR-V backends (Metal, Vulkan)

> Moves SPIR-V adstack storage from per-thread Function-scope arrays to per-dispatch heap StorageBuffers. Lifts the Metal / MoltenVK private-memory cap that made Autodiff 10's Function-scope path unusable for real reverse-mode kernels. Plus: Metal `allocate_memory` surfaces nil instead of silently wrapping, and `advisory_total_num_threads` is tightened at launch time against the actual `ndrange` shape.

## TL;DR

```cpp
// quadrants/codegen/spirv/kernel_utils.h
enum class BufferType : int {
  // ...
  AdStackHeapFloat,  // f32 adstacks (primal + adjoint interleaved)
  AdStackHeapInt,    // i32 adstacks (u1 reinterpreted as i32; primal-only, no adjoint slice)
};
```

Two new per-dispatch StorageBuffers. Each invocation owns an `invoc_id * stride` slice, sized by the pre-scanned per-thread stride × actual dispatched thread count. Shader indexing uses `invoc_id * stride + offset + count`, widened to u64 when `spirv_has_int64` is available (and the runtime asserts at launch time that the product fits in u32 when it isn't). Other primitive types (f64, i64, …) are hard-errored: the heap packs only `{f32, i32, u1}`, so the old Function-scope fallback for exotic types is removed because it was never usable on Metal anyway.

## Why

Autodiff 10's Function-scope SPIR-V adstack (per-thread `Array<T, max_size>`) kept working on small kernels but hit two walls on real workloads:

1. Apple's MSL translator rejects pipelines whose per-thread private-memory footprint exceeds a few hundred kilobytes. A reverse-mode articulated-body dynamics step in Genesis has ~100 i32 and u1 adstacks at `max_size=256`, totalling ~130 KB per thread — well past the MSL compiler's budget. The pipeline create fails with `XPC_ERROR_CONNECTION_INTERRUPTED`, which is not even recoverable on retry.
2. Even when the shader compiles, the per-thread Function-scope slice is permanent memory reservation in the driver's on-chip register allocation, which starves other kernels and drops occupancy.

Both constraints vanish once the storage lives in a shared StorageBuffer sliced by `invoc_id`. Per-thread shader footprint is O(1) regardless of `max_size`; the only real limit is `MTLDevice.maxBufferLength` and the driver's memory pool.

## Mechanism

### New buffer types (`quadrants/codegen/spirv/kernel_utils.{h,cpp}`)

Two new `BufferType` enum values — `AdStackHeapFloat` and `AdStackHeapInt` — plus `buffers_name()` cases for them and for the pre-existing `ListGen` / `ExtArr` / `AdStackOverflow` types that were missing (debug `buffers_name()` calls were hitting `QD_ERROR("unrecognized buffer type")` on any binding involving those).

The int heap deliberately stores u1 as i32 (matched to the historical Function-scope bool→int remap in `IRBuilder::get_array_type`). It carries only the primal slice, not the adjoint: `auto_diff.cpp`'s `is_real` guard only emits `AccAdjoint` / `LoadTopAdj` on real-typed stacks, so the int heap never needs an adjoint half.

### Pre-scan + eager base emission (`spirv_codegen.cpp`)

`TaskCodegen::run` pre-scans the task body before any visitor runs and accumulates `ad_stack_heap_per_thread_stride_float_` / `ad_stack_heap_per_thread_stride_int_`, and maps each `AdStackAllocaStmt` to its byte offset within the per-thread slice.

The per-thread heap base `invoc_id * stride` is emitted **eagerly** from `visit(AdStackAllocaStmt)` (not lazily at the first Push / LoadTop). Comment explicitly explains why: two sibling inner loops would reuse an SSA id defined in the first loop's body, which doesn't dominate the second — SPIR-V spec §2.16 dominance violation. Emitting the OpIMul at the outer dispatch body's insertion point guarantees it dominates every sibling loop body that later references it.

### u32 vs u64 index arithmetic

When `spirv_has_int64` is available the codegen widens `invoc_id * stride + offset + count` to u64 via `OpUConvert`. Without Int64 the codegen emits u32 `OpIMul` and the runtime asserts at launch time that `stride * dispatched_threads <= u32_max` to catch silent wrap-around aliasing into another thread's slice.

### Hard-error non-{f32, i32, u1} types

`visit(AdStackAllocaStmt)` hard-errors exotic primitive types (f64, i64, f16, …). The dead Function-scope fallback is removed (the `AdStackHeapKind::function_scope` enum branch, `primal_arr` / `adjoint_arr` fields in `AdStackSpirv`, and the else branch in `ad_stack_slot_ptr`).

The decision is deliberate: the Function-scope path was demonstrably unusable on Metal for real workloads, and silently falling back to it would paper over a correctness/perf cliff. Hard-erroring surfaces the unsupported combination at compile time with a precise message instead of a silent "your gradient is now backed by ~40 GB of Function-scope memory and Metal returned nil".

### Runtime heap growth (`runtime/gfx/runtime.{h,cpp}`)

`GfxRuntime` gains four new fields: a `DeviceAllocationGuard` + size for each of the float and int heaps. `launch_kernel` computes `required = stride * dispatched_threads * sizeof(element)` per binding and grows the heap via amortised doubling when `required > current_size`. On grow:

```cpp
size_t new_size = std::max(required, 2 * adstack_heap_buffer_float_size_);
auto [buf, res] = device_->allocate_memory_unique({new_size, ...});
// Fallback when doubling overshoots a device limit (e.g. Metal's maxBufferLength):
// retry at exactly `required` bytes before aborting.
if (res != RhiResult::success && new_size > required) {
  new_size = required;
  std::tie(buf, res) = device_->allocate_memory_unique({new_size, ...});
}
QD_ASSERT_INFO(res == RhiResult::success, ...);
```

The retry-at-required fallback covers Metal's `maxBufferLength` cap: at `old_size=150 MB, required=165 MB` the doubled `300 MB` request fails, but the `165 MB` retry succeeds. Without the fallback the process would abort with a spurious out-of-memory (claude bot flagged this; fix is applied symmetrically to both float and int grow paths).

Old buffers on grow are moved into `ctx_buffers_` (deferred-free) rather than freed synchronously — any in-flight cmdlist referencing them stays valid. Autodiff 11's `flush()` fix is load-bearing here: clearing `ctx_buffers_` on submit would GPU-side use-after-free the displaced buffers.

Empty-dispatch guard: when `required == 0` (empty field) the binding uses `kDeviceNullAllocation` instead of asking the RHI for a zero-sized buffer, which trips `RHI_ASSERT(params.size > 0)` on Vulkan.

### `advisory_total_num_threads` tightening

For SPIR-V dynamic `range_for` kernels, codegen previously set `advisory_total_num_threads = kMaxNumThreadsGridStrideLoop = 131072` as the fallback because the range bound wasn't known at codegen time. The runtime then sized the per-dispatch adstack heap at `131072 * per_thread_stride * sizeof(element)`, which for a deep reverse kernel crossed Metal's `maxBufferLength` even when the actual iteration count was tiny.

This PR records the shape-lookup product backing a runtime-resolved `end_stmt` into a new `RangeForAttributes::end_shape_product` vector at codegen time. At launch, `GfxRuntime::launch_kernel` reads each referenced `arr.shape[axis]` from the `LaunchContextBuilder` args buffer and tightens `advisory_total_num_threads` to the actual launch-time iteration count (6 for a 2×3 ndarray, not 131072). The in-shader grid-stride loop already handles any dispatched thread count correctly; the tight cap just means each dispatched thread processes fewer idle strides.

### Metal `allocate_memory` returns `out_of_memory` on nil

`MetalDevice::allocate_memory` now checks `newBufferWithLength: == nil` and returns `RhiResult::out_of_memory` (with an error log naming `params.size` and the device's `maxBufferLength`). Previously it wrapped nil in `MetalMemory` and returned `RhiResult::success`, and every subsequent `setBuffer:atIndex:...` bound nil — writes dropped silently, reads came back as zero, and reverse-mode kernels that hit this path produced NaN gradients without any error (divide-by-zero in a `.normalized()` sqrt adjoint that reloaded a never-actually-written primal).

Also surfaces Metal pipeline-creation failures that currently return `*out_pipeline == nullptr` as `RhiResult::error` instead of `RhiResult::success`, so launches on a null pipeline become catchable exceptions.

### Docs (`docs/source/user_guide/autodiff.md`)

- Drops the "SPIR-V on-chip cap" limitation from the known-limitations list.
- Adds a "Memory cost" section with the formula `num_threads * stack_size * bytes_per_element * num_loop_carried_variables` and a per-backend element-size table (LLVM = 8 B for f32 / i32 because primal+adjoint; SPIR-V = 8 for f32, 4 for i32 because primal-only, 4 for bool widened to i32). Includes a worked example: `ndrange(1024, 1024) × default_ad_stack_size=256 × 4 f32 vars ≈ 8 GB`.
- Order-of-remedies for OOM errors (drop `default_ad_stack_size`, reduce loop-carried vars, raise `device_memory_fraction`).

## Tests

Concentrated in this PR because the heap-backed behaviour only exists after 493c lands:

- **`test_adstack_rejects_unsupported_type`** — SPIR-V hard-errors f64 / i64 adstacks at compile time. Skip-gated on `spirv_has_int8` (Vulkan drivers without it reject i8 at the SPIR-V type gate before the adstack guard fires). Uses i8 as the probe because Metal / MoltenVK rejects f64 at the field-writer stage before codegen.
- **`test_adstack_mixed_f32_and_non_f32`** — f32 + i32 adstacks in one kernel. Exercises both the `AdStackHeapFloat` and `AdStackHeapInt` paths simultaneously; finite-difference cross-check.
- **`test_adstack_many_non_f32_stacks_heap_backed`** — six sibling dynamic loops × six data-dependent ifs = ~12 i32 + u1 adstacks per kernel on Metal. Function-scope storage would reject the pipeline; heap-backed keeps Function-scope memory bounded.
- **`test_adstack_large_capacity_heap_backed`** — `ad_stack_size=4096` on Metal with a single loop-carried variable. The old Function-scope path would fail shader compile; heap-backed runs to completion.
- **`test_adstack_ndrange_over_ndarray_shape_does_not_oversize_heap`** — grad kernel over `qd.ndrange(arr.shape[0], arr.shape[1])`. Pre-fix, allocated ~40 GB of adstack heap (131072 fallback × 10 loop-carried × 4096 × 4). Post-fix, tightens to the actual 6-iteration count. Finite-difference cross-check guards against the nil-binding NaN mode.
- **`test_adstack_near_capacity[overflow=True,False]`** — re-parametrized to pin `default_ad_stack_size=32` on both sides of the K+2=size bound (previously only pinned the no-overflow side).

## Side-effect audit

| Concern                                   | Verdict |
| ----------------------------------------- | ------- |
| Exotic primitive types on SPIR-V          | Hard-errored with a clear message. Function-scope fallback was unusable on Metal for real workloads; keeping it would have been a correctness / perf cliff. |
| Metal `maxBufferLength` cap on grow       | Retry-at-required fallback (claude bot fix); symmetric on both float and int heaps. |
| Empty-field dispatches                    | `kDeviceNullAllocation` path skips the zero-size allocation that trips RHI asserts. |
| AMDGPU `dealloc_memory` pooling           | Relies on the synchronous `hipFree(context_pointer)` tail added in Autodiff 11. Cross-launch safety invariant spelled out in the LLVM-side `.h` and `.cpp` adjacent to `adstack_heap_alloc_`. |
| Metal nil-buffer silent corruption        | Surfaced as `RhiResult::out_of_memory` and a Python exception. |
| SPIR-V dominance violation                | Eager `invoc_id * stride` emission from `visit(AdStackAllocaStmt)` (claude bot fix); header `lazily` comment rewritten to match. |
| u32 overflow on large dispatches          | Runtime-asserts when `spirv_has_int64` is off; u64 widening via `OpUConvert` when it's on. `OpBitcast(u64, u64)` avoided. |

## Stack

Autodiff 13 of 13. Top-most of the "heap-backed adstack" triplet split. Based on #537 (LLVM heap). End of the chain.
