### PR TITLE
[Type] Tensor 1b: field-backend variant + Backend enum

### DIFF
--- a/python/quadrants/lang/__init__.py
+++ b/python/quadrants/lang/__init__.py
@@ -4,7 +4,13 @@ from quadrants.lang import impl, simt  # noqa: F401
 from quadrants.lang._fast_caching.function_hasher import pure  # noqa: F401
 from quadrants.lang._ndarray import *
 from quadrants.lang._ndrange import ndrange  # noqa: F401
-from quadrants.lang._tensor import Tensor, tensor  # noqa: F401
+from quadrants.lang._tensor import (  # noqa: F401
+    Backend,
+    FieldTensor,
+    NdarrayTensor,
+    Tensor,
+    tensor,
+)
 from quadrants.lang.exception import *
 from quadrants.lang.field import *
 from quadrants.lang.impl import *

--- a/python/quadrants/lang/_tensor.py
+++ b/python/quadrants/lang/_tensor.py
@@ -1,33 +1,58 @@
-"""Layout-aware tensor — Phase 1 + Phase 2.
+"""Layout-aware tensor — Phases 1, 1b, 2.
 
-A ``Tensor`` is a logical view of a Quadrants ``Ndarray`` plus a layout
+A ``Tensor`` is a logical view of a Quadrants storage object plus a layout
 permutation that describes how logical dimensions map to physical memory
 dimensions.
 
-Phase 1 (Python scope):
-  - ``Tensor`` class wrapping ``(underlying_ndarray, shape, layout)``
-  - ``tensor(dtype, shape, layout=None)`` factory; ``layout=None`` means identity
-  - layout validation: must be a permutation of ``range(ndim)``
-  - python-scope ``__getitem__`` / ``__setitem__`` translate logical -> physical
-  - ``to_numpy`` / ``from_numpy`` operate on the logical shape
+Storage backend is selectable at construction via :class:`Backend`:
+
+- :attr:`Backend.NDARRAY` (default) wraps a :class:`~quadrants.lang.Ndarray`.
+- :attr:`Backend.FIELD` wraps a Quadrants :func:`~quadrants.lang.impl.field`
+  (SNode-backed storage).
+
+Both share a single python-scope API (``shape``, ``ndim``, ``dtype``,
+``__getitem__`` / ``__setitem__`` with logical indices, ``to_numpy`` /
+``from_numpy``, ``fill``).
 
 Phase 2 (kernel-arg binding):
-  - ``Tensor`` is a ``@dataclasses.dataclass`` with two bridge-recognised fields:
-      * ``underlying``: ``qd.types.ndarray(...)`` — the physical storage,
-        bound at the kernel boundary like a regular ``qd.ndarray``.
-      * ``layout``: ``qd.template`` — a Python tuple captured at trace time
-        so kernels can branch on it via ``qd.static(t.layout == ...)``.
-    This rides the existing dataclass kernel-arg bridge in
-    ``quadrants.lang._kernel_impl_dataclass``: no new annotation surface or
-    binding code is required.
-  - Inside a kernel, users currently write ``t.underlying[physical_idx]``
-    (verbose). Phase 3 (next) adds AST sugar so plain ``t[i, j]`` resolves to
-    the permuted physical access.
+  Each variant is a ``@dataclasses.dataclass`` with two bridge-recognised
+  fields:
+
+  - ``underlying`` — annotation differs per backend so the dataclass
+    kernel-arg bridge picks the right binding path:
+      * :class:`NdarrayTensor` uses ``qd.types.ndarray()``: bridged as a
+        regular ndarray.
+      * :class:`FieldTensor` uses ``qd.template``: fields are runtime
+        singletons captured by-reference at trace time, just like a bare
+        ``qd.field`` kernel arg.
+  - ``layout`` — ``qd.template``, captured as a Python tuple at trace time,
+    available for ``qd.static(t.layout == (1, 0))`` branching.
+
+  Both ride the existing dataclass bridge in
+  ``quadrants.lang._kernel_impl_dataclass`` — no new annotation surface or
+  binding code is required, and the backend distinction lands automatically
+  in the fastcache key via the ``underlying`` field's annotation type.
+
+Inside a kernel users currently write ``t.underlying[physical_idx]`` (verbose).
+Phase 3 (deferred) adds AST sugar so plain ``t[i, j]`` resolves to the
+permuted physical access.
+
+The user-facing factory :func:`tensor` dispatches on a :class:`Backend` enum::
+
+    qd.tensor(qd.f32, shape=(N, B))                              # ndarray
+    qd.tensor(qd.f32, shape=(N, B), layout=(1, 0))               # transposed ndarray
+    qd.tensor(qd.f32, shape=(N, B), backend=qd.Backend.FIELD)    # field
+
+For backward compatibility, ``Tensor`` is an alias for :class:`NdarrayTensor`,
+the default backend variant. Kernels that need to accept a field-backed tensor
+must annotate the parameter with :class:`FieldTensor` explicitly, since the
+dataclass bridge dispatches on the parameter annotation.
 
 See ``perso_hugh/doc/qd_tensor_design.md`` for the full design.
 """
 
 import dataclasses
+import enum
 from typing import Sequence, Tuple
 
 import numpy as np
@@ -36,7 +61,14 @@ from quadrants.lang import impl
 from quadrants.types.annotations import template as _template
 from quadrants.types.ndarray_type import NdarrayType as _NdarrayType
 
-__all__ = ["Tensor", "tensor"]
+__all__ = ["Backend", "Tensor", "NdarrayTensor", "FieldTensor", "tensor"]
+
+
+class Backend(enum.Enum):
+    """Storage backend for :func:`tensor`."""
+
+    NDARRAY = "ndarray"
+    FIELD = "field"
 
 
 def _validate_layout(layout: Sequence[int], ndim: int) -> Tuple[int, ...]:
@@ -74,35 +106,24 @@ def _logical_to_physical_indices(idx: Sequence[int], layout: Sequence[int]) -> T
 
 
 # ---------------------------------------------------------------------------
-# Tensor: dataclass-bridged layout-aware ndarray view.
+# _TensorBase: shared logical/physical-index logic, backend-agnostic.
 # ---------------------------------------------------------------------------
 
-# Field-type marker so the dataclass kernel-arg bridge sees the underlying as
-# a regular qd.ndarray. ``ndim`` is left None here because we want to accept
-# tensors of any rank as kernel args; per-call validation matches at runtime
-# inside ``check_matched`` upstream.
-_UNDERLYING_FIELD_TYPE = _NdarrayType()
 
+class _TensorBase:
+    """Shared layout-aware behaviour for :class:`NdarrayTensor` and :class:`FieldTensor`.
 
-@dataclasses.dataclass
-class Tensor:
-    """Layout-aware logical view of an ``Ndarray``.
+    Subclasses must be ``@dataclasses.dataclass`` with two fields:
 
-    Constructed via :func:`tensor`. Inside ``@qd.kernel`` it behaves as a
-    dataclass with two bridge-recognised fields:
-
-    - ``underlying`` (``qd.types.ndarray()``) — the physical storage.
-    - ``layout`` (``qd.template``) — the permutation tuple, available at
-      trace time via ``qd.static(t.layout == (1, 0))`` etc.
-
-    In Python scope, ``t[i, j]`` uses logical indices and is automatically
-    translated to the physical position. Phase 3 adds the same logical-subscript
-    sugar inside kernels.
+    - ``underlying`` (backend-specific annotation; has ``.shape``, ``.dtype``,
+      subscript, ``fill``, ``to_numpy``, ``from_numpy``)
+    - ``layout`` (``qd.template``; tuple set in ``__post_init__``)
     """
 
-    # Bridge-bound fields. Type annotations matter to the kernel-arg dispatcher.
-    underlying: _UNDERLYING_FIELD_TYPE  # type: ignore[valid-type]
-    layout: _template
+    # Declared here so type checkers see them on the base; concrete dataclass
+    # subclasses override with backend-specific annotations.
+    underlying: object
+    layout: tuple
 
     def __post_init__(self):
         layout_t = _validate_layout(self.layout, len(self.underlying.shape))
@@ -134,10 +155,15 @@ class Tensor:
     def dtype(self):
         return self.underlying.dtype
 
+    @property
+    def backend(self) -> Backend:
+        # Concrete subclass sets this as a class attribute.
+        return self._backend  # pylint: disable=no-member
+
     def __repr__(self):
         return (
-            f"<qd.Tensor shape={self.shape} layout={self.layout} "
-            f"physical_shape={self.physical_shape} dtype={self.dtype}>"
+            f"<qd.{type(self).__name__} shape={self.shape} layout={self.layout} "
+            f"physical_shape={self.physical_shape} dtype={self.dtype} backend={self.backend.value}>"
         )
 
     def _translate_key(self, key) -> Tuple[int, ...]:
@@ -199,8 +225,83 @@ class Tensor:
             self.underlying.from_numpy(physical)
 
 
-def tensor(dtype, shape, layout=None) -> Tensor:
-    """Create a layout-aware :class:`Tensor`.
+# ---------------------------------------------------------------------------
+# Concrete dataclass variants: one per storage backend.
+# ---------------------------------------------------------------------------
+
+# Field-type marker so the dataclass kernel-arg bridge sees the underlying as
+# a regular qd.ndarray. ``ndim`` is left None here because we want to accept
+# tensors of any rank as kernel args; per-call validation matches at runtime
+# inside ``check_matched`` upstream.
+_UNDERLYING_NDARRAY_TYPE = _NdarrayType()
+
+
+@dataclasses.dataclass(repr=False)
+class NdarrayTensor(_TensorBase):
+    """Layout-aware logical view of an ``Ndarray`` (default backend).
+
+    Constructed via :func:`tensor` with ``backend=Backend.NDARRAY`` (default).
+    Kernel-arg binding goes through the standard ndarray path, so passing a
+    :class:`NdarrayTensor` to a kernel costs no extra copies.
+    """
+
+    # Bridge-bound fields. Annotations matter to the kernel-arg dispatcher.
+    underlying: _UNDERLYING_NDARRAY_TYPE  # type: ignore[valid-type]
+    layout: _template
+
+    _backend = Backend.NDARRAY
+
+
+@dataclasses.dataclass(repr=False)
+class FieldTensor(_TensorBase):
+    """Layout-aware logical view of a :func:`~quadrants.lang.impl.field`.
+
+    Constructed via :func:`tensor` with ``backend=Backend.FIELD``. Fields are
+    SNode-backed and bound to kernels by-reference via the ``qd.template``
+    path (the same way bare fields are bound). Useful when the underlying
+    storage benefits from SNode features (sparse layouts, hierarchical
+    placement, ``order=`` overrides).
+
+    Kernel signatures must annotate parameters as :class:`FieldTensor`
+    explicitly (not :class:`Tensor` / :class:`NdarrayTensor`) so the
+    dataclass bridge picks the template binding path for ``underlying``.
+    """
+
+    # ``qd.template`` because qd.field is a runtime singleton, not a transient
+    # ndarray buffer.
+    underlying: _template
+    layout: _template
+
+    _backend = Backend.FIELD
+
+
+# Backwards-compatible alias: ``qd.Tensor`` resolves to the default ndarray
+# variant. New code that needs a field-backed kernel arg must use
+# :class:`FieldTensor` explicitly.
+Tensor = NdarrayTensor
+
+
+# ---------------------------------------------------------------------------
+# User-facing factory.
+# ---------------------------------------------------------------------------
+
+
+def _coerce_backend(backend) -> Backend:
+    if isinstance(backend, Backend):
+        return backend
+    if isinstance(backend, str):
+        # Tolerate string literals for ergonomics, but the canonical form is
+        # the enum value.
+        try:
+            return Backend(backend)
+        except ValueError as exc:
+            valid = ", ".join(repr(b.value) for b in Backend)
+            raise ValueError(f"unknown backend {backend!r}; expected one of {{{valid}}} or a Backend enum") from exc
+    raise TypeError(f"backend must be a Backend enum (got {type(backend).__name__}: {backend!r})")
+
+
+def tensor(dtype, shape, layout=None, backend: Backend = Backend.NDARRAY) -> _TensorBase:
+    """Create a layout-aware tensor.
 
     Args:
         dtype: element data type, e.g. ``qd.f32``, ``qd.i32``.
@@ -209,10 +310,13 @@ def tensor(dtype, shape, layout=None) -> Tensor:
             logical dim ``i`` is stored along physical axis ``p``. ``None``
             (default) means identity. For 2D, ``(1, 0)`` is the canonical
             "transposed in memory" choice.
+        backend: storage backend, a :class:`Backend` enum value. Defaults to
+            :attr:`Backend.NDARRAY`. :attr:`Backend.FIELD` allocates the
+            storage as a Quadrants field instead.
 
     Returns:
-        A :class:`Tensor` wrapping a freshly allocated ``Ndarray`` of the
-        appropriate physical shape.
+        A :class:`NdarrayTensor` or :class:`FieldTensor` wrapping freshly
+        allocated storage of the appropriate physical shape.
     """
     if isinstance(shape, int):
         shape = (shape,)
@@ -222,5 +326,13 @@ def tensor(dtype, shape, layout=None) -> Tensor:
         layout = tuple(range(ndim))
     layout = _validate_layout(layout, ndim)
     physical_shape = _logical_to_physical_shape(shape, layout)
-    underlying = impl.ndarray(dtype, physical_shape)
-    return Tensor(underlying=underlying, layout=layout)
+
+    backend = _coerce_backend(backend)
+    if backend is Backend.NDARRAY:
+        underlying = impl.ndarray(dtype, physical_shape)
+        return NdarrayTensor(underlying=underlying, layout=layout)
+    if backend is Backend.FIELD:
+        underlying = impl.field(dtype, shape=physical_shape)
+        return FieldTensor(underlying=underlying, layout=layout)
+    # Should be unreachable thanks to _coerce_backend.
+    raise ValueError(f"unhandled backend: {backend!r}")

--- a/python/quadrants/types/__init__.py
+++ b/python/quadrants/types/__init__.py
@@ -5,7 +5,7 @@ This module defines data types in Quadrants:
 - compound: matrix, vector, struct.
 - template: for reference types.
 - ndarray: for arbitrary arrays.
-- tensor: layout-aware ndarray (logical-to-physical permutation).
+- tensor: layout-aware ndarray or field (logical-to-physical permutation).
 - quant: for quantized types, see "https://yuanming.quadrants.graphics/publication/2021-quanquadrants/quanquadrants.pdf"
 """
 
@@ -17,14 +17,17 @@ from quadrants.types.primitive_types import *  # type: ignore
 from quadrants.types.utils import *  # type: ignore
 
 # isort: split
-# Layout-aware tensor: re-export the Tensor class as the type-annotation alias
-# for kernel arguments. Mirrors the qd.types.ndarray naming convention. The
-# underlying machinery is the dataclass kernel-arg bridge — see
-# quadrants.lang._tensor for details.
+# Layout-aware tensor: re-export both backend variants as type-annotation
+# aliases for kernel arguments. Mirrors the qd.types.ndarray naming
+# convention. The underlying machinery is the dataclass kernel-arg bridge —
+# see quadrants.lang._tensor for details. ``tensor`` aliases the default
+# (ndarray) variant for backward compatibility; ``field_tensor`` resolves
+# field-backed kernel args.
 #
-# This import deliberately lives *after* the type re-exports above, because
+# These imports deliberately live *after* the type re-exports above, because
 # quadrants.lang depends on quadrants.types and we would otherwise create a
 # circular import.
-from quadrants.lang._tensor import Tensor as tensor  # noqa: F401
+from quadrants.lang._tensor import FieldTensor as field_tensor  # noqa: F401
+from quadrants.lang._tensor import NdarrayTensor as tensor  # noqa: F401
 
-__all__ = ["quant", "tensor"]
+__all__ = ["quant", "tensor", "field_tensor"]

--- a/tests/python/test_tensor_field_backend.py
+++ b/tests/python/test_tensor_field_backend.py
@@ -1,0 +1,209 @@
+"""Tests for qd.tensor with backend=Backend.FIELD — Phase 1b.
+
+These tests cover the python-scope surface of :class:`qd.FieldTensor`,
+mirroring ``test_tensor.py`` but selecting the field storage backend.
+The kernel-arg binding path for FieldTensor is exercised in Phase 2b.
+"""
+
+import numpy as np
+import pytest
+
+import quadrants as qd
+from quadrants.lang.misc import get_host_arch_list
+
+from tests import test_utils
+
+# ---------------------------------------------------------------------------
+# Backend enum + factory dispatch.
+# ---------------------------------------------------------------------------
+
+
+def test_backend_enum_members():
+    """Backend exposes both NDARRAY and FIELD; values are stable strings."""
+    assert qd.Backend.NDARRAY.value == "ndarray"
+    assert qd.Backend.FIELD.value == "field"
+    assert {b.value for b in qd.Backend} == {"ndarray", "field"}
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_factory_default_is_ndarray():
+    """Default backend kwarg yields an NdarrayTensor (backwards compatible)."""
+    t = qd.tensor(qd.f32, shape=(3, 4))
+    assert isinstance(t, qd.NdarrayTensor)
+    assert t.backend is qd.Backend.NDARRAY
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_factory_field_backend_yields_FieldTensor():
+    t = qd.tensor(qd.f32, shape=(3, 4), backend=qd.Backend.FIELD)
+    assert isinstance(t, qd.FieldTensor)
+    assert t.backend is qd.Backend.FIELD
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_factory_string_backend_coercion():
+    """Tolerate string literal 'field' / 'ndarray' for ergonomics."""
+    t_field = qd.tensor(qd.f32, shape=(2, 3), backend="field")
+    t_nd = qd.tensor(qd.f32, shape=(2, 3), backend="ndarray")
+    assert isinstance(t_field, qd.FieldTensor)
+    assert isinstance(t_nd, qd.NdarrayTensor)
+
+
+def test_factory_rejects_bad_backend_type():
+    qd.init(arch=qd.cpu)
+    with pytest.raises(TypeError, match="backend must be a Backend enum"):
+        qd.tensor(qd.f32, shape=(2,), backend=42)
+
+
+def test_factory_rejects_unknown_backend_string():
+    qd.init(arch=qd.cpu)
+    with pytest.raises(ValueError, match="unknown backend"):
+        qd.tensor(qd.f32, shape=(2,), backend="nope")
+
+
+# ---------------------------------------------------------------------------
+# FieldTensor python-scope: same API as NdarrayTensor, different storage.
+# ---------------------------------------------------------------------------
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_default_layout_is_identity():
+    t = qd.tensor(qd.f32, shape=(4, 6), backend=qd.Backend.FIELD)
+    assert t.shape == (4, 6)
+    assert t.physical_shape == (4, 6)
+    assert t.layout == (0, 1)
+    assert t.ndim == 2
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_transposed_layout():
+    """layout=(1, 0) flips the physical shape but preserves logical shape."""
+    t = qd.tensor(qd.f32, shape=(4, 6), layout=(1, 0), backend=qd.Backend.FIELD)
+    assert t.shape == (4, 6)
+    assert t.physical_shape == (6, 4)
+    assert t.layout == (1, 0)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_3d_layout():
+    t = qd.tensor(qd.f32, shape=(2, 3, 5), layout=(2, 0, 1), backend=qd.Backend.FIELD)
+    assert t.shape == (2, 3, 5)
+    # physical[layout[i]] = logical[i] -> physical[2]=2, physical[0]=3, physical[1]=5
+    assert t.physical_shape == (3, 5, 2)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_dtype():
+    t = qd.tensor(qd.f32, shape=(3,), backend=qd.Backend.FIELD)
+    assert t.dtype == qd.f32
+
+
+# ---------------------------------------------------------------------------
+# Logical subscript translates to physical via field.__getitem__/__setitem__.
+# ---------------------------------------------------------------------------
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_subscript_identity_layout():
+    t = qd.tensor(qd.f32, shape=(3, 4), backend=qd.Backend.FIELD)
+    t[1, 2] = 7.5
+    assert t[1, 2] == 7.5
+    # No layout permutation: underlying field has the same physical layout.
+    assert t.underlying[1, 2] == 7.5
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_subscript_transposed_writes_to_swapped_physical():
+    """Writing logical[i, j] on a (1, 0) FieldTensor lands at physical[j, i]."""
+    t = qd.tensor(qd.f32, shape=(3, 4), layout=(1, 0), backend=qd.Backend.FIELD)
+    t[1, 2] = 7.5
+    # Physical shape is (4, 3); the write should be at physical[2, 1].
+    assert t.underlying[2, 1] == 7.5
+    # And reading back through the logical view returns the same value.
+    assert t[1, 2] == 7.5
+
+
+# ---------------------------------------------------------------------------
+# from_numpy / to_numpy round-trip (logical layout).
+# ---------------------------------------------------------------------------
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_from_numpy_to_numpy_identity():
+    t = qd.tensor(qd.f32, shape=(3, 4), backend=qd.Backend.FIELD)
+    src = np.arange(12, dtype=np.float32).reshape(3, 4)
+    t.from_numpy(src)
+    np.testing.assert_array_equal(t.to_numpy(), src)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_from_numpy_to_numpy_transposed():
+    t = qd.tensor(qd.f32, shape=(3, 4), layout=(1, 0), backend=qd.Backend.FIELD)
+    src = np.arange(12, dtype=np.float32).reshape(3, 4)
+    t.from_numpy(src)
+    # Logical view round-trips.
+    np.testing.assert_array_equal(t.to_numpy(), src)
+    # Underlying physical storage really is transposed.
+    np.testing.assert_array_equal(t.underlying.to_numpy(), src.T)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_from_numpy_3d_permuted():
+    """A 3D permutation: logical (2, 3, 5), layout (2, 0, 1)."""
+    t = qd.tensor(qd.f32, shape=(2, 3, 5), layout=(2, 0, 1), backend=qd.Backend.FIELD)
+    src = np.arange(30, dtype=np.float32).reshape(2, 3, 5)
+    t.from_numpy(src)
+    np.testing.assert_array_equal(t.to_numpy(), src)
+    # Physical shape: (3, 5, 2).
+    assert t.underlying.to_numpy().shape == (3, 5, 2)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_from_numpy_wrong_logical_shape_raises():
+    t = qd.tensor(qd.f32, shape=(3, 4), backend=qd.Backend.FIELD)
+    with pytest.raises(ValueError, match="expects logical shape"):
+        # Passing physical (transposed) shape should fail because we expect logical.
+        t.from_numpy(np.zeros((4, 3), dtype=np.float32))
+
+
+# ---------------------------------------------------------------------------
+# Misc: fill, repr, isinstance behaviour, separation from NdarrayTensor.
+# ---------------------------------------------------------------------------
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_fill_layout_independent():
+    t = qd.tensor(qd.f32, shape=(2, 3), layout=(1, 0), backend=qd.Backend.FIELD)
+    t.fill(2.0)
+    np.testing.assert_array_equal(t.to_numpy(), 2.0 * np.ones((2, 3), dtype=np.float32))
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_repr_includes_backend_marker():
+    t = qd.tensor(qd.f32, shape=(2, 3), layout=(1, 0), backend=qd.Backend.FIELD)
+    text = repr(t)
+    assert "FieldTensor" in text
+    assert "shape=(2, 3)" in text
+    assert "layout=(1, 0)" in text
+    assert "backend=field" in text
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_is_not_an_ndarray_tensor():
+    """Backend variants are distinct types so kernel-arg dispatch can branch on them."""
+    t_nd = qd.tensor(qd.f32, shape=(2, 3))
+    t_fd = qd.tensor(qd.f32, shape=(2, 3), backend=qd.Backend.FIELD)
+    assert isinstance(t_nd, qd.NdarrayTensor)
+    assert not isinstance(t_nd, qd.FieldTensor)
+    assert isinstance(t_fd, qd.FieldTensor)
+    assert not isinstance(t_fd, qd.NdarrayTensor)
+    # qd.Tensor is the backwards-compat alias for the ndarray variant.
+    assert qd.Tensor is qd.NdarrayTensor
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_tensor_invalid_layout_rejected():
+    """Layout validation must reject non-permutations on the field backend too."""
+    qd.init(arch=qd.cpu)
+    with pytest.raises(ValueError, match="permutation of range"):
+        qd.tensor(qd.f32, shape=(3, 4), layout=(0, 0), backend=qd.Backend.FIELD)


### PR DESCRIPTION
Add a second storage backend for ``qd.tensor`` so users can pick between ndarray (default) and Quadrants field at construction time:

    qd.tensor(qd.f32, shape=(N, B))                              # NDARRAY
    qd.tensor(qd.f32, shape=(N, B), backend=qd.Backend.FIELD)    # FIELD

The factory dispatches on a ``qd.Backend`` enum (string literals are tolerated for ergonomics but the canonical form is the enum). The Phase 1 ``Tensor`` dataclass is split into a ``_TensorBase`` mixin holding all backend-agnostic layout/index logic plus two concrete dataclass variants:

  - ``NdarrayTensor``: ``underlying: qd.types.ndarray()`` — bridged via the standard ndarray kernel-arg path.
  - ``FieldTensor``:   ``underlying: qd.template``        — bridged via
    the template path (field is a runtime singleton).

``qd.Tensor`` is kept as a backwards-compat alias for ``NdarrayTensor``, so kernels written against Phase 1 keep compiling unchanged.

Phase 2b will cover end-to-end FieldTensor kernel-arg binding; this commit covers only the python-scope surface (construction, shape/layout/dtype/ backend properties, logical subscript, to_numpy/from_numpy round-trips, repr, error paths).

Tests: 20 new tests in ``tests/python/test_tensor_field_backend.py``, covering both backends + the enum + string coercion + bad-input paths. All 42 tensor tests (Phase 1 + Phase 1b) green on cpu_x64.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
