### PR TITLE
[AutoDiff] Autodiff 3: Recompute tanh/exp on the operand in the reverse pass

### DIFF
--- a/quadrants/transforms/auto_diff.cpp
+++ b/quadrants/transforms/auto_diff.cpp
@@ -979,6 +979,14 @@ class ADTransform : public IRVisitor {
     return insert<UnaryOpStmt>(UnaryOpType::tan, load(op1));
   }
 
+  Stmt *tanh(Stmt *op1) {
+    return insert<UnaryOpStmt>(UnaryOpType::tanh, load(op1));
+  }
+
+  Stmt *exp(Stmt *op1) {
+    return insert<UnaryOpStmt>(UnaryOpType::exp, load(op1));
+  }
+
   Stmt *pow(Stmt *op1, Stmt *op2) {
     return insert<BinaryOpStmt>(BinaryOpType::pow, load(op1), load(op2));
   }
@@ -1256,7 +1264,12 @@ class MakeAdjoint : public ADTransform {
       // rides the adstack through its LocalLoad, so a fresh tan on it is per-iteration correct.
       accumulate(stmt->operand, mul(adjoint(stmt), add(constant(1, stmt->ret_type), sqr(tan(stmt->operand)))));
     } else if (stmt->op_type == UnaryOpType::tanh) {
-      accumulate(stmt->operand, mul(adjoint(stmt), sub(constant(1, stmt->ret_type), sqr(stmt))));
+      // Recompute tanh(operand) in the reverse pass instead of reusing the forward stmt value. In dynamic loops
+      // BackupSSA spills the forward stmt to a single plain alloca overwritten each iteration, so the reversed
+      // loop would read the last-iteration tanh for every backward step. The operand rides the adstack through
+      // LocalLoad, so a fresh tanh on it is per-iteration correct. Trade-off: tanh is evaluated twice per
+      // iteration (once forward, once backward); caching the forward value on the adstack is a future optimization.
+      accumulate(stmt->operand, mul(adjoint(stmt), sub(constant(1, stmt->ret_type), sqr(tanh(stmt->operand)))));
     } else if (stmt->op_type == UnaryOpType::asin) {
       accumulate(stmt->operand, mul(adjoint(stmt), div(constant(1, stmt->ret_type),
                                                        sqrt(sub(constant(1, stmt->ret_type), sqr(stmt->operand))))));
@@ -1265,10 +1278,20 @@ class MakeAdjoint : public ADTransform {
                  mul(adjoint(stmt), negate(div(constant(1, stmt->ret_type),
                                                sqrt(sub(constant(1, stmt->ret_type), sqr(stmt->operand)))))));
     } else if (stmt->op_type == UnaryOpType::exp) {
-      accumulate(stmt->operand, mul(adjoint(stmt), stmt));
+      // See the tanh case above: recompute exp on the adstack-backed operand so the reversed loop sees the
+      // per-iteration value rather than the last-forward value spilled by BackupSSA. Same trade-off as tanh: exp
+      // is evaluated twice per iteration (once forward, once backward); caching the forward value on the adstack
+      // is a future optimization.
+      accumulate(stmt->operand, mul(adjoint(stmt), exp(stmt->operand)));
     } else if (stmt->op_type == UnaryOpType::log) {
+      // No recompute workaround needed: the reverse formula `1 / operand` reads `stmt->operand` directly (which
+      // is adstack-backed via LocalLoad inside dynamic loops), not the forward `log(operand)` stmt value.
       accumulate(stmt->operand, div(adjoint(stmt), stmt->operand));
     } else if (stmt->op_type == UnaryOpType::sqrt) {
+      // No recompute workaround needed: the reverse formula reads `stmt->operand` (adstack-backed via LocalLoad
+      // inside dynamic loops, gated on `unary_collections` membership) and recomputes `sqrt(operand)` from it,
+      // not the forward `sqrt(operand)` stmt value. Unlike tanh/exp this case was already operand-based before
+      // the recompute fix landed; the structure mirrors log above.
       accumulate(stmt->operand, mul(adjoint(stmt), div(constant(0.5f, stmt->ret_type), sqrt(stmt->operand))));
     } else if (stmt->op_type == UnaryOpType::rsqrt) {
       accumulate(stmt->operand, mul(adjoint(stmt), mul(constant(-0.5f, stmt->ret_type),

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -7,12 +7,17 @@ import quadrants as qd
 from tests import test_utils
 
 _UNARY_OPS_PARAMS = [
-    # Ops whose domain is all real values use a step/offset that makes the operand cross
-    # zero as `j` advances, so the per-iteration sign varies. `abs` especially needs this:
-    # its derivative is piecewise-constant, so a non-crossing operand would pass trivially.
+    # Ops whose domain is all real values share a single `(step, offset)` pair that keeps the operand inside
+    # the domain and, for `abs`/`sin`/`cos`, forces it to cross zero as `j` advances so the per-iteration
+    # gradient sign actually varies. `abs` especially needs the sign-crossing: its derivative is piecewise-
+    # constant, so a non-crossing operand would pass trivially. `exp`/`tanh` do not need the crossing (their
+    # derivatives stay positive) but the same parameters work because their domain is all reals; they live
+    # in this group on that basis alone.
     ("sin", 0.3, -0.4),
     ("cos", 0.3, -0.4),
     ("abs", 0.3, -0.4),
+    ("tanh", 0.3, -0.4),
+    ("exp", 0.3, -0.4),
     # Ops restricted to positive/subunit operands use a smaller step and zero offset to
     # stay inside their domain across every `x_val` and `n_iter` combination.
     # `tan` joins this positive-domain group because its singularity at pi/2 ~= 1.57 lies outside
@@ -110,6 +115,51 @@ def test_adstack_unary_loop_carried(op_name, step, offset, x_val, n_iter):
 @test_utils.test(require=[qd.extension.adstack, qd.extension.data64], default_fp=qd.f64)
 def test_adstack_unary_loop_carried_f64(op_name, step, offset, x_val, n_iter):
     _run_unary_loop_carried(qd.f64, op_name, step, offset, x_val, n_iter, rel_tol=1e-12)
+
+
+@pytest.mark.needs_torch
+@pytest.mark.parametrize(
+    "op_name",
+    # Pins MakeDual (forward mode) for the ops whose reverse formulas were just patched (tan/tanh/exp) plus the
+    # two audit-adjacent operand-based ops (log/sqrt). Forward mode is argued safe-by-construction because it
+    # runs in primal order and does not rely on BackupSSA spilling, but that invariant is not itself tested by
+    # the reverse-mode regression above; this test pins it. Note the asymmetry with MakeAdjoint::tanh / exp:
+    # this PR's reverse-mode recompute of `tanh(stmt->operand)` / `exp(stmt->operand)` has a detailed comment
+    # explaining why reusing the forward `stmt` would be wrong under BackupSSA; the forward-mode formulas
+    # reuse the same `stmt` value without a safety comment because MakeDual runs in primal order, so `stmt`
+    # is the current-iteration value. This test pins that forward-order invariant.
+    ["tan", "tanh", "exp", "log", "sqrt"],
+)
+@test_utils.test()
+def test_unary_forward_mode_derivative(op_name):
+    import torch
+
+    N = 4
+    x = qd.field(qd.f32, shape=N)
+    loss = qd.field(qd.f32, shape=())
+    qd.root.lazy_dual()
+
+    qd_op = getattr(qd, op_name)
+    torch_op = getattr(torch, op_name)
+
+    @qd.kernel
+    def kern():
+        for i in x:
+            loss[None] += qd_op(x[i])
+
+    for i in range(N):
+        x[i] = 0.1 * (i + 1)
+
+    seed = [1.0] * N
+    with qd.ad.FwdMode(loss=loss, param=x, seed=seed):
+        kern()
+
+    x_t = torch.tensor([0.1 * (i + 1) for i in range(N)], dtype=torch.float32, requires_grad=True)
+    l_t = torch_op(x_t).sum()
+    l_t.backward()
+    expected = float(x_t.grad.sum().item())
+
+    assert loss.dual[None] == test_utils.approx(expected, rel=1e-4)
 
 
 def _run_nan_propagation(qd_dtype, op_name, x_val):


### PR DESCRIPTION
# Recompute `tanh` / `exp` on the operand in the reverse pass

> Fixes silently-wrong gradients at `n_iter >= 3` in dynamic loops by recomputing `tanh(operand)` / `exp(operand)` instead of reusing the forward `UnaryOpStmt` value. Same root cause and same fix pattern as Autodiff 2 applied to two more ops.

## TL;DR

Reverse mode, before / after:

```diff
 } else if (stmt->op_type == UnaryOpType::tanh) {
-  accumulate(stmt->operand, mul(adjoint(stmt), sub(constant(1), sqr(stmt))));
+  // Recompute tanh(operand) in the reverse pass: BackupSSA spills the forward `stmt` to a
+  // single plain alloca overwritten each iteration, so reading it from a reversed dynamic loop
+  // would use the last-iteration value. `operand` rides the adstack, so a fresh tanh on it is
+  // per-iteration correct. Trade-off: tanh is evaluated twice per iteration (forward + backward);
+  // caching the forward value on the adstack is a future optimization.
+  accumulate(stmt->operand, mul(adjoint(stmt), sub(constant(1), sqr(tanh(stmt->operand)))));
 } else if (stmt->op_type == UnaryOpType::exp) {
-  accumulate(stmt->operand, mul(adjoint(stmt), stmt));
+  // See the tanh case above.
+  accumulate(stmt->operand, mul(adjoint(stmt), exp(stmt->operand)));
```

## Why

Both ops were already in `NonLinearOps::unary_collections`, so their operand allocas get promoted to `AdStackAllocaStmt` in dynamic loops. But the reverse-mode formulas read the forward `stmt`:
- `tanh`: `1 - tanh(x)²`, where `tanh(x)` was substituted with the forward `stmt`.
- `exp`: `exp(x)`, where `exp(x)` was substituted with the forward `stmt`.

`BackupSSA` spills each forward `UnaryOpStmt` value to a single plain alloca for later reverse-pass reads. Inside a dynamic loop that alloca gets overwritten every forward iteration, so by the time the reversed loop reads it, it holds the last-iteration value regardless of which reverse iteration is running. Gradients come out off by a factor proportional to the op's non-linearity across the iteration range.

Recomputing from the operand (which rides the adstack through its `LocalLoad`) makes the reverse pass per-iteration correct.

## Changes

### `quadrants/transforms/auto_diff.cpp`

- `ADTransform::tanh(Stmt*)` and `ADTransform::exp(Stmt*)` — new IR builder helpers, mirroring the existing `ADTransform::tan` helper from Autodiff 2.
- `MakeAdjoint::visit(UnaryOpStmt*)`:
  - `UnaryOpType::tanh` branch — `sqr(stmt)` → `sqr(tanh(stmt->operand))`.
  - `UnaryOpType::exp` branch — `stmt` → `exp(stmt->operand)`.
  - **`UnaryOpType::log` and `UnaryOpType::sqrt` branches** — no code change. New comments spell out explicitly that these do **not** need the same recompute: their reverse formulas already read `stmt->operand` directly (not the forward `stmt`), so `BackupSSA` is not in the critical path. Comments mirror the `log` block's phrasing so a future reviewer can quickly distinguish "already operand-based" from "needs the recompute workaround".

### `tests/python/test_adstack.py`

- `_UNARY_OPS_PARAMS`: add `("tanh", 0.3, -0.4)` and `("exp", 0.3, -0.4)` to the real-domain group. The parametrize-level comment is rewritten to distinguish the sign-crossing requirement for `abs` / `sin` / `cos` from the mere-domain requirement for `tanh` / `exp` (both groups share the same `(step, offset)` because their domains are all reals; `tanh` / `exp` don't need the zero-crossing but it doesn't hurt them).
- New `test_unary_forward_mode_derivative` — pins `MakeDual` (forward mode) for `tan` / `tanh` / `exp` plus the audit-adjacent `log` / `sqrt`. Forward mode is safe-by-primal-order (no BackupSSA stale-value concern) but that invariant wasn't tested anywhere; now it is.

## Side-effect audit

| Concern                                          | Verdict |
| ------------------------------------------------ | ------- |
| Multi-iteration reverse-mode for `tanh` / `exp`  | Fixed; regression pinned by `_UNARY_OPS_PARAMS`. |
| `log` / `sqrt` correctness                       | Unchanged (both were already operand-based). Comments make this explicit. |
| Forward mode                                     | Unchanged; pinned by new `test_unary_forward_mode_derivative`. |
| Recompute cost                                   | `tanh` / `exp` now evaluated twice per iteration. For `exp` in hot ML kernels this may be measurable; future optimization would cache the forward value on the adstack. |

## Stack

Autodiff 3 of 13. Based on #501 (tan). Followed by #503 (rsqrt).
