### PR TITLE
[AutoDiff] Autodiff 1: Add baseline adstack regression test for unary_collections

### DIFF
--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -1,0 +1,107 @@
+import pytest
+
+import quadrants as qd
+
+from tests import test_utils
+
+_UNARY_OPS_PARAMS = [
+    # Ops whose domain is all real values use a step/offset that makes the operand cross
+    # zero as `j` advances, so the per-iteration sign varies. `abs` especially needs this:
+    # its derivative is piecewise-constant, so a non-crossing operand would pass trivially.
+    ("sin", 0.3, -0.4),
+    ("cos", 0.3, -0.4),
+    ("abs", 0.3, -0.4),
+    # Ops restricted to positive/subunit operands use a smaller step and zero offset to
+    # stay inside their domain across every `x_val` and `n_iter` combination.
+    ("log", 0.05, 0.0),
+    ("sqrt", 0.05, 0.0),
+    ("asin", 0.05, 0.0),
+    ("acos", 0.05, 0.0),
+]
+
+
+def _run_unary_loop_carried(qd_dtype, op_name, step, offset, x_val, n_iter, rel_tol):
+    import torch
+
+    qd_op = getattr(qd, op_name)
+    torch_op = getattr(torch, op_name)
+    torch_dtype = torch.float64 if qd_dtype == qd.f64 else torch.float32
+
+    n = 4
+    x = qd.field(qd_dtype, shape=n, needs_grad=True)
+    y = qd.field(qd_dtype, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i in x:
+            acc = 0.0
+            for j in range(n_iter):
+                a = x[i] + qd.cast(j, qd_dtype) * step + offset
+                acc += qd_op(a)
+            y[None] += acc
+
+    for i in range(n):
+        x[i] = x_val + i * 0.05
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    for i in range(n):
+        x.grad[i] = 0.0
+    compute.grad()
+
+    x_t = torch.tensor([x_val + i * 0.05 for i in range(n)], dtype=torch_dtype, requires_grad=True)
+    y_t = torch.zeros((), dtype=torch_dtype)
+    for i in range(n):
+        acc_t = torch.zeros((), dtype=torch_dtype)
+        for j in range(n_iter):
+            a_t = x_t[i] + float(j) * step + offset
+            acc_t = acc_t + torch_op(a_t)
+        y_t = y_t + acc_t
+    y_t.backward()
+
+    # Use `pytest.approx` directly rather than `test_utils.approx` so the caller's `rel_tol` is honoured as-is.
+    # `test_utils.approx` floors `rel` to `max(rel, get_rel_eps())` which is >= 1e-6 on every backend (1e-4 on
+    # Metal); that floor silently defeats the f64 variant's tight tolerance and makes it validate identical
+    # precision to a loose f32 assertion. The backend-aware floor is not wanted here because the f64 variant
+    # specifically exists to detect an f32-precision regression in an f64 backward pass.
+    assert y[None] == pytest.approx(y_t.item(), rel=rel_tol)
+    for i in range(n):
+        assert x.grad[i] == pytest.approx(x_t.grad[i].item(), rel=rel_tol)
+
+
+@pytest.mark.needs_torch
+@pytest.mark.parametrize("n_iter", [1, 3, 10])
+@pytest.mark.parametrize("x_val", [0.001, 0.15, 0.26, 0.399])
+@pytest.mark.parametrize("op_name,step,offset", _UNARY_OPS_PARAMS)
+@test_utils.test(require=qd.extension.adstack)
+def test_adstack_unary_loop_carried(op_name, step, offset, x_val, n_iter):
+    # Cross-check `d/dx sum_j op(x + j * step + offset)` against PyTorch autograd for a parametrized unary `op`.
+    # Each op is sampled at interior values and at the edge of its domain: `x_val = 0.001` drives the positive-path
+    # operand against 0 (log/sqrt gradients blow up there), `x_val = 0.399` drives it against 1 (asin/acos
+    # gradient `1/sqrt(1 - x^2)` diverges), and `0.15` / `0.26` are interior samples. `0.26` (rather than `0.25`)
+    # avoids `x[3] + offset = 0` at `j=0`, where `abs`'s derivative is undefined. The `(step, offset)` per op
+    # keeps the operand inside the op's domain for every `x_val` and `n_iter`, while making the operand cross zero
+    # for abs/sin/cos so the per-iteration sign actually varies.
+    #
+    # Extend the parametrize list below when a new unary op becomes differentiable through a dynamic loop: add
+    # the op together with a `(step, offset)` pair that keeps the operand inside the op's domain. `n_iter = 1`
+    # only covers the single-iteration path and will not on its own catch a regression in the multi-iteration
+    # case; `abs` additionally needs the sign-crossing operand, otherwise its piecewise-constant derivative makes
+    # the test pass trivially.
+    #
+    # Internal details: when reverse-mode AD walks a loop-variant unary op backwards it needs the exact forward
+    # operand from each iteration to compute the gradient. If the op is not in the set the AD transform knows how
+    # to back up per iteration, the operand falls back to a single slot overwritten each forward step, and the
+    # reversed loop then reads the last-iteration value for every backward step - which at `n_iter >= 3` produces
+    # a wrong gradient. That is the regression this test pins against: any unary op dropped from the supported set
+    # causes the multi-iteration parametrize variants to fail.
+    _run_unary_loop_carried(qd.f32, op_name, step, offset, x_val, n_iter, rel_tol=1e-4)
+
+
+@pytest.mark.needs_torch
+@pytest.mark.parametrize("n_iter", [1, 3, 10])
+@pytest.mark.parametrize("x_val", [0.001, 0.15, 0.26, 0.399])
+@pytest.mark.parametrize("op_name,step,offset", _UNARY_OPS_PARAMS)
+@test_utils.test(require=[qd.extension.adstack, qd.extension.data64], default_fp=qd.f64)
+def test_adstack_unary_loop_carried_f64(op_name, step, offset, x_val, n_iter):
+    _run_unary_loop_carried(qd.f64, op_name, step, offset, x_val, n_iter, rel_tol=1e-12)


### PR DESCRIPTION
# Baseline adstack regression test for `unary_collections`

> Test-only PR. Pins reverse-mode AD through a dynamic loop over every unary op currently in `NonLinearOps::unary_collections`, cross-checked against PyTorch autograd in both f32 and f64.

## TL;DR

```python
@qd.kernel
def compute():
    for i in x:
        acc = 0.0
        for j in range(n_iter):
            a = x[i] + qd.cast(j, qd_dtype) * step + offset
            acc += qd_op(a)
        y[None] += acc
```

`a` is rebuilt from scratch every iteration of the inner dynamic range-for, so the reverse pass cannot reuse a single BackupSSA-spilled copy — it has to walk the adstack. Any nonlinear unary op dropped from `unary_collections` causes the multi-iteration variants (`n_iter >= 3`) to fail with gradients off by large factors; single-iteration variants happen to pass even without promotion, which is noted in the comment.

## Why

The existing reverse-mode AD tests in `test_ad_*.py` exercise the formulas, not the per-iteration spill path. The bug class that motivates this PR is a unary op silently not being in `NonLinearOps::unary_collections` (the set that drives `AdStackAllocaJudger`'s decision to promote the operand alloca): without promotion, `BackupSSA` spills the operand to a single plain alloca that every forward iteration overwrites, so every backward step reads the last-iteration value. Gradients come out silently wrong at `n_iter >= 3`.

Pinning this explicitly with a per-op parametrize means (a) every op currently in `unary_collections` has a failing-case regression, and (b) subsequent PRs in the chain get a ready-made slot to drop new ops into.

## Surface

Single new test file: `tests/python/test_adstack.py`.

- Module-level `_UNARY_OPS_PARAMS` tuple: `(op_name, step, offset)` per op, grouped by domain (real / positive-subunit) with comments explaining the `(step, offset)` choices.
- `_run_unary_loop_carried(qd_dtype, op_name, step, offset, x_val, n_iter, rel_tol)` helper: builds the kernel, runs forward + backward, compares against a PyTorch reference in the matching dtype.
- `test_adstack_unary_loop_carried` — f32, `rel=1e-4`, decorated with `require=qd.extension.adstack`.
- `test_adstack_unary_loop_carried_f64` — f64, `rel=1e-12`, decorated with `require=[qd.extension.adstack, qd.extension.data64], default_fp=qd.f64`.

Both iterate the same `_UNARY_OPS_PARAMS × x_val ∈ {0.001, 0.15, 0.26, 0.399} × n_iter ∈ {1, 3, 10}` matrix. `0.26` (rather than `0.25`) avoids `x[3] + offset = 0` at `j=0`, where `abs`'s derivative is undefined. `abs`/`sin`/`cos` use a `(step, offset)` that makes the operand cross zero across iterations so their gradient signs actually vary (otherwise they'd pass even if dropped from the set).

## Why two separate tests instead of parametrizing dtype

`qd.cast(py_float_literal, qd.f64)` bakes the literal at `default_fp` first, then casts to f64 — so `qd.cast(0.3, qd.f64)` is not bit-equal to IEEE-754 `0.3`. The only way to get truly tight (~`1e-12`) f64 tolerance is to decorate the test with `default_fp=qd.f64` so the frontend treats Python floats as f64 from the start. That forces the two tests to be separate at the decorator level; the shared body lives in `_run_unary_loop_carried`.

## Tests

All parametrize entries pass across arm64 / Metal / Vulkan (local) and x86_64 / AMDGPU / Vulkan (amdgpu).

## Stack

Autodiff 1 of 13. Followed by #501 (tan).
