### PR TITLE
[SPIRV] Vulkan SPIR-V correctness: atomic-view aliasing, PSB stride, narrow storage caps, u1 cast, per-init layer recheck

### DIFF
--- a/quadrants/codegen/spirv/detail/spirv_codegen.h
+++ b/quadrants/codegen/spirv/detail/spirv_codegen.h
@@ -17,6 +17,8 @@
 #include <spirv-tools/libspirv.hpp>
 #include <spirv-tools/optimizer.hpp>
 
+#include <unordered_set>
+
 namespace quadrants::lang {
 namespace spirv {
 namespace detail {
@@ -154,6 +156,14 @@ class TaskCodegen : public IRVisitor {
   std::shared_ptr<spirv::IRBuilder> ir_;  // spirv binary code builder
   std::unordered_map<std::pair<BufferInfo, int>, spirv::Value, BufferInfoTypeTupleHasher> buffer_value_map_;
   std::unordered_map<std::pair<BufferInfo, int>, uint32_t, BufferInfoTypeTupleHasher> buffer_binding_map_;
+  // All existing type views of each underlying storage buffer, in creation order. When a second or later
+  // view is minted in `get_buffer_value`, we decorate every entry here with `Aliased` so the driver is
+  // forbidden from assuming the views don't alias -- otherwise a plain load through one view is not
+  // ordered against an atomic through another view of the same memory, silently zeroing gradients on the
+  // load-and-clear reverse-mode pattern. See `get_buffer_value` for the decoration site and the commit
+  // message for the full failure matrix.
+  std::unordered_map<BufferInfo, std::vector<spirv::Value>, BufferInfoHasher> buffer_views_by_buffer_;
+  std::unordered_set<uint32_t> aliased_decorated_buffer_ids_;
   std::vector<spirv::Value> shared_array_binds_;
   spirv::Value kernel_function_;
   spirv::Label kernel_return_label_;

--- a/quadrants/codegen/spirv/spirv_codegen.cpp
+++ b/quadrants/codegen/spirv/spirv_codegen.cpp
@@ -2152,9 +2152,24 @@ void TaskCodegen::store_buffer(const Stmt *ptr, spirv::Value val) {
   }
 
   auto buf_ptr = at_buffer(ptr, ti_buffer_type);
-  auto val_bits = val.stype.dt == ti_buffer_type
-                      ? val
-                      : ir_->make_value(spv::OpBitcast, ir_->get_primitive_type(ti_buffer_type), val);
+  spirv::Value val_bits;
+  if (val.stype.dt == ti_buffer_type) {
+    val_bits = val;
+  } else if (val.stype.dt->is_primitive(PrimitiveTypeID::u1)) {
+    // SPIR-V `OpBitcast` rejects bool operands (spec: operand must be numerical scalar / vector or
+    // pointer). Before this fix, a `u1` field / ndarray store emitted
+    // `OpBitcast %char %bool_val` and validated as
+    // `Expected input to be a pointer or int or float vector or scalar: Bitcast`. Most drivers
+    // ignore that and crash inside the pipeline compiler (observed on Mesa RADV: a hard SIGSEGV
+    // inside `libvulkan_radeon.so::create_compute_pipeline` the moment the offending kernel is
+    // registered). Route through `IRBuilder::cast`, which lowers `bool -> int` to `OpSelect`
+    // picking `1` or `0` of the target type -- that's the canonical spec-compliant way to widen a
+    // bool, matches what `load_buffer` already does on the reverse path, and keeps the
+    // "bool serialises as 0 / 1" behaviour every user of `to_numpy()` / `from_numpy()` depends on.
+    val_bits = ir_->cast(ir_->get_primitive_type(ti_buffer_type), val);
+  } else {
+    val_bits = ir_->make_value(spv::OpBitcast, ir_->get_primitive_type(ti_buffer_type), val);
+  }
   ir_->store_variable(buf_ptr, val_bits);
 }
 

--- a/quadrants/codegen/spirv/spirv_codegen.cpp
+++ b/quadrants/codegen/spirv/spirv_codegen.cpp
@@ -2096,16 +2096,37 @@ spirv::Value TaskCodegen::at_buffer(const Stmt *ptr, DataType dt) {
   return ret;
 }
 
+// For primitive float types, access the storage buffer through the native type view instead of
+// the uint-punned view. SPIR-V / Vulkan treats each (descriptor_set, binding) as a distinct
+// variable; `at_buffer` creates a new binding per (buffer, element_type) pair, so the u32 view
+// of a buffer and its f32 view are different variables pointing to the same memory. Without an
+// `Aliased` decoration the driver / SPIRV-Tools is free to assume they do not alias, meaning a
+// plain `OpLoad` through the u32 view is not ordered against a preceding `OpAtomicFAddEXT` on
+// the f32 view at the same address. The reverse-mode pattern `m.grad[i][j,k] += loss.grad;
+// tmp = m.grad[i][j,k]; m.grad[i][j,k] = 0; n.grad += tmp * factor` hits this: the load reads
+// the stale zero initial value, `tmp = 0`, and the adjoint never propagates (`test_ad_dynamic_index.py::
+// test_matrix_non_constant_index[arch=vulkan]` asserts `0.0 == 1.0`). Using the native f32 view
+// for plain load/store keeps them on the same binding as the atomic and removes the aliasing
+// question entirely. Integer types (i32/u32/i16/u16/i8/u8) already route through their own uint
+// view which matches the atomic path, so those stay as-is. `u1` stays on u8 because u1 has no
+// native SPIR-V storage representation.
+static DataType pick_buffer_access_type(DataType dt, const spirv::Value &ptr_val, spirv::IRBuilder &ir) {
+  if (dt->is_primitive(PrimitiveTypeID::u1)) {
+    return PrimitiveType::u8;
+  }
+  if (ptr_val.stype.dt == PrimitiveType::u64) {
+    return dt;
+  }
+  if (is_real(dt)) {
+    return dt;
+  }
+  return ir.get_quadrants_uint_type(dt);
+}
+
 spirv::Value TaskCodegen::load_buffer(const Stmt *ptr, DataType dt) {
   spirv::Value ptr_val = ir_->query_value(ptr->raw_name());
 
-  DataType ti_buffer_type = ir_->get_quadrants_uint_type(dt);
-
-  if (dt->is_primitive(PrimitiveTypeID::u1)) {
-    ti_buffer_type = PrimitiveType::u8;
-  } else if (ptr_val.stype.dt == PrimitiveType::u64) {
-    ti_buffer_type = dt;
-  }
+  DataType ti_buffer_type = pick_buffer_access_type(dt, ptr_val, *ir_);
 
   auto buf_ptr = at_buffer(ptr, ti_buffer_type);
   auto val_bits = ir_->load_variable(buf_ptr, ir_->get_primitive_type(ti_buffer_type));
@@ -2117,12 +2138,10 @@ spirv::Value TaskCodegen::load_buffer(const Stmt *ptr, DataType dt) {
 void TaskCodegen::store_buffer(const Stmt *ptr, spirv::Value val) {
   spirv::Value ptr_val = ir_->query_value(ptr->raw_name());
 
-  DataType ti_buffer_type = ir_->get_quadrants_uint_type(val.stype.dt);
-
+  DataType ti_buffer_type = pick_buffer_access_type(val.stype.dt, ptr_val, *ir_);
   if (val.stype.dt->is_primitive(PrimitiveTypeID::u1)) {
+    // Stores go through i8 (matching the original path) so a signed i1 narrowing is preserved.
     ti_buffer_type = PrimitiveType::i8;
-  } else if (ptr_val.stype.dt == PrimitiveType::u64) {
-    ti_buffer_type = val.stype.dt;
   }
 
   auto buf_ptr = at_buffer(ptr, ti_buffer_type);

--- a/quadrants/codegen/spirv/spirv_codegen.cpp
+++ b/quadrants/codegen/spirv/spirv_codegen.cpp
@@ -2117,7 +2117,14 @@ static DataType pick_buffer_access_type(DataType dt, const spirv::Value &ptr_val
   if (ptr_val.stype.dt == PrimitiveType::u64) {
     return dt;
   }
-  if (is_real(dt)) {
+  // Explicit whitelist of the real primitives we route natively, replacing the prior
+  // open-ended `is_real(dt)` predicate. Any future real-like primitive (e.g. a bfloat16, or an
+  // fp8 variant) would not have an audited SPIR-V storage-capability story yet -- rather than
+  // silently fall into the native-view branch, it must be added here deliberately after the
+  // storage-capability plumbing for its bit width is confirmed (see the
+  // `CapabilityStorageBuffer{8,16}BitAccess` emissions in `spirv_ir_builder.cpp`).
+  if (dt->is_primitive(PrimitiveTypeID::f16) || dt->is_primitive(PrimitiveTypeID::f32) ||
+      dt->is_primitive(PrimitiveTypeID::f64)) {
     return dt;
   }
   return ir.get_quadrants_uint_type(dt);

--- a/quadrants/codegen/spirv/spirv_codegen.cpp
+++ b/quadrants/codegen/spirv/spirv_codegen.cpp
@@ -2185,6 +2185,37 @@ spirv::Value TaskCodegen::get_buffer_value(BufferInfo buffer, DataType dt) {
     ir_->decorate(spv::OpDecorate, buffer_value, spv::DecorationVolatile);
   }
   buffer_value_map_[key] = buffer_value;
+
+  // Type-punned views of the same underlying `VkBuffer` need an explicit `Aliased` decoration. Every
+  // `(BufferInfo, element_type)` pair here gets its own `OpVariable` with a fresh `DescriptorSet` /
+  // `Binding`, so a field read through the `u32` view and a preceding `OpAtomicFAddEXT` through the
+  // `f32` view are separate SPIR-V variables pointing to the same memory. Without `Aliased` the
+  // driver is spec-free to assume they don't alias, and the plain load is not ordered against the
+  // atomic write -- the load reads the stale zero initial value and the reverse-mode adjoint silently
+  // drops to zero (`test_ad_dynamic_index.py::test_matrix_non_constant_index[arch=vulkan]` reproduces
+  // this on every device that exposes `shaderBufferFloat32AtomicAdd`).
+  //
+  // The aliasing hazard applies across every pairing of views on the same buffer, not just
+  // (native-float atomic, plain load): the CAS-emulation atomic path on devices without
+  // `shaderBufferFloat32AtomicAdd` routes float atomics through the `u32` view while other sites may
+  // emit atomics min / max / mul directly against the `u32` view -- each such pairing against a
+  // plain-load-through-any-view needs the same decoration. Decorating here rather than at first
+  // `at_buffer` call keeps the fix independent of which call site happens to introduce the second
+  // view.
+  //
+  // Decorate lazily: a single-view buffer stays un-decorated (no perf cost from disabled
+  // cross-variable scheduling optimizations), and only when a buffer gets its second distinct view do
+  // we retroactively decorate every view -- existing ones through the id-set guard below, and the new
+  // one unconditionally in the same sweep.
+  auto &views = buffer_views_by_buffer_[buffer];
+  views.push_back(buffer_value);
+  if (views.size() >= 2) {
+    for (const auto &v : views) {
+      if (aliased_decorated_buffer_ids_.insert(v.id).second) {
+        ir_->decorate(spv::OpDecorate, v, spv::DecorationAliased);
+      }
+    }
+  }
   QD_TRACE("buffer name = {}, value = {}", buffer_instance_name(buffer), buffer_value.id);
 
   return buffer_value;

--- a/quadrants/codegen/spirv/spirv_ir_builder.cpp
+++ b/quadrants/codegen/spirv/spirv_ir_builder.cpp
@@ -54,6 +54,22 @@ void IRBuilder::init_header() {
   if (caps_->get(cap::spirv_has_int16)) {
     ib_.begin(spv::OpCapability).add(spv::CapabilityInt16).commit(&header_);
   }
+  // `CapabilityStorageBuffer{8,16}BitAccess` gate narrow-typed loads / stores through a
+  // descriptor-bound `StorageBuffer` pointer (e.g. `OpLoad %_ptr_StorageBuffer_ushort`). The
+  // existing codegen has been emitting these narrow-typed accesses via the uint-punning path in
+  // `load_buffer` / `store_buffer` for a while (`get_quadrants_uint_type(i16) = u16`,
+  // `get_quadrants_uint_type(i8) = u8`), which strict Vulkan validation requires these capabilities
+  // for -- so we emit them unconditionally whenever the queried feature is set, independent of
+  // whether the current kernel actually uses a narrow type. The cost is a single extra
+  // `OpCapability` word in the shader header; the upside is that every 16-bit / 8-bit field or
+  // ndarray access is spec-compliant on drivers that enforce the letter of
+  // `SPV_KHR_{8,16}bit_storage`.
+  if (caps_->get(cap::spirv_has_storage_buffer_8bit_access)) {
+    ib_.begin(spv::OpCapability).add(spv::CapabilityStorageBuffer8BitAccess).commit(&header_);
+  }
+  if (caps_->get(cap::spirv_has_storage_buffer_16bit_access)) {
+    ib_.begin(spv::OpCapability).add(spv::CapabilityStorageBuffer16BitAccess).commit(&header_);
+  }
   if (caps_->get(cap::spirv_has_int64)) {
     ib_.begin(spv::OpCapability).add(spv::CapabilityInt64).commit(&header_);
   }
@@ -76,6 +92,17 @@ void IRBuilder::init_header() {
   }
 
   ib_.begin(spv::OpExtension).add("SPV_KHR_storage_buffer_storage_class").commit(&header_);
+
+  // `SPV_KHR_{8,16}bit_storage` is paired with `CapabilityStorageBuffer{8,16}BitAccess` above.
+  // Both the capability and the extension are needed for narrow-typed `StorageBuffer` loads /
+  // stores to validate on Vulkan; declaring only the capability without the extension is
+  // ill-formed SPIR-V.
+  if (caps_->get(cap::spirv_has_storage_buffer_8bit_access)) {
+    ib_.begin(spv::OpExtension).add("SPV_KHR_8bit_storage").commit(&header_);
+  }
+  if (caps_->get(cap::spirv_has_storage_buffer_16bit_access)) {
+    ib_.begin(spv::OpExtension).add("SPV_KHR_16bit_storage").commit(&header_);
+  }
 
   if (caps_->get(cap::spirv_has_no_integer_wrap_decoration)) {
     ib_.begin(spv::OpExtension).add("SPV_KHR_no_integer_wrap_decoration").commit(&header_);

--- a/quadrants/codegen/spirv/spirv_ir_builder.cpp
+++ b/quadrants/codegen/spirv/spirv_ir_builder.cpp
@@ -366,6 +366,21 @@ SType IRBuilder::get_pointer_type(const SType &value_type, spv::StorageClass sto
   t.element_type_id = value_type.id;
   t.storage_class = storage_class;
   ib_.begin(spv::OpTypePointer).add_seq(t, storage_class, value_type).commit(&global_);
+  // An `OpTypePointer` in the `PhysicalStorageBuffer` storage class that points to a scalar or vector
+  // needs an explicit `ArrayStride` decoration for `OpPtrAccessChain`'s `Element` offset to be scaled
+  // correctly on Vulkan. Without the decoration, drivers that strictly follow SPV_KHR_physical_storage_buffer
+  // treat the stride as undefined and collapse every element index to the base address, which manifests as
+  // `arr[i]` reads returning `arr[0]` for all `i` across the whole kernel (and any indexed ndarray write
+  // landing on slot 0). Sized-pointees (structs, arrays) already carry explicit layout decorations so they
+  // don't need this; the fix is limited to scalars/vectors, where the natural stride is just the pointee
+  // byte size. Uniform / StorageBuffer / Input / Output / Workgroup pointers don't use PSB arithmetic, so
+  // the decoration is a no-op for them and is skipped.
+  if (storage_class == spv::StorageClassPhysicalStorageBuffer && value_type.flag == TypeKind::kPrimitive) {
+    size_t stride = get_primitive_type_size(value_type.dt);
+    if (stride > 0) {
+      this->decorate(spv::OpDecorate, t, spv::DecorationArrayStride, uint32_t(stride));
+    }
+  }
   pointer_type_tbl_[key] = t;
   return t;
 }

--- a/quadrants/inc/rhi_constants.inc.h
+++ b/quadrants/inc/rhi_constants.inc.h
@@ -14,6 +14,17 @@ PER_DEVICE_CAPABILITY(spirv_has_int16)
 PER_DEVICE_CAPABILITY(spirv_has_int64)
 PER_DEVICE_CAPABILITY(spirv_has_float16)
 PER_DEVICE_CAPABILITY(spirv_has_float64)
+// Vulkan `VkPhysicalDevice8BitStorageFeatures::storageBuffer8BitAccess` /
+// `VkPhysicalDevice16BitStorageFeatures::storageBuffer16BitAccess` queried flags, enabling
+// `CapabilityStorageBuffer{8,16}BitAccess` emission in the SPIR-V header. Needed independently of
+// `spirv_has_int{8,16}` / `spirv_has_float16`: `Int8` / `Int16` / `Float16` capabilities gate
+// whether the type can be declared, whereas these gate whether it can be loaded / stored through
+// a descriptor-bound `StorageBuffer` pointer. Emitting the storage caps without the underlying
+// device feature makes the driver reject the shader at pipeline creation on strict
+// implementations; skipping them when the device does support them is silent-corruption-UB on
+// drivers that enforce them.
+PER_DEVICE_CAPABILITY(spirv_has_storage_buffer_8bit_access)
+PER_DEVICE_CAPABILITY(spirv_has_storage_buffer_16bit_access)
 PER_DEVICE_CAPABILITY(spirv_has_atomic_int64)
 PER_DEVICE_CAPABILITY(spirv_has_atomic_float16)  // load, store, exchange
 PER_DEVICE_CAPABILITY(spirv_has_atomic_float16_add)

--- a/quadrants/rhi/vulkan/vulkan_device_creator.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device_creator.cpp
@@ -304,6 +304,27 @@ void VulkanDeviceCreator::create_instance(uint32_t vk_api_version, bool manual_c
     }
   }
 
+  // Normalize `params_.enable_validation_layer` against the host's actual layer availability BEFORE
+  // the instance-reuse short-circuit below: downstream code (device-extension enumeration at
+  // `create_logical_device`, the `VK_KHR_SHADER_NON_SEMANTIC_INFO` cap gate, the device layer arrays
+  // at the tail of `create_logical_device`) reads this flag on every cycle, and `create_logical_device`
+  // runs on every re-init. If we let the request pass through unchanged on the reuse path, the cap is
+  // set to `true` every subsequent cycle even when the layer is not actually loaded on the cached
+  // instance (the only cycle where the layer-load flip happens is the very first, which is also the
+  // only cycle where a fresh `vkCreateInstance` runs). Users observed this as `test_overflow.py`
+  // passing on the first parametrization and failing on every subsequent one in the same pytest
+  // session: `DebugPrintf`-ext-imported shaders compile fine, but the validation layer that would
+  // route those messages to stdout was never loaded, so the overflow-detected strings never appear in
+  // `capfd`. Running the check here keeps the flag consistent across re-inits; re-running on every
+  // call is cheap (it enumerates instance layers, ~microseconds).
+  if (params_.enable_validation_layer && !check_validation_layer_support()) {
+    RHI_LOG_ERROR(
+        "Validation layers requested but not available, turning off... "
+        "Please make sure Vulkan SDK from https://vulkan.lunarg.com/sdk/home "
+        "is installed.");
+    params_.enable_validation_layer = false;
+  }
+
   // Reuse the VkInstance from a previous init/reset cycle if available.
   // Repeated vkDestroyInstance/vkCreateInstance triggers an NVIDIA driver bug
   // that corrupts SubgroupLocalInvocationId after ~11 cycles.
@@ -325,15 +346,8 @@ void VulkanDeviceCreator::create_instance(uint32_t vk_api_version, bool manual_c
   create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
   create_info.pApplicationInfo = &app_info;
 
-  if (params_.enable_validation_layer) {
-    if (!check_validation_layer_support()) {
-      RHI_LOG_ERROR(
-          "Validation layers requested but not available, turning off... "
-          "Please make sure Vulkan SDK from https://vulkan.lunarg.com/sdk/home "
-          "is installed.");
-      params_.enable_validation_layer = false;
-    }
-  }
+  // `params_.enable_validation_layer` has already been normalized against the host's actual layer
+  // availability above, before the cached-instance short-circuit. No second check needed here.
 
   VkDebugUtilsMessengerCreateInfoEXT debug_create_info{};
 

--- a/quadrants/rhi/vulkan/vulkan_device_creator.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device_creator.cpp
@@ -789,12 +789,25 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
       features2.pNext = &shader_8bit_storage_feature;
       vkGetPhysicalDeviceFeatures2KHR(physical_device_, &features2);
 
+      // Gate the SPIR-V `CapabilityStorageBuffer8BitAccess` emission strictly on the queried
+      // feature bit. `VK_KHR_8bit_storage` promoted into Vulkan 1.2 core doesn't imply the feature
+      // is actually supported -- implementations can still expose `storageBuffer8BitAccess = FALSE`
+      // -- so the SPIR-V cap may only be emitted when this feature is true, otherwise strict
+      // validation rejects shaders that declare the capability.
+      if (shader_8bit_storage_feature.storageBuffer8BitAccess) {
+        caps.set(DeviceCapability::spirv_has_storage_buffer_8bit_access, true);
+      }
+
       *pNextEnd = &shader_8bit_storage_feature;
       pNextEnd = &shader_8bit_storage_feature.pNext;
     }
     if (CHECK_VERSION(1, 1) || CHECK_EXTENSION(VK_KHR_16BIT_STORAGE_EXTENSION_NAME)) {
       features2.pNext = &shader_16bit_storage_feature;
       vkGetPhysicalDeviceFeatures2KHR(physical_device_, &features2);
+
+      if (shader_16bit_storage_feature.storageBuffer16BitAccess) {
+        caps.set(DeviceCapability::spirv_has_storage_buffer_16bit_access, true);
+      }
 
       *pNextEnd = &shader_16bit_storage_feature;
       pNextEnd = &shader_16bit_storage_feature.pNext;


### PR DESCRIPTION
# Vulkan SPIR-V correctness: atomic-view aliasing, PSB pointer stride, narrow-type storage caps, `u1` storage cast, per-init validation-layer re-check

> Six small SPIR-V codegen / RHI changes, all silent-corruption or latent validation fixes on Vulkan, stacked so each builds on the last. None regresses any other backend.

## TL;DR

Six independent correctness gaps, all with observable silent-corruption failure modes on Vulkan:

### 1. Plain float loads / stores went through the `u32`-punned view of the buffer instead of the native `f32` view

`OpAtomicFAddEXT` has always used the native `f32` view. Plain `OpLoad` / `OpStore` went through the `u32` view. Each `(buffer, element_type)` pair gets its own `OpVariable` with a fresh `DescriptorSet` / `Binding`, so those two views are different SPIR-V variables pointing at the same `VkBuffer`. Without an `Aliased` decoration, a driver is free to assume they don't alias, so the plain load is not memory-ordered against the preceding atomic. Reverse-mode AD's load-and-clear pattern (`x.grad[i] += delta; tmp = x.grad[i]; x.grad[i] = 0; y.grad += tmp * factor`) reads the stale zero, silent gradient drop.

Originally discovered via `tests/python/test_ad_dynamic_index.py::test_matrix_non_constant_index[arch=vulkan]` asserting `0.0 == 1.0`.

### 2. `OpTypePointer` in `PhysicalStorageBuffer` was missing `ArrayStride`

`OpPtrAccessChain` on a PSB pointer multiplies `Element` by `ArrayStride` to produce the byte offset. We were emitting bare pointers; strict drivers collapsed indexed access back to the base. Symptom: every `arr[i]` ndarray read returns `arr[0]`.

```python
@qd.kernel
def kern(arr_a: qd.types.ndarray(dtype=qd.i32, ndim=1)):
    for _d in range(1):
        out[0] = arr_a[0]; out[1] = arr_a[1]; out[2] = arr_a[2]
# arr_a=[10,20,30] -> out=[10,10,10] pre-fix, [10,20,30] post-fix.
```

### 3. Type-punned views of the same buffer weren't flagged as mutually `Aliased`

Fix 1 closes the aliasing hazard only for the native-atomic-add hot path. CAS-emulation atomic on devices without `shaderBufferFloat32AtomicAdd`, non-add float atomics (`min`/`max`/`mul`), and `f16` / `f64`-without-native-add each route the atomic through `u32` while plain load / store are now on the native float view -- same cross-view aliasing, different pairing. Close all of them with an `Aliased` decoration on every buffer `OpVariable` that gets a second type view. Lazy: single-view buffers stay undecorated.

### 4. Narrow-type `StorageBuffer` access requires `StorageBuffer{8,16}BitAccess` capabilities that weren't emitted

The uint-punning path has always relied on `OpLoad` / `OpStore` through `u16` / `u8` descriptor-bound pointers. Per `SPV_KHR_16bit_storage` / `SPV_KHR_8bit_storage`, that needs `CapabilityStorageBuffer16BitAccess` / `CapabilityStorageBuffer8BitAccess` in the header. Neither capability nor its extension was emitted, so strict drivers were within their rights to reject every Quadrants shader touching an `i8` / `i16` / `f16` / `u8` / `u16` field. Also narrow the `is_real(dt)` predicate in `pick_buffer_access_type` to an explicit `{f16, f32, f64}` whitelist so a future `bfloat16` / `fp8` doesn't silently fall through.

### 5. Widening a `u1` value to its `i8` storage slot used `OpBitcast`, which is ill-formed on booleans

`TaskCodegen::store_buffer` widened `u1` through `OpBitcast %char %bool_val`. `spirv-val`: `Expected input to be a pointer or int or float vector or scalar: Bitcast`. Mesa RADV (AMD RX 7900 XTX) crashed deep inside `libvulkan_radeon.so::create_compute_pipeline` with a raw `SIGSEGV` the moment a `u1` field / ndarray / struct member store was registered. Surfaced as `timeout: the monitored command dumped core` across `test_tensor_consistency`, `test_pickle[vulkan-u1]`, `test_matrixfree_{cg,bicgstab}`, `test_struct_field_with_bool`, `test_dual_return_spirv`, and `test_offload_cross`.

Route the `u1 -> i8` widening through `IRBuilder::cast`, which lowers `bool -> int` to the canonical `OpSelect(cond, 1, 0)` at the target integer type. That's what the load side already does, and it preserves "`u1` serialises as 0 / 1" for `to_numpy()` / `from_numpy()`.

### 6. `VulkanDeviceCreator::create_instance` skipped the validation-layer re-check on re-init

The instance-reuse short-circuit (kept around an NVIDIA driver bug with repeated `vkDestroyInstance` / `vkCreateInstance`) used to return before `check_validation_layer_support()` ran, so every re-init after the first one read `params_.enable_validation_layer` as whatever the caller passed (`True` for `debug=True`) instead of the flipped-`False` reflecting the host's actual layer availability. Downstream, the `spirv_has_non_semantic_info` cap followed the stale `True`, the shader emitted `NonSemantic.DebugPrintf` extinsts with no validation layer loaded to route them, and every `capfd`-based assertion after the first parametrisation in the same pytest session failed with an empty capture buffer. `test_overflow.py::test_shl_overflow[arch=vulkan-ty0-6]` passing + `test_shl_overflow[arch=vulkan-ty1-7]` failing in the same `-n 1` session was the fingerprint.

Move the check above the cached-instance return. Re-running `vkEnumerateInstanceLayerProperties` on every cycle costs microseconds and keeps the flag consistent.

## Why

Every fix is a spec-compliance gap, not a driver workaround:

- **#1** is only observable on devices with `shaderBufferFloat32AtomicAdd`. CI's T4 falls back to CAS emulation, which matched the old `u32` plain-load path, so the aliasing gap didn't exist there and the bug has been latent since native-atomic lowering landed on non-T4 drivers.
- **#2** is observable on every Vulkan device with PSB, but only strict drivers (AMD RADV) implement the spec letter. Lenient drivers (NVIDIA) tolerated the missing stride.
- **#3** would re-surface the silent-zero gradient on the CAS / non-add / narrow-float paths after #1, trading one failure class for another. Shipping #1 alone wasn't safe.
- **#4** is cross-cutting: any narrow-typed field access would be rejected at pipeline creation on drivers that enforce the storage-caps.
- **#5** crashes the pipeline compiler on any `u1` store path. Dozens of existing tests were observed to segfault; the only reason this wasn't caught earlier is that Quadrants' other `u1` code paths (loads, casts, atomics) already went through `IRBuilder::cast` and didn't exercise the broken store widening.
- **#6** is a pytest-session-scoped flake fingerprint: first parametrisation passes, later ones fail. The failure has nothing to do with the kernel under test -- the caps state is corrupted across re-inits. Any `debug=True` test that expects `DebugPrintf` output in `capfd` is at risk.

None of the six regresses any other backend. Metal's MoltenVK path goes through SPIRV-Cross -> MSL, which ignores the aliasing question, the `ArrayStride`, the narrow-storage caps, and the device-creator-path ordering. AMDGPU / CUDA / CPU don't use the SPIR-V codegen. Fix 5 is a bit-identical refactor on every other type path (only `u1` changes); fix 6 runs only inside `VulkanDeviceCreator`.

## Mechanism

### Fix 1: `pick_buffer_access_type` routes whitelisted float types through the native view

`quadrants/codegen/spirv/spirv_codegen.cpp`:

```cpp
static DataType pick_buffer_access_type(DataType dt, const spirv::Value &ptr_val, spirv::IRBuilder &ir) {
  if (dt->is_primitive(PrimitiveTypeID::u1)) return PrimitiveType::u8;
  if (ptr_val.stype.dt == PrimitiveType::u64) return dt;
  if (dt->is_primitive(PrimitiveTypeID::f16) || dt->is_primitive(PrimitiveTypeID::f32) ||
      dt->is_primitive(PrimitiveTypeID::f64)) return dt;
  return ir.get_quadrants_uint_type(dt);
}
```

### Fix 2: `get_pointer_type` emits `ArrayStride` for PSB scalar / vector pointees

`quadrants/codegen/spirv/spirv_ir_builder.cpp::get_pointer_type`. When `storage_class == PhysicalStorageBuffer` and the pointee is a primitive scalar / vector, decorate with `ArrayStride = sizeof(pointee)`. Struct / array pointees already carry full per-member layout, so no double-decoration. Non-PSB storage classes skipped.

### Fix 3: `get_buffer_value` decorates multi-view buffer variables with `Aliased`

`quadrants/codegen/spirv/spirv_codegen.cpp::get_buffer_value`. Track per-`BufferInfo` list of existing type views. When a second (or later) view is minted, retroactively decorate every peer with `Aliased`; dedupe via an id-set. Single-view buffers stay undecorated.

### Fix 4: narrow-type storage caps gated on Vulkan-queried feature bits

Three-part change:

1. `quadrants/inc/rhi_constants.inc.h`: add `spirv_has_storage_buffer_{8,16}bit_access` to the `DeviceCapability` enum.
2. `quadrants/rhi/vulkan/vulkan_device_creator.cpp`: query `VkPhysicalDevice{8,16}BitStorageFeatures::storageBuffer{8,16}BitAccess` and set the device caps. Strictly gated on the feature bit (the Vulkan 1.2-core `VK_KHR_{8,16}bit_storage` promotion doesn't imply the feature is supported).
3. `quadrants/codegen/spirv/spirv_ir_builder.cpp`: emit `CapabilityStorageBuffer{8,16}BitAccess` + the matching `SPV_KHR_{8,16}bit_storage` extension when the device caps are set.

### Fix 5: `store_buffer` routes `u1 -> i8` through `IRBuilder::cast`

`quadrants/codegen/spirv/spirv_codegen.cpp::TaskCodegen::store_buffer`. Widened the three-way logic:

```cpp
if (val.stype.dt == ti_buffer_type) {
  val_bits = val;
} else if (val.stype.dt->is_primitive(PrimitiveTypeID::u1)) {
  val_bits = ir_->cast(ir_->get_primitive_type(ti_buffer_type), val);   // -> OpSelect(1, 0)
} else {
  val_bits = ir_->make_value(spv::OpBitcast, ir_->get_primitive_type(ti_buffer_type), val);
}
```

`IRBuilder::cast(int, bool)` already emits `OpSelect(cond, int_immediate(1), int_immediate(0))` at the target type -- matches the spec-compliant `bool -> int` lowering, matches what `load_buffer` does on the reverse path, and keeps the serialisation convention.

### Fix 6: `create_instance` runs the layer-availability check before the cached-instance return

`quadrants/rhi/vulkan/vulkan_device_creator.cpp::create_instance`. Moved:

```cpp
if (params_.enable_validation_layer && !check_validation_layer_support()) {
  RHI_LOG_ERROR("Validation layers requested but not available, turning off... ...");
  params_.enable_validation_layer = false;
}
```

from after the cached-`VkInstance` short-circuit to before it. Dropped the duplicate check that used to live lower in the function.

## Per-backend coverage matrix

| Backend                         | #1 (float view) | #2 (ArrayStride) | #3 (Aliased) | #4 (storage caps) | #5 (`u1` cast) | #6 (layer recheck) |
| ------------------------------- | ---------- | ---------- | ---------- | ------------------ | --------------- | -------------------- |
| **CPU**                         | N/A - no SPIR-V | N/A | N/A | N/A | N/A | N/A |
| **CUDA**                        | N/A | N/A | N/A | N/A | N/A | N/A |
| **AMDGPU**                      | N/A | N/A | N/A | N/A | N/A | N/A |
| **Vulkan** (native)             | Fixes silent-zero gradient on devices with `shaderBufferFloat32AtomicAdd` | Fixes `arr[i] -> arr[0]` collapse on strict-PSB drivers | Fixes the CAS / non-add / narrow-float paths #1 doesn't cover | Fixes pipeline rejection on strict `SPV_KHR_{8,16}bit_storage` drivers | Fixes `u1` store pipeline crash (RADV `SIGSEGV`; spec-invalid `OpBitcast %bool`) | Fixes stale `spirv_has_non_semantic_info` on re-init across a pytest session |
| **Metal / MoltenVK**            | No-op | No-op | No-op | No-op | No-op - MSL's `bool -> int` cast was already correct | N/A - MoltenVK has its own validation-layer story |

## Tests

No new tests added in this PR. Every fix is pinned by an existing regression whose assertion already covered the failure mode:

- **#1**: `tests/python/test_ad_dynamic_index.py::test_matrix_non_constant_index[arch=vulkan]`.
- **#2**: `tests/python/test_ndarray.py::test_ndarray_1d[arch=vulkan]` + every cross-suite test that does `arr[i]` indexed access.
- **#3**: covered implicitly by reverse-mode tests on the CI T4 runner (CAS path).
- **#4**: covered by `test_ndarray.py`'s dtype-parametrised suite on narrow primitives.
- **#5**: the segfaults in `test_tensor_consistency`, `test_pickle[vulkan-u1]`, `test_matrixfree_{cg,bicgstab}`, `test_struct_field_with_bool`, `test_dual_return_spirv`, `test_offload_cross` all disappear post-fix.
- **#6**: `test_overflow.py` / `test_print.py` first-passes-then-fails pattern across a single pytest session.

Measured on an AMD RX 7900 XTX (advertises `shaderBufferFloat32AtomicAdd`, strict PSB, `storageBuffer{8,16}BitAccess`), across `tests/python/` with `test_adstack.py` and `test_ndarray.py` excluded for measurement independence: **506 failing pre-series, 22 failing post-series.** On `test_adstack.py` specifically this takes Vulkan from 12 failing -> fully green; on `test_ndarray.py`, from 3 failing -> fully green. The remaining 22 are all in `test_scan.py` -- a pre-series parallel-scan correctness issue unrelated to any of the six gaps here, left for a follow-up PR.

## Side-effect audit

| Concern                                                | Verdict                                                                                          |
| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
| Integer ndarray / field access (#1)                    | Unchanged - integer branch of `pick_buffer_access_type` returns `get_quadrants_uint_type(dt)` as before |
| PSB pointer path in `at_buffer` (#1)                   | Unchanged - `ptr_val.stype.dt == u64` branch preserved                                           |
| Future real-like primitive (bf16 / fp8) (#1)           | Explicit `{f16, f32, f64}` whitelist replaces `is_real(dt)` -- unknown reals fall into uint view |
| Struct / array PSB pointer ArrayStride (#2)            | Not decorated - struct / array pointees carry full layout elsewhere                              |
| Non-PSB pointer types (#2)                             | Skipped - Uniform / StorageBuffer / Input / Output / Workgroup don't use PSB arithmetic          |
| Single-view buffer performance (#3)                    | Undecorated - compiler scheduling freedom preserved                                              |
| Double-decoration on revisit of a buffer view (#3)     | Prevented via `aliased_decorated_buffer_ids_` id-set                                             |
| Devices without `storageBuffer{8,16}BitAccess` (#4)    | SPIR-V cap not emitted - shaders remain acceptable                                               |
| SPIR-V header without matching extension (#4)          | Capability and extension always emitted together                                                 |
| Non-`u1` stores (#5)                                   | Unchanged - they take the else-branch `OpBitcast` path as before                                 |
| `u1` loads (#5)                                        | Already correctly routed through `IRBuilder::cast` pre-fix                                       |
| First-cycle validation-layer flip (#6)                 | Unchanged - the first init sees the same flip as before, just at a different line                |
| Duplicate re-check inside the post-return block (#6)   | Removed - would have been dead code now that the check is above                                  |
| MoltenVK / Metal output                                | No-op for all six fixes                                                                          |
| Offline cache key                                      | SPIR-V blob differs, cache invalidates once on upgrade                                           |
| LLVM / CUDA / AMDGPU codegen                           | Files outside `quadrants/codegen/spirv/`, `quadrants/rhi/vulkan/`, `quadrants/inc/` untouched    |
