### PR TITLE
[AutoDiff] Autodiff 2: Implement derivative for tan

### DIFF
--- a/quadrants/transforms/auto_diff.cpp
+++ b/quadrants/transforms/auto_diff.cpp
@@ -41,9 +41,9 @@ class IndependentBlockMetaData {
 class NonLinearOps {
  public:
   inline static const std::set<TernaryOpType> ternary_collections{TernaryOpType::select};
-  inline static const std::set<UnaryOpType> unary_collections{UnaryOpType::abs,  UnaryOpType::sin,  UnaryOpType::cos,
-                                                              UnaryOpType::tanh, UnaryOpType::asin, UnaryOpType::acos,
-                                                              UnaryOpType::exp,  UnaryOpType::log,  UnaryOpType::sqrt};
+  inline static const std::set<UnaryOpType> unary_collections{
+      UnaryOpType::abs,  UnaryOpType::sin,  UnaryOpType::cos, UnaryOpType::tan, UnaryOpType::tanh,
+      UnaryOpType::asin, UnaryOpType::acos, UnaryOpType::exp, UnaryOpType::log, UnaryOpType::sqrt};
   inline static const std::set<BinaryOpType> binary_collections{BinaryOpType::mul, BinaryOpType::div,
                                                                 BinaryOpType::atan2, BinaryOpType::pow};
 };
@@ -975,6 +975,10 @@ class ADTransform : public IRVisitor {
     return insert<UnaryOpStmt>(UnaryOpType::log, load(op1));
   }
 
+  Stmt *tan(Stmt *op1) {
+    return insert<UnaryOpStmt>(UnaryOpType::tan, load(op1));
+  }
+
   Stmt *pow(Stmt *op1, Stmt *op2) {
     return insert<BinaryOpStmt>(BinaryOpType::pow, load(op1), load(op2));
   }
@@ -1246,11 +1250,11 @@ class MakeAdjoint : public ADTransform {
     } else if (stmt->op_type == UnaryOpType::cos) {
       accumulate(stmt->operand, negate(mul(adjoint(stmt), sin(stmt->operand))));
     } else if (stmt->op_type == UnaryOpType::tan) {
-      // The derivative of `tan` is `1 / cos^2`, which has many singular points
-      // causing NaNs. Though the NaNs are expected, it is error prone and hard
-      // to debug. Therefore we currently don't support computing derivative for
-      // `tan`.
-      QD_NOT_IMPLEMENTED;
+      // d/dx tan(x) = 1 + tan(x)^2. Recompute tan(operand) rather than reusing the forward value: the primal is
+      // per-iteration inside dynamic loops but BackupSSA only spills forward values to a single plain alloca, so
+      // reading the forward tan would use the last-iteration value in the reversed loop. The operand, in contrast,
+      // rides the adstack through its LocalLoad, so a fresh tan on it is per-iteration correct.
+      accumulate(stmt->operand, mul(adjoint(stmt), add(constant(1, stmt->ret_type), sqr(tan(stmt->operand)))));
     } else if (stmt->op_type == UnaryOpType::tanh) {
       accumulate(stmt->operand, mul(adjoint(stmt), sub(constant(1, stmt->ret_type), sqr(stmt))));
     } else if (stmt->op_type == UnaryOpType::asin) {
@@ -1841,11 +1845,10 @@ class MakeDual : public ADTransform {
     } else if (stmt->op_type == UnaryOpType::cos) {
       accumulate(stmt, negate(mul(sin(stmt->operand), dual(stmt->operand))));
     } else if (stmt->op_type == UnaryOpType::tan) {
-      // The derivative of `tan` is `1 / cos^2`, which has many singular points
-      // causing NaNs. Though the NaNs are expected, it is error prone and hard
-      // to debug. Therefore we currently don't support computing derivative for
-      // `tan`.
-      QD_NOT_IMPLEMENTED;
+      // d/dx tan(x) = 1 + tan(x)^2. Forward mode executes in primal order, so `stmt` is the
+      // current-iteration tan value - no BackupSSA stale-value concern; reusing it is per-iteration
+      // correct.
+      accumulate(stmt, mul(add(constant(1), sqr(stmt)), dual(stmt->operand)));
     } else if (stmt->op_type == UnaryOpType::tanh) {
       accumulate(stmt, mul(sub(constant(1), sqr(stmt)), dual(stmt->operand)));
     } else if (stmt->op_type == UnaryOpType::asin) {

--- a/tests/python/test_ad_basics.py
+++ b/tests/python/test_ad_basics.py
@@ -117,6 +117,7 @@ def test_poly(tifunc):
         (lambda x: qd.tanh(x), lambda x: np.tanh(x)),
         (lambda x: qd.sin(x), lambda x: np.sin(x)),
         (lambda x: qd.cos(x), lambda x: np.cos(x)),
+        (lambda x: qd.tan(x), lambda x: np.tan(x)),
         (lambda x: qd.acos(x), lambda x: np.arccos(x)),
         (lambda x: qd.asin(x), lambda x: np.arcsin(x)),
     ],

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 
 import quadrants as qd
@@ -13,6 +15,9 @@ _UNARY_OPS_PARAMS = [
     ("abs", 0.3, -0.4),
     # Ops restricted to positive/subunit operands use a smaller step and zero offset to
     # stay inside their domain across every `x_val` and `n_iter` combination.
+    # `tan` joins this positive-domain group because its singularity at pi/2 ~= 1.57 lies outside
+    # the positive-path operand's reach for every `x_val` and `n_iter` combination.
+    ("tan", 0.05, 0.0),
     ("log", 0.05, 0.0),
     ("sqrt", 0.05, 0.0),
     ("asin", 0.05, 0.0),
@@ -105,3 +110,67 @@ def test_adstack_unary_loop_carried(op_name, step, offset, x_val, n_iter):
 @test_utils.test(require=[qd.extension.adstack, qd.extension.data64], default_fp=qd.f64)
 def test_adstack_unary_loop_carried_f64(op_name, step, offset, x_val, n_iter):
     _run_unary_loop_carried(qd.f64, op_name, step, offset, x_val, n_iter, rel_tol=1e-12)
+
+
+def _run_nan_propagation(qd_dtype, op_name, x_val):
+    qd_op = getattr(qd, op_name)
+
+    x = qd.field(qd_dtype, shape=(), needs_grad=True)
+    y = qd.field(qd_dtype, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        y[None] = qd_op(x[None])
+
+    x[None] = x_val
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    x.grad[None] = 0.0
+    compute.grad()
+
+    assert math.isnan(x.grad[None])
+
+
+@pytest.mark.xfail(
+    reason="Reverse-mode NaN/Inf poisoning semantics is TBD. PyTorch propagates forward NaN into the backward graph "
+    "(e.g. `log(-0.3).backward()` gives NaN), but Quadrants evaluates the reverse formula directly and returns a "
+    "finite gradient. Either behaviour is defensible; picking a consistent rule is a separate design decision.",
+    strict=True,
+)
+@pytest.mark.parametrize(
+    "op_name,x_val",
+    [
+        # `(log, -0.3)` puts the operand outside the op's domain so the forward result is NaN. PyTorch backward
+        # poisons the gradient with NaN; Quadrants currently evaluates `1 / operand = -3.333` verbatim and returns
+        # that finite number, which this test documents as the expected-failure mode. The sqrt/asin/acos siblings
+        # cannot be parametrized here under `xfail(strict=True)` because their reverse formulas divide by
+        # `sqrt(<=0)` which is itself NaN, so Quadrants actually does return NaN there (test would XPASS and
+        # `strict=True` treats an xpass as a failure).
+        ("log", -0.3),
+    ],
+)
+@test_utils.test()
+def test_adstack_nan_propagation(op_name, x_val):
+    # Pins the open question about reverse-mode NaN propagation. For each out-of-domain input the forward output
+    # is NaN (both Quadrants and PyTorch agree). In reverse, PyTorch's backward pass propagates the NaN into the
+    # gradient (`x.grad = NaN`) because a single NaN anywhere in the forward graph poisons every dependent grad.
+    # Quadrants instead runs the analytical formula and returns a finite number. Which behaviour is "correct" is a
+    # design call; the test is marked `xfail(strict=True)` so a deliberate change of semantics in either direction
+    # forces a reviewer decision.
+    _run_nan_propagation(qd.f32, op_name, x_val)
+
+
+@pytest.mark.xfail(
+    reason="Reverse-mode NaN/Inf poisoning semantics is TBD (f64 variant). Same divergence as the f32 case: PyTorch "
+    "propagates NaN in the backward graph; Quadrants runs `1 / operand` verbatim and returns a finite number.",
+    strict=True,
+)
+@pytest.mark.parametrize("op_name,x_val", [("log", -0.3)])
+@test_utils.test(require=qd.extension.data64, default_fp=qd.f64)
+def test_adstack_nan_propagation_f64(op_name, x_val):
+    # f64 counterpart of `test_adstack_nan_propagation`. The NaN-poisoning semantics question is dtype-independent
+    # (PyTorch's backward graph propagates NaN regardless of dtype; Quadrants' reverse formula `1 / operand`
+    # produces a finite number in both f32 and f64). Parametrizing over dtype ensures a future decision to change
+    # semantics cannot accidentally fix one dtype and miss the other.
+    _run_nan_propagation(qd.f64, op_name, x_val)


### PR DESCRIPTION
# Implement derivative for `qd.tan`

> Replaces `QD_NOT_IMPLEMENTED` in reverse and forward mode, registers `tan` as non-linear so its operand rides the adstack in dynamic loops, and pins the NaN-propagation open question with a strict xfail.

## TL;DR

Reverse mode:

```cpp
} else if (stmt->op_type == UnaryOpType::tan) {
  // d/dx tan(x) = 1 + tan(x)^2. Recompute tan(operand) rather than reuse the forward stmt:
  // BackupSSA spills forward values to a single plain alloca overwritten each iteration, so
  // reading the forward `stmt` in a reversed dynamic loop would use the last-iteration value.
  // `operand` rides the adstack through its LocalLoad, so a fresh tan on it is per-iteration correct.
  accumulate(stmt->operand,
             mul(adjoint(stmt),
                 add(constant(1, stmt->ret_type), sqr(tan(stmt->operand)))));
```

Forward mode uses the same identity but reuses `stmt` (safe because MakeDual runs in primal order — no BackupSSA stale-value concern).

## Why

`qd.tan` was the only trig primitive that hit `QD_NOT_IMPLEMENTED` on differentiation. The old comment mentioned NaN concerns near `π/2`; that concern is real but orthogonal to the basic formula, and the formula itself is straightforward (`sec²(x) = 1 + tan²(x)`). The NaN-propagation semantics question is pinned separately as an xfail so a later design decision on reverse-mode NaN poisoning doesn't block implementing the common case.

## Changes

### `quadrants/transforms/auto_diff.cpp`

- `NonLinearOps::unary_collections` — add `UnaryOpType::tan`. Without this, `AdStackAllocaJudger` would not promote the operand alloca in dynamic loops, and the reverse pass would silently read the last-iteration operand at `n_iter >= 3`.
- `ADTransform::tan(Stmt*)` — new IR builder helper, mirrors the existing `sin` / `cos` helpers.
- `MakeAdjoint::visit(UnaryOpStmt*)` — new `UnaryOpType::tan` branch, `accumulate(operand, adjoint * (1 + tan(operand)²))`. Comment spells out the recompute-vs-reuse choice (so the next reviewer in the chain doesn't "fix" it back to `sqr(stmt)`).
- `MakeDual::visit(UnaryOpStmt*)` — new `UnaryOpType::tan` branch, `accumulate(stmt, (1 + sqr(stmt)) * dual(operand))`. Comment notes that forward mode runs in primal order so reusing `stmt` is safe.

### `tests/python/test_ad_basics.py`

Adds `(qd.tan, np.tan)` to `test_poly`'s parametrize — smoke coverage outside dynamic loops.

### `tests/python/test_adstack.py`

- Adds `("tan", 0.05, 0.0)` to `_UNARY_OPS_PARAMS`. Inherits the full `x_val × n_iter` matrix from Autodiff 1 in both f32 and f64.
- New `test_adstack_nan_propagation` — parametrized over `(log, -0.3)`, marked `xfail(strict=True)`. Pins the open question: PyTorch's backward pass poisons `x.grad` with NaN when the forward is NaN; Quadrants currently evaluates the analytical formula (e.g. `1 / operand = -3.33`) and returns a finite number. Either behaviour is defensible; the xfail documents the current divergence so a deliberate change of semantics in either direction forces a reviewer decision. Only `log` is parametrized — `sqrt` / `asin` / `acos` would XPASS under `strict=True` because their reverse formulas divide by `sqrt(<=0)` which is itself NaN.

## Side-effect audit

| Concern                              | Verdict |
| ------------------------------------ | ------- |
| Multi-iteration reverse-mode         | Now correct for `tan`; pinned by the extended `_UNARY_OPS_PARAMS`. |
| Forward mode                         | Correct; pinned by `test_ad_basics::test_poly` + Autodiff 3's `test_unary_forward_mode_derivative`. |
| Near-singularity behaviour           | Not addressed; bounded operand `a_max ≈ 0.999` in the adstack test keeps us away from `π/2 ≈ 1.57`. If `tan` near-singularity gradient behaviour ever becomes a concern, a dedicated test can be added. |
| NaN propagation                      | Pinned as `xfail(strict=True)` — deliberate design-decision deferral. |

## Stack

Autodiff 2 of 13. Based on #500 (baseline). Followed by #502 (tanh/exp).
