### PR TITLE
[AutoDiff] Recompute tanh/exp on the operand in the reverse pass

### DIFF
--- a/quadrants/transforms/auto_diff.cpp
+++ b/quadrants/transforms/auto_diff.cpp
@@ -979,6 +979,14 @@ class ADTransform : public IRVisitor {
     return insert<UnaryOpStmt>(UnaryOpType::tan, load(op1));
   }
 
+  Stmt *tanh(Stmt *op1) {
+    return insert<UnaryOpStmt>(UnaryOpType::tanh, load(op1));
+  }
+
+  Stmt *exp(Stmt *op1) {
+    return insert<UnaryOpStmt>(UnaryOpType::exp, load(op1));
+  }
+
   Stmt *pow(Stmt *op1, Stmt *op2) {
     return insert<BinaryOpStmt>(BinaryOpType::pow, load(op1), load(op2));
   }
@@ -1256,7 +1264,11 @@ class MakeAdjoint : public ADTransform {
       // rides the adstack through its LocalLoad, so a fresh tan on it is per-iteration correct.
       accumulate(stmt->operand, mul(adjoint(stmt), add(constant(1, stmt->ret_type), sqr(tan(stmt->operand)))));
     } else if (stmt->op_type == UnaryOpType::tanh) {
-      accumulate(stmt->operand, mul(adjoint(stmt), sub(constant(1, stmt->ret_type), sqr(stmt))));
+      // Recompute tanh(operand) in the reverse pass instead of reusing the forward stmt value. In dynamic loops
+      // BackupSSA spills the forward stmt to a single plain alloca overwritten each iteration, so the reversed
+      // loop would read the last-iteration tanh for every backward step. The operand rides the adstack through
+      // LocalLoad, so a fresh tanh on it is per-iteration correct.
+      accumulate(stmt->operand, mul(adjoint(stmt), sub(constant(1, stmt->ret_type), sqr(tanh(stmt->operand)))));
     } else if (stmt->op_type == UnaryOpType::asin) {
       accumulate(stmt->operand, mul(adjoint(stmt), div(constant(1, stmt->ret_type),
                                                        sqrt(sub(constant(1, stmt->ret_type), sqr(stmt->operand))))));
@@ -1265,7 +1277,9 @@ class MakeAdjoint : public ADTransform {
                  mul(adjoint(stmt), negate(div(constant(1, stmt->ret_type),
                                                sqrt(sub(constant(1, stmt->ret_type), sqr(stmt->operand)))))));
     } else if (stmt->op_type == UnaryOpType::exp) {
-      accumulate(stmt->operand, mul(adjoint(stmt), stmt));
+      // See the tanh case above: recompute exp on the adstack-backed operand so the reversed loop sees the
+      // per-iteration value rather than the last-forward value spilled by BackupSSA.
+      accumulate(stmt->operand, mul(adjoint(stmt), exp(stmt->operand)));
     } else if (stmt->op_type == UnaryOpType::log) {
       accumulate(stmt->operand, div(adjoint(stmt), stmt->operand));
     } else if (stmt->op_type == UnaryOpType::sqrt) {

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -17,6 +17,8 @@ from tests import test_utils
         (qd.acos, "acos"),
         (qd.log, "log"),
         (qd.sqrt, "sqrt"),
+        (qd.tanh, "tanh"),
+        (qd.exp, "exp"),
     ],
 )
 @test_utils.test(require=qd.extension.adstack, ad_stack_experimental_enabled=True)


### PR DESCRIPTION
## Summary

Previously the reverse-mode formulas for \`tanh(x)\` and \`exp(x)\` reused the forward stmt value (\`sqr(stmt)\`, \`stmt\`). \`BackupSSA\` spills that forward value to a single plain alloca, so inside a dynamic loop the reversed iteration reads the last-iteration value for every backward step - giving silently wrong gradients for all earlier iterations.

Recompute \`tanh(operand)\` / \`exp(operand)\` instead. The operand rides the adstack through \`LocalLoad\`, so a fresh call on it is per-iteration correct. Both ops are already in \`NonLinearOps::unary_collections\` so the operand alloca is promoted.

## Test plan

- [ ] \`test_adstack_tanh_exp_loop_carried[tanh]\` and \`[exp]\` (new, added here): 3-iteration dynamic loop where \`a\` is redefined from scratch each iteration (read-only alloca pattern). Verifies gradient against \`torch.autograd\`; the pre-fix formula would produce silently wrong values.