### PR TITLE
[Types] Tensor 1: Python-side Tensor wrapper

### DIFF
--- a/python/quadrants/lang/__init__.py
+++ b/python/quadrants/lang/__init__.py
@@ -4,6 +4,7 @@ from quadrants.lang import impl, simt  # noqa: F401
 from quadrants.lang._fast_caching.function_hasher import pure  # noqa: F401
 from quadrants.lang._ndarray import *
 from quadrants.lang._ndrange import ndrange  # noqa: F401
+from quadrants.lang._tensor import Tensor, tensor  # noqa: F401
 from quadrants.lang.exception import *
 from quadrants.lang.field import *
 from quadrants.lang.impl import *

--- a/python/quadrants/lang/_tensor.py
+++ b/python/quadrants/lang/_tensor.py
@@ -1,0 +1,226 @@
+"""Layout-aware tensor — Phase 1 + Phase 2.
+
+A ``Tensor`` is a logical view of a Quadrants ``Ndarray`` plus a layout
+permutation that describes how logical dimensions map to physical memory
+dimensions.
+
+Phase 1 (Python scope):
+  - ``Tensor`` class wrapping ``(underlying_ndarray, shape, layout)``
+  - ``tensor(dtype, shape, layout=None)`` factory; ``layout=None`` means identity
+  - layout validation: must be a permutation of ``range(ndim)``
+  - python-scope ``__getitem__`` / ``__setitem__`` translate logical -> physical
+  - ``to_numpy`` / ``from_numpy`` operate on the logical shape
+
+Phase 2 (kernel-arg binding):
+  - ``Tensor`` is a ``@dataclasses.dataclass`` with two bridge-recognised fields:
+      * ``underlying``: ``qd.types.ndarray(...)`` — the physical storage,
+        bound at the kernel boundary like a regular ``qd.ndarray``.
+      * ``layout``: ``qd.template`` — a Python tuple captured at trace time
+        so kernels can branch on it via ``qd.static(t.layout == ...)``.
+    This rides the existing dataclass kernel-arg bridge in
+    ``quadrants.lang._kernel_impl_dataclass``: no new annotation surface or
+    binding code is required.
+  - Inside a kernel, users currently write ``t.underlying[physical_idx]``
+    (verbose). Phase 3 (next) adds AST sugar so plain ``t[i, j]`` resolves to
+    the permuted physical access.
+
+See ``perso_hugh/doc/qd_tensor_design.md`` for the full design.
+"""
+
+import dataclasses
+from typing import Sequence, Tuple
+
+import numpy as np
+
+from quadrants.lang import impl
+from quadrants.types.annotations import template as _template
+from quadrants.types.ndarray_type import NdarrayType as _NdarrayType
+
+__all__ = ["Tensor", "tensor"]
+
+
+def _validate_layout(layout: Sequence[int], ndim: int) -> Tuple[int, ...]:
+    """Validate that ``layout`` is a permutation of ``range(ndim)`` and return it as a tuple.
+
+    Convention: ``layout[i] = physical_axis_for_logical_dim_i``. So
+    ``layout=(0, 1, ..., n-1)`` is identity and ``layout=(1, 0)`` is a 2D transpose.
+    """
+    layout_t = tuple(int(p) for p in layout)
+    if len(layout_t) != ndim:
+        raise ValueError(f"layout must have length {ndim} (one entry per dim), got length {len(layout_t)}: {layout_t}")
+    if sorted(layout_t) != list(range(ndim)):
+        raise ValueError(
+            f"layout must be a permutation of range({ndim}), got {layout_t}. "
+            f"Each physical axis index must appear exactly once."
+        )
+    return layout_t
+
+
+def _logical_to_physical_shape(logical_shape: Sequence[int], layout: Sequence[int]) -> Tuple[int, ...]:
+    """``physical_shape[layout[i]] = logical_shape[i]``."""
+    ndim = len(logical_shape)
+    physical = [0] * ndim
+    for i, p in enumerate(layout):
+        physical[p] = int(logical_shape[i])
+    return tuple(physical)
+
+
+def _logical_to_physical_indices(idx: Sequence[int], layout: Sequence[int]) -> Tuple[int, ...]:
+    """Translate a tuple of logical indices to physical indices via ``layout``."""
+    physical = [0] * len(idx)
+    for i, p in enumerate(layout):
+        physical[p] = idx[i]
+    return tuple(physical)
+
+
+# ---------------------------------------------------------------------------
+# Tensor: dataclass-bridged layout-aware ndarray view.
+# ---------------------------------------------------------------------------
+
+# Field-type marker so the dataclass kernel-arg bridge sees the underlying as
+# a regular qd.ndarray. ``ndim`` is left None here because we want to accept
+# tensors of any rank as kernel args; per-call validation matches at runtime
+# inside ``check_matched`` upstream.
+_UNDERLYING_FIELD_TYPE = _NdarrayType()
+
+
+@dataclasses.dataclass
+class Tensor:
+    """Layout-aware logical view of an ``Ndarray``.
+
+    Constructed via :func:`tensor`. Inside ``@qd.kernel`` it behaves as a
+    dataclass with two bridge-recognised fields:
+
+    - ``underlying`` (``qd.types.ndarray()``) — the physical storage.
+    - ``layout`` (``qd.template``) — the permutation tuple, available at
+      trace time via ``qd.static(t.layout == (1, 0))`` etc.
+
+    In Python scope, ``t[i, j]`` uses logical indices and is automatically
+    translated to the physical position. Phase 3 adds the same logical-subscript
+    sugar inside kernels.
+    """
+
+    # Bridge-bound fields. Type annotations matter to the kernel-arg dispatcher.
+    underlying: _UNDERLYING_FIELD_TYPE  # type: ignore[valid-type]
+    layout: _template
+
+    def __post_init__(self):
+        layout_t = _validate_layout(self.layout, len(self.underlying.shape))
+        # Re-assign as a tuple so equality and hashing work uniformly.
+        object.__setattr__(self, "layout", layout_t)
+        physical_shape = tuple(int(d) for d in self.underlying.shape)
+        # Logical shape = inverse permutation applied to physical_shape:
+        # logical_shape[i] = physical_shape[layout[i]].
+        logical_shape = tuple(physical_shape[p] for p in layout_t)
+        object.__setattr__(self, "_logical_shape", logical_shape)
+        object.__setattr__(self, "_physical_shape", physical_shape)
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        """Logical shape (the user-facing shape)."""
+        # _logical_shape is set in __post_init__ via object.__setattr__.
+        return self._logical_shape  # pylint: disable=no-member
+
+    @property
+    def physical_shape(self) -> Tuple[int, ...]:
+        """Physical (in-memory) shape, after applying ``layout``."""
+        return self._physical_shape  # pylint: disable=no-member
+
+    @property
+    def ndim(self) -> int:
+        return len(self._logical_shape)  # pylint: disable=no-member
+
+    @property
+    def dtype(self):
+        return self.underlying.dtype
+
+    def __repr__(self):
+        return (
+            f"<qd.Tensor shape={self.shape} layout={self.layout} "
+            f"physical_shape={self.physical_shape} dtype={self.dtype}>"
+        )
+
+    def _translate_key(self, key) -> Tuple[int, ...]:
+        if not isinstance(key, tuple):
+            key = (key,)
+        if len(key) != self.ndim:
+            raise IndexError(f"{self.ndim}d tensor indexed with {len(key)}d key {key}")
+        for axis, k in enumerate(key):
+            if not isinstance(k, (int, np.integer)):
+                raise TypeError(
+                    f"Tensor python-scope subscript only supports integer indices for now; "
+                    f"got {type(k).__name__} on logical axis {axis}. "
+                    f"Slicing is not yet implemented (see Phase 3 for kernel-scope support)."
+                )
+        return _logical_to_physical_indices(key, self.layout)
+
+    def __getitem__(self, key):
+        physical_key = self._translate_key(key)
+        return self.underlying[physical_key]
+
+    def __setitem__(self, key, value):
+        physical_key = self._translate_key(key)
+        self.underlying[physical_key] = value
+
+    def fill(self, value):
+        """Fill the underlying storage with a scalar value (layout-independent)."""
+        self.underlying.fill(value)
+
+    def _inverse_layout(self) -> Tuple[int, ...]:
+        """Inverse permutation of ``layout``: ``inverse[p] = i where layout[i] = p``."""
+        inverse = [0] * self.ndim
+        for i, p in enumerate(self.layout):
+            inverse[p] = i
+        return tuple(inverse)
+
+    def to_numpy(self) -> np.ndarray:
+        """Return the tensor data as a numpy array in *logical* shape.
+
+        ``logical[i] = physical[layout[i]]`` -> ``transpose(layout)``.
+        """
+        physical_np = self.underlying.to_numpy()
+        if self.layout == tuple(range(self.ndim)):
+            return physical_np
+        return physical_np.transpose(self.layout)
+
+    def from_numpy(self, arr: np.ndarray) -> None:
+        """Load data from a logical-shape numpy array.
+
+        Inverse of :meth:`to_numpy`: ``physical = arr.transpose(inverse_layout)``.
+        """
+        if not isinstance(arr, np.ndarray):
+            raise TypeError(f"expected numpy.ndarray, got {type(arr).__name__}")
+        if tuple(arr.shape) != self.shape:
+            raise ValueError(f"from_numpy expects logical shape {self.shape}, got {tuple(arr.shape)}")
+        if self.layout == tuple(range(self.ndim)):
+            self.underlying.from_numpy(arr)
+        else:
+            physical = np.ascontiguousarray(arr.transpose(self._inverse_layout()))
+            self.underlying.from_numpy(physical)
+
+
+def tensor(dtype, shape, layout=None) -> Tensor:
+    """Create a layout-aware :class:`Tensor`.
+
+    Args:
+        dtype: element data type, e.g. ``qd.f32``, ``qd.i32``.
+        shape: logical shape (tuple of positive ints, or a single int for 1D).
+        layout: optional permutation of ``range(ndim)``. ``layout[i] = p`` means
+            logical dim ``i`` is stored along physical axis ``p``. ``None``
+            (default) means identity. For 2D, ``(1, 0)`` is the canonical
+            "transposed in memory" choice.
+
+    Returns:
+        A :class:`Tensor` wrapping a freshly allocated ``Ndarray`` of the
+        appropriate physical shape.
+    """
+    if isinstance(shape, int):
+        shape = (shape,)
+    shape = tuple(int(d) for d in shape)
+    ndim = len(shape)
+    if layout is None:
+        layout = tuple(range(ndim))
+    layout = _validate_layout(layout, ndim)
+    physical_shape = _logical_to_physical_shape(shape, layout)
+    underlying = impl.ndarray(dtype, physical_shape)
+    return Tensor(underlying=underlying, layout=layout)

--- a/python/quadrants/types/__init__.py
+++ b/python/quadrants/types/__init__.py
@@ -5,6 +5,7 @@ This module defines data types in Quadrants:
 - compound: matrix, vector, struct.
 - template: for reference types.
 - ndarray: for arbitrary arrays.
+- tensor: layout-aware ndarray (logical-to-physical permutation).
 - quant: for quantized types, see "https://yuanming.quadrants.graphics/publication/2021-quanquadrants/quanquadrants.pdf"
 """
 
@@ -15,4 +16,15 @@ from quadrants.types.ndarray_type import *  # type: ignore
 from quadrants.types.primitive_types import *  # type: ignore
 from quadrants.types.utils import *  # type: ignore
 
-__all__ = ["quant"]
+# isort: split
+# Layout-aware tensor: re-export the Tensor class as the type-annotation alias
+# for kernel arguments. Mirrors the qd.types.ndarray naming convention. The
+# underlying machinery is the dataclass kernel-arg bridge — see
+# quadrants.lang._tensor for details.
+#
+# This import deliberately lives *after* the type re-exports above, because
+# quadrants.lang depends on quadrants.types and we would otherwise create a
+# circular import.
+from quadrants.lang._tensor import Tensor as tensor  # noqa: F401
+
+__all__ = ["quant", "tensor"]

--- a/tests/python/test_tensor.py
+++ b/tests/python/test_tensor.py
@@ -1,0 +1,194 @@
+"""Tests for qd.tensor / qd.Tensor — Phase 1: Python-side wrapper.
+
+These tests cover construction, validation, properties, python-scope
+__getitem__/__setitem__, and to_numpy/from_numpy round-trips. Kernel-scope
+subscript translation is added in Phase 3 and tested separately.
+"""
+
+import numpy as np
+import pytest
+
+import quadrants as qd
+from quadrants.lang.misc import get_host_arch_list
+
+from tests import test_utils
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_default_layout_is_identity():
+    t = qd.tensor(qd.f32, shape=(4, 6))
+    assert t.shape == (4, 6)
+    assert t.physical_shape == (4, 6)
+    assert t.layout == (0, 1)
+    assert t.ndim == 2
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_explicit_identity_layout():
+    t = qd.tensor(qd.f32, shape=(4, 6), layout=(0, 1))
+    assert t.layout == (0, 1)
+    assert t.physical_shape == (4, 6)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_transposed_layout_swaps_physical_shape():
+    t = qd.tensor(qd.f32, shape=(4, 6), layout=(1, 0))
+    assert t.shape == (4, 6)
+    assert t.physical_shape == (6, 4)
+    assert t.layout == (1, 0)
+    assert tuple(t.underlying.shape) == (6, 4)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_3d_arbitrary_permutation():
+    t = qd.tensor(qd.f32, shape=(2, 3, 5), layout=(2, 0, 1))
+    assert t.shape == (2, 3, 5)
+    # logical 0 -> physical 2, logical 1 -> physical 0, logical 2 -> physical 1
+    # so physical_shape[2]=2, physical_shape[0]=3, physical_shape[1]=5
+    assert t.physical_shape == (3, 5, 2)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_int_shape_promoted_to_tuple():
+    t = qd.tensor(qd.i32, shape=8)
+    assert t.shape == (8,)
+    assert t.layout == (0,)
+    assert t.physical_shape == (8,)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_invalid_layout_wrong_length():
+    with pytest.raises(ValueError, match="layout must have length"):
+        qd.tensor(qd.f32, shape=(4, 6), layout=(0, 1, 2))
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_invalid_layout_not_a_permutation():
+    with pytest.raises(ValueError, match="must be a permutation"):
+        qd.tensor(qd.f32, shape=(4, 6), layout=(0, 0))
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_invalid_layout_out_of_range():
+    with pytest.raises(ValueError, match="must be a permutation"):
+        qd.tensor(qd.f32, shape=(4, 6), layout=(0, 5))
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_dtype_property():
+    t = qd.tensor(qd.f32, shape=(3,))
+    assert t.dtype == qd.f32
+
+    t_i = qd.tensor(qd.i32, shape=(3,))
+    assert t_i.dtype == qd.i32
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_python_scope_setitem_getitem_identity():
+    t = qd.tensor(qd.f32, shape=(3, 4))
+    t[1, 2] = 7.5
+    assert t[1, 2] == pytest.approx(7.5)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_python_scope_setitem_getitem_transposed():
+    """Logical indexing should be transparent regardless of layout."""
+    t = qd.tensor(qd.f32, shape=(3, 4), layout=(1, 0))
+    t[1, 2] = 7.5
+    assert t[1, 2] == pytest.approx(7.5)
+    # Verify the physical storage actually has the value at the transposed slot.
+    # logical (1, 2) -> physical (2, 1) when layout=(1, 0).
+    assert t.underlying[2, 1] == pytest.approx(7.5)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_python_scope_wrong_ndim_index_raises():
+    t = qd.tensor(qd.f32, shape=(3, 4))
+    with pytest.raises(IndexError, match="2d tensor indexed with 1d key"):
+        _ = t[1]
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_python_scope_slice_raises_clear_error():
+    t = qd.tensor(qd.f32, shape=(3, 4))
+    with pytest.raises(TypeError, match="Slicing is not yet implemented"):
+        _ = t[1, slice(0, 2)]
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_to_numpy_identity():
+    t = qd.tensor(qd.f32, shape=(2, 3))
+    expected = np.arange(6, dtype=np.float32).reshape(2, 3)
+    for i in range(2):
+        for j in range(3):
+            t[i, j] = float(expected[i, j])
+    np.testing.assert_array_equal(t.to_numpy(), expected)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_to_numpy_transposed_returns_logical_view():
+    t = qd.tensor(qd.f32, shape=(2, 3), layout=(1, 0))
+    expected = np.arange(6, dtype=np.float32).reshape(2, 3)
+    for i in range(2):
+        for j in range(3):
+            t[i, j] = float(expected[i, j])
+    np.testing.assert_array_equal(t.to_numpy(), expected)
+    # Underlying physical storage should be the transpose.
+    np.testing.assert_array_equal(t.underlying.to_numpy(), expected.T)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_from_numpy_identity_roundtrip():
+    src = np.arange(12, dtype=np.float32).reshape(3, 4)
+    t = qd.tensor(qd.f32, shape=(3, 4))
+    t.from_numpy(src)
+    np.testing.assert_array_equal(t.to_numpy(), src)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_from_numpy_transposed_roundtrip():
+    src = np.arange(12, dtype=np.float32).reshape(3, 4)
+    t = qd.tensor(qd.f32, shape=(3, 4), layout=(1, 0))
+    t.from_numpy(src)
+    np.testing.assert_array_equal(t.to_numpy(), src)
+    # Physical storage should be the transposed view.
+    np.testing.assert_array_equal(t.underlying.to_numpy(), src.T)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_from_numpy_wrong_shape_raises():
+    t = qd.tensor(qd.f32, shape=(3, 4))
+    with pytest.raises(ValueError, match="expects logical shape"):
+        t.from_numpy(np.zeros((4, 3), dtype=np.float32))
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_from_numpy_non_ndarray_raises():
+    t = qd.tensor(qd.f32, shape=(3,))
+    with pytest.raises(TypeError, match="expected numpy.ndarray"):
+        t.from_numpy([1.0, 2.0, 3.0])
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_3d_transpose_roundtrip():
+    src = np.arange(2 * 3 * 5, dtype=np.float32).reshape(2, 3, 5)
+    # Move logical axes (0,1,2) -> physical (2,0,1).
+    t = qd.tensor(qd.f32, shape=(2, 3, 5), layout=(2, 0, 1))
+    t.from_numpy(src)
+    np.testing.assert_array_equal(t.to_numpy(), src)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_repr_contains_key_fields():
+    t = qd.tensor(qd.f32, shape=(2, 3), layout=(1, 0))
+    r = repr(t)
+    assert "shape=(2, 3)" in r
+    assert "layout=(1, 0)" in r
+    assert "physical_shape=(3, 2)" in r
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_tensor_fill():
+    t = qd.tensor(qd.f32, shape=(2, 3), layout=(1, 0))
+    t.fill(2.5)
+    np.testing.assert_array_equal(t.to_numpy(), np.full((2, 3), 2.5, dtype=np.float32))


### PR DESCRIPTION
Adds qd.Tensor / qd.tensor — a logical view of a Quadrants Ndarray plus a layout permutation describing logical -> physical axis mapping.

This is Phase 1 of the qd.Tensor design (see
perso_hugh/doc/qd_tensor_design.md):
  - Tensor class wrapping (underlying_ndarray, shape, layout)
  - tensor(dtype, shape, layout=None) factory; layout=None means identity
  - layout validation: must be a permutation of range(ndim)
  - python-scope __getitem__/__setitem__ translate logical -> physical
  - to_numpy / from_numpy operate on the logical shape (transposing as needed)
  - properties: shape, physical_shape, layout, ndim, dtype, underlying

Phase 2 (next branch hp/tensor-2) will add qd.types.tensor(...) annotation for kernel arguments and fastcache integration.

Tests: 22 new tests in tests/python/test_tensor.py covering construction, validation, python-scope subscript, and to_numpy/from_numpy round-trips for 1D / 2D / 3D layouts. All 241 existing test_ndarray.py tests still pass.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
