### PR TITLE
[AutoDiff] Mark rsqrt as non-linear for adstack promotion

### DIFF
--- a/quadrants/transforms/auto_diff.cpp
+++ b/quadrants/transforms/auto_diff.cpp
@@ -42,8 +42,8 @@ class NonLinearOps {
  public:
   inline static const std::set<TernaryOpType> ternary_collections{TernaryOpType::select};
   inline static const std::set<UnaryOpType> unary_collections{
-      UnaryOpType::abs,  UnaryOpType::sin,  UnaryOpType::cos, UnaryOpType::tan, UnaryOpType::tanh,
-      UnaryOpType::asin, UnaryOpType::acos, UnaryOpType::exp, UnaryOpType::log, UnaryOpType::sqrt};
+      UnaryOpType::abs,  UnaryOpType::sin, UnaryOpType::cos, UnaryOpType::tan,  UnaryOpType::tanh, UnaryOpType::asin,
+      UnaryOpType::acos, UnaryOpType::exp, UnaryOpType::log, UnaryOpType::sqrt, UnaryOpType::rsqrt};
   inline static const std::set<BinaryOpType> binary_collections{BinaryOpType::mul, BinaryOpType::div,
                                                                 BinaryOpType::atan2, BinaryOpType::pow};
 };

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -19,6 +19,7 @@ from tests import test_utils
         (qd.sqrt, "sqrt"),
         (qd.tanh, "tanh"),
         (qd.exp, "exp"),
+        (qd.rsqrt, "rsqrt"),
     ],
 )
 @test_utils.test(require=qd.extension.adstack, ad_stack_experimental_enabled=True)


### PR DESCRIPTION
## Summary

\`AdStackAllocaJudger\` walks \`NonLinearOps::unary_collections\` to decide whether the operand alloca of a unary op needs AdStack backing. rsqrt's reverse formula is \`-0.5 * rsqrt(x)^3\` and already recomputes on the operand, so correctness inside a dynamic loop hinges entirely on the operand's alloca being promoted to AdStack. Without membership in the set, a loop-variant alloca feeding only rsqrt stayed plain and the reversed loop read the last-forward value, producing wrong gradients.

## Test plan

- [ ] \`test_adstack_tanh_exp_loop_carried[rsqrt]\` (extends the parametrize added in #498): read-only operand pattern so promotion hinges solely on unary_collections membership; the pre-fix would fail with the last-forward value.