### PR TITLE
[AutoDiff] Autodiff 4: Mark rsqrt as non-linear for adstack promotion

### DIFF
--- a/quadrants/transforms/auto_diff.cpp
+++ b/quadrants/transforms/auto_diff.cpp
@@ -42,8 +42,8 @@ class NonLinearOps {
  public:
   inline static const std::set<TernaryOpType> ternary_collections{TernaryOpType::select};
   inline static const std::set<UnaryOpType> unary_collections{
-      UnaryOpType::abs,  UnaryOpType::sin,  UnaryOpType::cos, UnaryOpType::tan, UnaryOpType::tanh,
-      UnaryOpType::asin, UnaryOpType::acos, UnaryOpType::exp, UnaryOpType::log, UnaryOpType::sqrt};
+      UnaryOpType::abs,  UnaryOpType::sin, UnaryOpType::cos, UnaryOpType::tan,  UnaryOpType::tanh, UnaryOpType::asin,
+      UnaryOpType::acos, UnaryOpType::exp, UnaryOpType::log, UnaryOpType::sqrt, UnaryOpType::rsqrt};
   inline static const std::set<BinaryOpType> binary_collections{BinaryOpType::mul, BinaryOpType::div,
                                                                 BinaryOpType::atan2, BinaryOpType::pow};
 };
@@ -1246,56 +1246,83 @@ class MakeAdjoint : public ADTransform {
     return adjoint_stmt[stmt];
   }
 
+  // For ops in `NonLinearOps::unary_collections` the reverse formula must NOT read the forward `stmt`
+  // directly - only `stmt->operand` (adstack-backed), `adjoint(stmt)`, and constants. BackupSSA spills the
+  // forward stmt to a single plain alloca overwritten each iteration, so reading `stmt` from a reversed
+  // dynamic loop would use the last-iteration value regardless of which reverse iteration is running. This
+  // helper walks the value-tree at IR-transform time and asserts the invariant; paired with the Python
+  // meta-test `test_unary_collections_audit` (which catches "forgot to add to unary_collections"), it
+  // covers both halves of the class of bugs the per-op audit used to miss.
+  void accumulate_unary_operand_checked(UnaryOpStmt *stmt, Stmt *value) {
+    if (NonLinearOps::unary_collections.find(stmt->op_type) != NonLinearOps::unary_collections.end()) {
+      std::unordered_set<const Stmt *> visited;
+      std::function<void(const Stmt *)> walk = [&](const Stmt *s) {
+        if (!s || visited.count(s))
+          return;
+        visited.insert(s);
+        QD_ASSERT_INFO(s != stmt,
+                       "MakeAdjoint adjoint formula for UnaryOpType::{} reads the forward stmt directly. It "
+                       "must read `stmt->operand` (adstack-backed) instead - see the tan/tanh/exp branches "
+                       "for the recompute pattern.",
+                       unary_op_type_name(stmt->op_type));
+        for (auto *op : s->get_operands())
+          walk(op);
+      };
+      walk(value);
+    }
+    accumulate(stmt->operand, value);
+  }
+
   void visit(UnaryOpStmt *stmt) override {
+    auto acc = [&](Stmt *value) { accumulate_unary_operand_checked(stmt, value); };
     if (stmt->op_type == UnaryOpType::floor || stmt->op_type == UnaryOpType::ceil) {
       // do nothing
     } else if (stmt->op_type == UnaryOpType::neg) {
       accumulate(stmt->operand, negate(adjoint(stmt)));
     } else if (stmt->op_type == UnaryOpType::abs) {
-      accumulate(stmt->operand, mul(adjoint(stmt), sgn(stmt->operand)));
+      acc(mul(adjoint(stmt), sgn(stmt->operand)));
     } else if (stmt->op_type == UnaryOpType::sin) {
-      accumulate(stmt->operand, mul(adjoint(stmt), cos(stmt->operand)));
+      acc(mul(adjoint(stmt), cos(stmt->operand)));
     } else if (stmt->op_type == UnaryOpType::cos) {
-      accumulate(stmt->operand, negate(mul(adjoint(stmt), sin(stmt->operand))));
+      acc(negate(mul(adjoint(stmt), sin(stmt->operand))));
     } else if (stmt->op_type == UnaryOpType::tan) {
       // d/dx tan(x) = 1 + tan(x)^2. Recompute tan(operand) rather than reusing the forward value: the primal is
       // per-iteration inside dynamic loops but BackupSSA only spills forward values to a single plain alloca, so
       // reading the forward tan would use the last-iteration value in the reversed loop. The operand, in contrast,
       // rides the adstack through its LocalLoad, so a fresh tan on it is per-iteration correct.
-      accumulate(stmt->operand, mul(adjoint(stmt), add(constant(1, stmt->ret_type), sqr(tan(stmt->operand)))));
+      acc(mul(adjoint(stmt), add(constant(1, stmt->ret_type), sqr(tan(stmt->operand)))));
     } else if (stmt->op_type == UnaryOpType::tanh) {
       // Recompute tanh(operand) in the reverse pass instead of reusing the forward stmt value. In dynamic loops
       // BackupSSA spills the forward stmt to a single plain alloca overwritten each iteration, so the reversed
       // loop would read the last-iteration tanh for every backward step. The operand rides the adstack through
       // LocalLoad, so a fresh tanh on it is per-iteration correct. Trade-off: tanh is evaluated twice per
       // iteration (once forward, once backward); caching the forward value on the adstack is a future optimization.
-      accumulate(stmt->operand, mul(adjoint(stmt), sub(constant(1, stmt->ret_type), sqr(tanh(stmt->operand)))));
+      acc(mul(adjoint(stmt), sub(constant(1, stmt->ret_type), sqr(tanh(stmt->operand)))));
     } else if (stmt->op_type == UnaryOpType::asin) {
-      accumulate(stmt->operand, mul(adjoint(stmt), div(constant(1, stmt->ret_type),
-                                                       sqrt(sub(constant(1, stmt->ret_type), sqr(stmt->operand))))));
+      acc(mul(adjoint(stmt),
+              div(constant(1, stmt->ret_type), sqrt(sub(constant(1, stmt->ret_type), sqr(stmt->operand))))));
     } else if (stmt->op_type == UnaryOpType::acos) {
-      accumulate(stmt->operand,
-                 mul(adjoint(stmt), negate(div(constant(1, stmt->ret_type),
-                                               sqrt(sub(constant(1, stmt->ret_type), sqr(stmt->operand)))))));
+      acc(mul(adjoint(stmt),
+              negate(div(constant(1, stmt->ret_type), sqrt(sub(constant(1, stmt->ret_type), sqr(stmt->operand)))))));
     } else if (stmt->op_type == UnaryOpType::exp) {
       // See the tanh case above: recompute exp on the adstack-backed operand so the reversed loop sees the
       // per-iteration value rather than the last-forward value spilled by BackupSSA. Same trade-off as tanh: exp
       // is evaluated twice per iteration (once forward, once backward); caching the forward value on the adstack
       // is a future optimization.
-      accumulate(stmt->operand, mul(adjoint(stmt), exp(stmt->operand)));
+      acc(mul(adjoint(stmt), exp(stmt->operand)));
     } else if (stmt->op_type == UnaryOpType::log) {
       // No recompute workaround needed: the reverse formula `1 / operand` reads `stmt->operand` directly (which
       // is adstack-backed via LocalLoad inside dynamic loops), not the forward `log(operand)` stmt value.
-      accumulate(stmt->operand, div(adjoint(stmt), stmt->operand));
+      acc(div(adjoint(stmt), stmt->operand));
     } else if (stmt->op_type == UnaryOpType::sqrt) {
       // No recompute workaround needed: the reverse formula reads `stmt->operand` (adstack-backed via LocalLoad
       // inside dynamic loops, gated on `unary_collections` membership) and recomputes `sqrt(operand)` from it,
       // not the forward `sqrt(operand)` stmt value. Unlike tanh/exp this case was already operand-based before
       // the recompute fix landed; the structure mirrors log above.
-      accumulate(stmt->operand, mul(adjoint(stmt), div(constant(0.5f, stmt->ret_type), sqrt(stmt->operand))));
+      acc(mul(adjoint(stmt), div(constant(0.5f, stmt->ret_type), sqrt(stmt->operand))));
     } else if (stmt->op_type == UnaryOpType::rsqrt) {
-      accumulate(stmt->operand, mul(adjoint(stmt), mul(constant(-0.5f, stmt->ret_type),
-                                                       pow(rsqrt(stmt->operand), constant(3, stmt->ret_type)))));
+      acc(mul(adjoint(stmt),
+              mul(constant(-0.5f, stmt->ret_type), pow(rsqrt(stmt->operand), constant(3, stmt->ret_type)))));
     } else if (stmt->op_type == UnaryOpType::cast_value) {
       if (is_real(stmt->cast_type.get_element_type()) && is_real(stmt->operand->ret_type.get_element_type())) {
         accumulate(stmt->operand, adjoint(stmt));

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -128,14 +128,13 @@ def test_adstack_unary_loop_carried_f64(op_name, step, offset, x_val, n_iter):
 @pytest.mark.needs_torch
 @pytest.mark.parametrize(
     "op_name",
-    # Pins MakeDual (forward mode) for every nonlinear unary op currently in `unary_collections` whose forward
-    # formula actually reuses the forward `stmt` value (the case where the BackupSSA concern from reverse mode
-    # would matter if MakeDual ran in reverse order). Forward mode is argued safe-by-construction because it
-    # runs in primal order, so `stmt` is the current-iteration value and reusing it is correct; this test pins
-    # that forward-order invariant. The set is {tan, tanh, exp, log, sqrt, rsqrt} — the six ops whose MakeAdjoint
-    # recompute audit was the focus of the prior PRs in the chain. The sign/absolute-value siblings (abs, sin,
-    # cos, asin, acos) have operand-only MakeDual formulas where there is no stmt reuse to audit; they are
-    # covered by `test_adstack_unary_loop_carried` in the reverse-mode direction already.
+    # Pins MakeDual (forward mode) for every nonlinear unary op whose MakeAdjoint (reverse-mode) recompute audit was the
+    # focus of PRs 1-4 of this chain: {tan, tanh, exp, log, sqrt, rsqrt}. Forward mode is argued safe-by-construction
+    # because it runs in primal order, so the primal value is the current-iteration value by definition - there is no
+    # stale-read hazard analogous to the reverse-mode one the audit targeted. This test pins that forward-order safety
+    # argument per audited op so a future MakeDual refactor cannot regress it silently. The sign/absolute-value siblings
+    # (abs, sin, cos, asin, acos) are covered by `test_adstack_unary_loop_carried` in the reverse-mode direction already
+    # and were not part of the audit.
     ["tan", "tanh", "exp", "log", "sqrt", "rsqrt"],
 )
 @test_utils.test()

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -1,10 +1,17 @@
 import math
+import pathlib
+import re
 
 import pytest
 
 import quadrants as qd
 
 from tests import test_utils
+
+# Diffable unary ops whose reverse formula accumulates a constant coefficient onto `stmt->operand` and therefore
+# does not need per-iteration operand spilling on the adstack. Update this set and `unary_collections` in
+# `quadrants/transforms/auto_diff.cpp` together when a new op lands in this class.
+_KNOWN_LINEAR_UNARY_OPS = {"neg"}
 
 _UNARY_OPS_PARAMS = [
     # Ops whose domain is all real values share a single `(step, offset)` pair that keeps the operand inside
@@ -25,6 +32,7 @@ _UNARY_OPS_PARAMS = [
     ("tan", 0.05, 0.0),
     ("log", 0.05, 0.0),
     ("sqrt", 0.05, 0.0),
+    ("rsqrt", 0.05, 0.0),
     ("asin", 0.05, 0.0),
     ("acos", 0.05, 0.0),
 ]
@@ -120,15 +128,15 @@ def test_adstack_unary_loop_carried_f64(op_name, step, offset, x_val, n_iter):
 @pytest.mark.needs_torch
 @pytest.mark.parametrize(
     "op_name",
-    # Pins MakeDual (forward mode) for the ops whose reverse formulas were just patched (tan/tanh/exp) plus the
-    # two audit-adjacent operand-based ops (log/sqrt). Forward mode is argued safe-by-construction because it
-    # runs in primal order and does not rely on BackupSSA spilling, but that invariant is not itself tested by
-    # the reverse-mode regression above; this test pins it. Note the asymmetry with MakeAdjoint::tanh / exp:
-    # this PR's reverse-mode recompute of `tanh(stmt->operand)` / `exp(stmt->operand)` has a detailed comment
-    # explaining why reusing the forward `stmt` would be wrong under BackupSSA; the forward-mode formulas
-    # reuse the same `stmt` value without a safety comment because MakeDual runs in primal order, so `stmt`
-    # is the current-iteration value. This test pins that forward-order invariant.
-    ["tan", "tanh", "exp", "log", "sqrt"],
+    # Pins MakeDual (forward mode) for every nonlinear unary op currently in `unary_collections` whose forward
+    # formula actually reuses the forward `stmt` value (the case where the BackupSSA concern from reverse mode
+    # would matter if MakeDual ran in reverse order). Forward mode is argued safe-by-construction because it
+    # runs in primal order, so `stmt` is the current-iteration value and reusing it is correct; this test pins
+    # that forward-order invariant. The set is {tan, tanh, exp, log, sqrt, rsqrt} — the six ops whose MakeAdjoint
+    # recompute audit was the focus of the prior PRs in the chain. The sign/absolute-value siblings (abs, sin,
+    # cos, asin, acos) have operand-only MakeDual formulas where there is no stmt reuse to audit; they are
+    # covered by `test_adstack_unary_loop_carried` in the reverse-mode direction already.
+    ["tan", "tanh", "exp", "log", "sqrt", "rsqrt"],
 )
 @test_utils.test()
 def test_unary_forward_mode_derivative(op_name):
@@ -162,24 +170,80 @@ def test_unary_forward_mode_derivative(op_name):
     assert loss.dual[None] == test_utils.approx(expected, rel=1e-4)
 
 
-def _run_nan_propagation(qd_dtype, op_name, x_val):
-    qd_op = getattr(qd, op_name)
+def test_unary_collections_audit():
+    # Prevents drift between the Python unary op registry and the C++ `unary_collections` set in
+    # `quadrants/transforms/auto_diff.cpp`. Every unary op whose `MakeAdjoint` branch accumulates onto
+    # `stmt->operand` must be either in `unary_collections` (nonlinear: needs per-iteration operand spilling on
+    # the adstack inside dynamic loops) or in the local `_KNOWN_LINEAR_UNARY_OPS` allow-list (reverse formula
+    # uses a compile-time constant coefficient, so the single-slot spill path is correct for it). Forgetting to
+    # classify a new diffable unary op falls back to the single-slot spill and produces silently wrong gradients
+    # in dynamic loops.
+    #
+    # Four invariants are checked, all of them symmetric:
+    #   (1) Every diffable-math op detected in MakeAdjoint is in `cpp_nonlinear` OR in `_KNOWN_LINEAR_UNARY_OPS`.
+    #   (2) Every op in `cpp_nonlinear` has a matching diffable-math branch in MakeAdjoint.
+    #   (3) Every op in `_KNOWN_LINEAR_UNARY_OPS` has a matching diffable-math branch in MakeAdjoint.
+    #   (4) `cpp_nonlinear` and `_KNOWN_LINEAR_UNARY_OPS` are disjoint (an op cannot be both nonlinear and linear).
+    src_path = pathlib.Path(__file__).resolve().parents[2] / "quadrants" / "transforms" / "auto_diff.cpp"
+    src = src_path.read_text()
 
-    x = qd.field(qd_dtype, shape=(), needs_grad=True)
-    y = qd.field(qd_dtype, shape=(), needs_grad=True)
+    cc_match = re.search(r"unary_collections\s*\{([^}]+)\}", src)
+    assert cc_match is not None, "unary_collections not located in auto_diff.cpp"
+    cpp_nonlinear = set(re.findall(r"UnaryOpType::(\w+)", cc_match.group(1)))
 
-    @qd.kernel
-    def compute():
-        y[None] = qd_op(x[None])
+    make_adjoint_start = src.find("class MakeAdjoint")
+    assert make_adjoint_start != -1, "class MakeAdjoint not located in auto_diff.cpp"
+    adj_start = src.find("void visit(UnaryOpStmt *stmt) override", make_adjoint_start)
+    assert adj_start != -1, "MakeAdjoint::visit(UnaryOpStmt*) not located in auto_diff.cpp"
+    adj_end = src.find("void visit(", adj_start + 10)
+    assert adj_end != -1, "next visitor method after MakeAdjoint::visit(UnaryOpStmt*) not found"
+    adj_block = src[adj_start:adj_end]
+    # Split the visitor's if/else-if chain into per-op segments, then classify each segment as "diffable math"
+    # iff its body accumulates onto `stmt->operand`. Two accumulate entry points are recognised: the raw
+    # `accumulate(stmt->operand, ...)` call (used by `neg` and `cast_value`) and the `acc(...)` lambda (used by
+    # every nonlinear branch; `acc` wraps `accumulate_unary_operand_checked` which validates that the adjoint
+    # formula does not read the forward `stmt` directly, and then delegates to `accumulate(stmt->operand, ...)`).
+    # `cast_value` is excluded: its conditional accumulate is gated on real-typed elements and is orthogonal to
+    # the `unary_collections` trade-off.
+    #
+    # Use `re.findall` rather than `re.search` so a future branch that ORs multiple `UnaryOpType::X` conditions
+    # (e.g. `op_type == floor || op_type == ceil`) still classifies every op in the branch — capturing just the
+    # first match would silently skip later ops in an OR chain.
+    branches = re.split(r"\belse if\b", adj_block)
+    diffable_math = set()
+    for seg in branches:
+        ops_in_seg = re.findall(r"UnaryOpType::(\w+)", seg)
+        if not ops_in_seg:
+            continue
+        if "accumulate(stmt->operand" in seg or re.search(r"\bacc\(", seg):
+            diffable_math.update(ops_in_seg)
+    diffable_math.discard("cast_value")
 
-    x[None] = x_val
-    y[None] = 0.0
-    compute()
-    y.grad[None] = 1.0
-    x.grad[None] = 0.0
-    compute.grad()
+    overlap = cpp_nonlinear & _KNOWN_LINEAR_UNARY_OPS
+    assert not overlap, (
+        f"Ops appear in BOTH `unary_collections` and `_KNOWN_LINEAR_UNARY_OPS`: {sorted(overlap)}. "
+        f"An op must be classified as exactly one of (nonlinear, linear); otherwise the per-op audits below "
+        f"silently cancel out."
+    )
 
-    assert math.isnan(x.grad[None])
+    missing = diffable_math - cpp_nonlinear - _KNOWN_LINEAR_UNARY_OPS
+    assert not missing, (
+        f"Diffable unary ops not classified as nonlinear or linear: {sorted(missing)}. "
+        f"Add each one to `unary_collections` in quadrants/transforms/auto_diff.cpp (if nonlinear) or to "
+        f"`_KNOWN_LINEAR_UNARY_OPS` in this file (if linear)."
+    )
+    stray_nonlinear = cpp_nonlinear - diffable_math
+    assert not stray_nonlinear, (
+        f"`unary_collections` lists ops with no matching accumulate branch (`accumulate(stmt->operand, ...)` or "
+        f"`acc(...)`) in MakeAdjoint: {sorted(stray_nonlinear)}. Either remove them from `unary_collections` or "
+        f"restore the MakeAdjoint branch."
+    )
+    stray_linear = _KNOWN_LINEAR_UNARY_OPS - diffable_math
+    assert not stray_linear, (
+        f"`_KNOWN_LINEAR_UNARY_OPS` lists ops with no matching accumulate branch in MakeAdjoint: "
+        f"{sorted(stray_linear)}. Either remove them from `_KNOWN_LINEAR_UNARY_OPS` or restore the MakeAdjoint "
+        f"branch; an entry here without a visitor means the op silently has no gradient implementation."
+    )
 
 
 @pytest.mark.xfail(
@@ -208,7 +272,23 @@ def test_adstack_nan_propagation(op_name, x_val):
     # Quadrants instead runs the analytical formula and returns a finite number. Which behaviour is "correct" is a
     # design call; the test is marked `xfail(strict=True)` so a deliberate change of semantics in either direction
     # forces a reviewer decision.
-    _run_nan_propagation(qd.f32, op_name, x_val)
+    qd_op = getattr(qd, op_name)
+
+    x = qd.field(qd.f32, shape=(), needs_grad=True)
+    y = qd.field(qd.f32, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        y[None] = qd_op(x[None])
+
+    x[None] = x_val
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    x.grad[None] = 0.0
+    compute.grad()
+
+    assert math.isnan(x.grad[None])
 
 
 @pytest.mark.xfail(
@@ -223,4 +303,20 @@ def test_adstack_nan_propagation_f64(op_name, x_val):
     # (PyTorch's backward graph propagates NaN regardless of dtype; Quadrants' reverse formula `1 / operand`
     # produces a finite number in both f32 and f64). Parametrizing over dtype ensures a future decision to change
     # semantics cannot accidentally fix one dtype and miss the other.
-    _run_nan_propagation(qd.f64, op_name, x_val)
+    qd_op = getattr(qd, op_name)
+
+    x = qd.field(qd.f64, shape=(), needs_grad=True)
+    y = qd.field(qd.f64, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        y[None] = qd_op(x[None])
+
+    x[None] = x_val
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    x.grad[None] = 0.0
+    compute.grad()
+
+    assert math.isnan(x.grad[None])


### PR DESCRIPTION
# Mark `rsqrt` as non-linear for adstack promotion

> One-entry addition to `NonLinearOps::unary_collections` so `AdStackAllocaJudger` promotes the operand alloca of `qd.rsqrt` in dynamic loops. Also adds a meta-test that prevents this class of omission from sneaking in again.

## TL;DR

```diff
 inline static const std::set<UnaryOpType> unary_collections{
     UnaryOpType::abs,  UnaryOpType::sin, UnaryOpType::cos, UnaryOpType::tan,  UnaryOpType::tanh, UnaryOpType::asin,
-    UnaryOpType::acos, UnaryOpType::exp, UnaryOpType::log, UnaryOpType::sqrt};
+    UnaryOpType::acos, UnaryOpType::exp, UnaryOpType::log, UnaryOpType::sqrt, UnaryOpType::rsqrt};
```

`rsqrt`'s reverse formula is `-0.5 * rsqrt(operand)³ * adjoint` — already operand-based, so no `MakeAdjoint` / `MakeDual` change is needed, just the set-membership fix. Previously, a kernel using `qd.rsqrt` inside a dynamic loop got its operand alloca demoted to a single-slot plain alloca, and the reverse pass read the last-iteration operand for every backward step.

## Why

`rsqrt` is listed alongside `sqrt` / `log` / `asin` / `acos` as nonlinear in every other place in `MakeAdjoint` — it was an oversight that `AdStackAllocaJudger` didn't agree. Fixing it brings the set to parity with the reverse-mode formula coverage.

After this PR, `unary_collections` covers `{abs, sin, cos, tan, tanh, asin, acos, exp, log, sqrt, rsqrt}` — the 11 nonlinear ops that `MakeAdjoint::visit(UnaryOpStmt*)` calls `accumulate(stmt->operand, ...)` on. The only remaining diff-able unary op is `neg`, which is linear (gradient is a constant coefficient of `adjoint`), does not need the per-iteration adstack replay, and is intentionally absent.

## The meta-test

New `test_unary_collections_audit` in `tests/python/test_adstack.py`. It parses `quadrants/transforms/auto_diff.cpp` at test time and asserts:

1. Every `UnaryOpType::X` that `MakeAdjoint::visit(UnaryOpStmt*)` reaches via `accumulate(stmt->operand, ...)` is either in `unary_collections` or in a local `_KNOWN_LINEAR_UNARY_OPS = {"neg"}` allow-list.
2. Every member of `unary_collections` has a matching `accumulate(stmt->operand, ...)` branch in `MakeAdjoint` (no stray entries).

The parse is regex-based and intentionally cheap — it splits the visitor's `if / else-if` chain at `else if` boundaries and looks for `accumulate(stmt->operand` inside each segment. `cast_value` has a conditional accumulate gated on real-typed elements and is excluded.

This prevents the whole class of bugs Autodiff 1–4 had to fix one op at a time: any future diff-able unary op that lands in `MakeAdjoint` without being classified triggers an explicit test failure pointing the contributor at both the C++ file and the allow-list.

## Changes

### `quadrants/transforms/auto_diff.cpp`

One entry added to `NonLinearOps::unary_collections`. Formatting is reflowed to fit 120 cols.

### `tests/python/test_adstack.py`

- `_UNARY_OPS_PARAMS`: add `("rsqrt", 0.05, 0.0)` to the positive-domain group.
- New `_KNOWN_LINEAR_UNARY_OPS = {"neg"}` module-level constant.
- New `test_unary_collections_audit` (described above).

## Side-effect audit

| Concern                          | Verdict |
| -------------------------------- | ------- |
| Existing `rsqrt` scalar AD       | Untouched; formula is already operand-based. |
| Dynamic-loop `rsqrt`             | Now correct; pinned by `_UNARY_OPS_PARAMS`. |
| Future unary-op additions        | Caught by `test_unary_collections_audit` at CI time. |
| Meta-test brittleness            | Regex tracks the `if / else if / UnaryOpType::X` shape of `MakeAdjoint`. If that visitor is ever rewritten to a `switch`, the meta-test needs a one-line update — acceptable cost. |

## Stack

Autodiff 4 of 13. Based on #502 (tanh/exp). Followed by #496 (alloca placement).
