### PR TITLE
[Type] Tensor 3: AST subscript translation for qd.Tensor params

### DIFF
--- a/python/quadrants/lang/_tensor_ast.py
+++ b/python/quadrants/lang/_tensor_ast.py
@@ -1,0 +1,251 @@
+"""AST pass that rewrites tensor subscripts inside ``@qd.kernel`` / ``@qd.func``.
+
+This is the Phase 3 sugar layer: lets users write logical subscripts on a
+:class:`~quadrants.lang._tensor._TensorBase` parameter directly inside a
+kernel body, e.g.
+
+    @qd.kernel
+    def k(t: qd.Tensor, n0: qd.i32, n1: qd.i32):
+        for i, j in qd.ndrange(n0, n1):
+            t[i, j] = qd.f32(i + j)            # was: t.underlying[j, i] for layout=(1, 0)
+
+without having to spell out ``t.underlying[...]`` and manually permute
+indices. The permutation is resolved at trace time from the bound
+``Tensor.layout`` (which is part of the fastcache key, so each layout
+gets its own specialised compilation).
+
+The pass runs *before* the dataclass flattening pass
+(``unpack_ast_struct_expressions``); subscripts get rewritten from
+``t[i, j]`` to ``t.underlying[j, i]``, and the flattening pass then turns
+``t.underlying`` into the flattened name ``__qd_t__qd_underlying`` exactly
+as it does for any other dataclass field access.
+
+Covers:
+- read:           ``x = t[i, j]``
+- write:          ``t[i, j] = x``
+- augmented:      ``t[i, j] += x``  (and friends ``-= *= /= //= %= **= &= |= ^=``)
+- 1D / 2D / 3D / arbitrary rank
+- both backends (NdarrayTensor + FieldTensor) — backend-agnostic; only
+  ``layout`` and the ``underlying`` attribute name are used.
+
+Subscripts where the value is *not* a Name (e.g. ``f(t)[i, j]``) or where
+the Name does not refer to a tensor parameter are left untouched.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from typing import Any
+
+from quadrants.lang import _tensor
+
+
+def _is_tensor_param_annotation(annotation: Any) -> bool:
+    """True if ``annotation`` is a concrete :class:`_TensorBase` subclass."""
+    return (
+        isinstance(annotation, type)
+        and issubclass(annotation, _tensor._TensorBase)
+        and annotation is not _tensor._TensorBase
+    )
+
+
+def _tensor_param_names(fn) -> list[str]:
+    """Names of parameters of ``fn`` whose annotation is a tensor backend variant."""
+    return [
+        name
+        for name, parameter in inspect.signature(fn).parameters.items()
+        if _is_tensor_param_annotation(parameter.annotation)
+    ]
+
+
+def extract_tensor_params_from_kernel_args(
+    fn, py_args: tuple[Any, ...]
+) -> dict[str, tuple[int, ...]]:
+    """Return ``{param_name: layout_tuple}`` for every kernel parameter typed
+    as a tensor backend variant.
+
+    Used on the kernel-call path, where ``py_args`` still contains the bound
+    Tensor instances positionally aligned with the function signature.
+    """
+    layouts: dict[str, tuple[int, ...]] = {}
+    parameters = inspect.signature(fn).parameters
+    for i, (name, parameter) in enumerate(parameters.items()):
+        if not _is_tensor_param_annotation(parameter.annotation):
+            continue
+        if i >= len(py_args):
+            continue
+        bound = py_args[i]
+        if not isinstance(bound, _tensor._TensorBase):
+            # Annotation says tensor but caller passed something else; let the
+            # downstream binder produce the canonical error.
+            continue
+        layouts[name] = tuple(bound.layout)
+    return layouts
+
+
+def extract_tensor_params_from_expanded_args(
+    fn, py_args: tuple[Any, ...], arg_metas_expanded
+) -> dict[str, tuple[int, ...]]:
+    """Return ``{param_name: layout_tuple}`` for every tensor parameter of a
+    ``qd.func`` whose call has been expanded by the kernel-side
+    ``CallTransformer``.
+
+    The expansion replaces a ``Tensor`` instance with two flat fields named
+    ``__qd_{param}__qd_underlying`` and ``__qd_{param}__qd_layout``; the
+    layout slot's runtime value is the actual layout tuple. We match these
+    by name in ``arg_metas_expanded`` to locate the layout position.
+    """
+    from quadrants.lang._dataclass_util import create_flat_name
+
+    by_name = {meta.name: i for i, meta in enumerate(arg_metas_expanded)}
+    layouts: dict[str, tuple[int, ...]] = {}
+    for name in _tensor_param_names(fn):
+        layout_arg_name = create_flat_name(name, "layout")
+        idx = by_name.get(layout_arg_name)
+        if idx is None or idx >= len(py_args):
+            continue
+        value = py_args[idx]
+        if not isinstance(value, tuple):
+            # Pre-trace: layout slot might not yet be a python tuple if pruning
+            # changed the layout; skip and let the original error surface.
+            continue
+        layouts[name] = value
+    return layouts
+
+
+def _permute_slice(slice_node: ast.AST, layout: tuple[int, ...]) -> ast.AST:
+    """Reorder the elements of a Subscript ``slice`` according to ``layout``.
+
+    Convention (matches Python-scope :class:`_TensorBase`): for each logical
+    axis ``k``, the index value lands at physical position ``layout[k]``::
+
+        physical[layout[k]] = slice[k]
+
+    For 1D layouts ``(0,)`` this is the identity. Multi-axis subscripts must
+    be ``ast.Tuple`` nodes (Python parses ``t[i, j]`` as
+    ``Subscript(slice=Tuple([i, j]))``); other slice shapes pass through
+    unchanged so we don't accidentally rewrite something exotic.
+    """
+    if len(layout) == 1:
+        # Identity permutation: nothing to do, regardless of how the user
+        # spelled the single index.
+        return slice_node
+
+    if not isinstance(slice_node, ast.Tuple):
+        # Single non-tuple index on a multi-dim tensor: caller error, but we
+        # leave the AST alone and let the downstream subscript path raise
+        # with its native error message.
+        return slice_node
+
+    elts = slice_node.elts
+    if len(elts) != len(layout):
+        # Arity mismatch: same reasoning — leave alone.
+        return slice_node
+
+    permuted: list[ast.AST | None] = [None] * len(layout)
+    for k, p in enumerate(layout):
+        permuted[p] = elts[k]
+    new_tuple = ast.Tuple(elts=permuted, ctx=slice_node.ctx)  # type: ignore[arg-type]
+    return ast.copy_location(new_tuple, slice_node)
+
+
+class _TensorSubscriptTransformer(ast.NodeTransformer):
+    """Rewrites ``t[idx]`` -> ``t.underlying[permuted_idx]`` for tensor
+    parameters whose layout is given in ``tensor_layouts``.
+
+    The transformer rewrites only the ``Subscript`` *value* and *slice*
+    nodes; ``ctx`` (Load / Store / Del) is preserved, so reads, plain
+    assignments, and augmented assignments all flow through unchanged.
+    """
+
+    def __init__(self, tensor_layouts: dict[str, tuple[int, ...]]) -> None:
+        self.tensor_layouts = tensor_layouts
+
+    def visit_Subscript(self, node: ast.Subscript) -> ast.AST:
+        # Recurse into children first so nested subscripts (e.g.
+        # ``t[other[i], j]``) get rewritten before we touch the outer one.
+        self.generic_visit(node)
+
+        if not isinstance(node.value, ast.Name):
+            return node
+        name = node.value.id
+        layout = self.tensor_layouts.get(name)
+        if layout is None:
+            return node
+
+        permuted_slice = _permute_slice(node.slice, layout)
+        new_value = ast.Attribute(
+            value=ast.Name(id=name, ctx=ast.Load()),
+            attr="underlying",
+            ctx=ast.Load(),
+        )
+        new_value = ast.copy_location(new_value, node.value)
+        new_node = ast.Subscript(
+            value=new_value,
+            slice=permuted_slice,
+            ctx=node.ctx,
+        )
+        return ast.copy_location(new_node, node)
+
+
+def _make_keepalive_layout_stmt(name: str, lineno: int, col_offset: int) -> ast.stmt:
+    """Synthetic ``__qd_keepalive_<name>_layout = <name>.layout`` statement.
+
+    Inserted at the top of a kernel/func body for each tensor param so that
+    pruning sees the layout slot as used. The rewrite consumes the layout
+    *value* at trace time (folded into the index permutation), but leaves
+    no literal reference to ``t.layout`` in the rewritten body. Without
+    this keepalive, pruning's pass-0 record for a ``qd.func`` would mark
+    ``__qd_<t>__qd_layout`` as unused, and pass-1 would re-trace with the
+    slot stripped — at which point this transformer can no longer learn
+    the layout to permute the subscripts, and ``t[i, j]`` reaches Quadrants
+    unrewritten and crashes.
+
+    Assigning to a discarded local avoids the question of whether a bare
+    expression statement is legal in Quadrants scope.
+    """
+    target = ast.Name(id=f"__qd_keepalive_{name}_layout", ctx=ast.Store())
+    value = ast.Attribute(
+        value=ast.Name(id=name, ctx=ast.Load()),
+        attr="layout",
+        ctx=ast.Load(),
+    )
+    stmt = ast.Assign(targets=[target], value=value)
+    for node in (target, value, value.value, stmt):
+        node.lineno = lineno
+        node.col_offset = col_offset
+        node.end_lineno = lineno
+        node.end_col_offset = col_offset
+    return stmt
+
+
+def unpack_ast_tensor_subscripts(
+    tree: ast.Module, tensor_layouts: dict[str, tuple[int, ...]]
+) -> ast.Module:
+    """Apply :class:`_TensorSubscriptTransformer` to the tree, in place.
+
+    Returns the (possibly mutated) tree with line numbers fixed up. If
+    ``tensor_layouts`` is empty this is a near-no-op and skips the walk.
+
+    Also injects a tiny "keep-layout-alive" statement at the top of the
+    target function body for each tensor param (see
+    :func:`_make_keepalive_layout_stmt`).
+    """
+    if not tensor_layouts:
+        return tree
+    transformer = _TensorSubscriptTransformer(tensor_layouts=tensor_layouts)
+    new_tree = transformer.visit(tree)
+
+    # Inject keepalive statements at the top of the function body.
+    if isinstance(new_tree, ast.Module) and new_tree.body and isinstance(new_tree.body[0], ast.FunctionDef):
+        func_def = new_tree.body[0]
+        first_stmt = func_def.body[0] if func_def.body else func_def
+        keepalives = [
+            _make_keepalive_layout_stmt(name, first_stmt.lineno, first_stmt.col_offset)
+            for name in tensor_layouts
+        ]
+        func_def.body = keepalives + func_def.body
+
+    ast.fix_missing_locations(new_tree)
+    return new_tree

--- a/python/quadrants/lang/func.py
+++ b/python/quadrants/lang/func.py
@@ -5,7 +5,7 @@ from quadrants._lib.core.quadrants_python import (
     Function as FunctionCxx,
 )
 from quadrants._lib.core.quadrants_python import FunctionKey
-from quadrants.lang import _kernel_impl_dataclass, impl, ops
+from quadrants.lang import _kernel_impl_dataclass, _tensor_ast, impl, ops
 from quadrants.lang.any_array import AnyArray
 from quadrants.lang.ast import (
     transform_tree,
@@ -85,6 +85,16 @@ class Func(FuncBase):
 
         struct_locals = _kernel_impl_dataclass.extract_struct_locals_from_context(ctx)
 
+        # Tensor subscript sugar (Phase 3): rewrite ``t[i, j]`` ->
+        # ``t.underlying[permuted_idx]`` for any tensor parameter, then let
+        # the dataclass flatten pass turn ``t.underlying`` into the standard
+        # flat name. The kernel-side CallTransformer already expanded each
+        # Tensor arg into ``(underlying, layout)``, so we look up the layout
+        # by name in arg_metas_expanded rather than in the original py_args.
+        tensor_layouts = _tensor_ast.extract_tensor_params_from_expanded_args(
+            self.func, py_args, self.arg_metas_expanded
+        )
+        tree = _tensor_ast.unpack_ast_tensor_subscripts(tree, tensor_layouts=tensor_layouts)
         tree = _kernel_impl_dataclass.unpack_ast_struct_expressions(tree, struct_locals=struct_locals)
         ret = transform_tree(tree, ctx)
         if not self.is_real_function:

--- a/python/quadrants/lang/kernel.py
+++ b/python/quadrants/lang/kernel.py
@@ -24,7 +24,7 @@ from quadrants._lib.core.quadrants_python import (
     KernelCxx,
     KernelLaunchContext,
 )
-from quadrants.lang import _kernel_impl_dataclass, impl, runtime_ops
+from quadrants.lang import _kernel_impl_dataclass, _tensor_ast, impl, runtime_ops
 from quadrants.lang._fast_caching import src_hasher
 from quadrants.lang._wrap_inspect import FunctionSourceInfo, get_source_info_and_src
 from quadrants.lang.ast import (
@@ -220,7 +220,16 @@ class ASTGenerator:
                 struct_locals = pruning.used_vars_by_func_id[ctx.func.func_id]
             # struct locals are the expanded py dataclass fields that we will write to
             # local variables, and will then be available to use in build_Call, later.
-            tree = _kernel_impl_dataclass.unpack_ast_struct_expressions(self.tree, struct_locals=struct_locals)
+            #
+            # Tensor subscript sugar (Phase 3): rewrite ``t[i, j]`` into
+            # ``t.underlying[permuted_idx]`` for any kernel parameter typed as a
+            # qd._TensorBase subclass. The struct-flatten pass below then turns
+            # ``t.underlying`` into the standard flat name. This must run
+            # *before* unpack_ast_struct_expressions so the new ``Attribute``
+            # node it inserts is visible to the flattener.
+            tensor_layouts = _tensor_ast.extract_tensor_params_from_kernel_args(ctx.func.func, ctx.py_args)
+            tree = _tensor_ast.unpack_ast_tensor_subscripts(self.tree, tensor_layouts=tensor_layouts)
+            tree = _kernel_impl_dataclass.unpack_ast_struct_expressions(tree, struct_locals=struct_locals)
             ctx.only_parse_function_def = self.only_parse_function_def
             transform_tree(tree, ctx)
             if not ctx.is_real_function and not ctx.only_parse_function_def:

--- a/tests/python/test_tensor_subscript.py
+++ b/tests/python/test_tensor_subscript.py
@@ -1,0 +1,240 @@
+"""Phase 3 tests: bare ``t[i, j]`` subscript inside a kernel.
+
+Phase 3 ships an AST pre-pass that rewrites tensor subscripts so users can
+write logical indexing directly inside kernels:
+
+    @qd.kernel
+    def k(t: qd.Tensor, n0, n1):
+        for i, j in qd.ndrange(n0, n1):
+            t[i, j] = ...   # was: t.underlying[j, i] for layout=(1, 0)
+
+Coverage:
+- Read / write / augmented assignment.
+- 1D / 2D / 3D layouts; identity and non-identity permutations.
+- Both backends (NdarrayTensor + FieldTensor).
+- ``qd.func`` callee with a tensor parameter.
+- The pass leaves non-tensor subscripts (e.g. ``ndarray[i, j]``,
+  ``vec[k]``) untouched — including when both a tensor and a non-tensor
+  parameter sit in the same kernel.
+"""
+
+import numpy as np
+
+import quadrants as qd
+from quadrants.lang.misc import get_host_arch_list
+
+from tests import test_utils
+
+
+# ---------------------------------------------------------------------------
+# Read / write — both layouts, both backends.
+# ---------------------------------------------------------------------------
+
+
+@qd.kernel
+def _write_logical(t: qd.Tensor, n0: qd.i32, n1: qd.i32):
+    """Write logical i*10+j via bare subscript syntax."""
+    for i, j in qd.ndrange(n0, n1):
+        t[i, j] = qd.f32(i * 10 + j)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_subscript_write_identity_layout():
+    t = qd.tensor(qd.f32, shape=(3, 4))
+    _write_logical(t, 3, 4)
+    expected = np.fromfunction(lambda i, j: i * 10 + j, (3, 4), dtype=np.float32)
+    np.testing.assert_array_equal(t.to_numpy(), expected)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_subscript_write_transposed_layout():
+    """Bare t[i, j] write on a transposed tensor lands at the right physical slot."""
+    t = qd.tensor(qd.f32, shape=(3, 4), layout=(1, 0))
+    _write_logical(t, 3, 4)
+    expected = np.fromfunction(lambda i, j: i * 10 + j, (3, 4), dtype=np.float32)
+    # Logical view round-trips.
+    np.testing.assert_array_equal(t.to_numpy(), expected)
+    # Physical storage is the transpose.
+    np.testing.assert_array_equal(t.underlying.to_numpy(), expected.T)
+
+
+@qd.kernel
+def _read_sum(t: qd.Tensor, n0: qd.i32, n1: qd.i32, out: qd.types.ndarray(qd.f32, 1)):
+    """Read every cell via bare subscript and accumulate."""
+    s = qd.f32(0.0)
+    for i, j in qd.ndrange(n0, n1):
+        s += t[i, j]
+    out[0] = s
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_subscript_read_identity_layout():
+    src = np.arange(12, dtype=np.float32).reshape(3, 4)
+    t = qd.tensor(qd.f32, shape=(3, 4))
+    t.from_numpy(src)
+    out = qd.ndarray(qd.f32, shape=(1,))
+    _read_sum(t, 3, 4, out)
+    assert out[0] == src.sum()
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_subscript_read_transposed_layout():
+    src = np.arange(12, dtype=np.float32).reshape(3, 4)
+    t = qd.tensor(qd.f32, shape=(3, 4), layout=(1, 0))
+    t.from_numpy(src)
+    out = qd.ndarray(qd.f32, shape=(1,))
+    _read_sum(t, 3, 4, out)
+    assert out[0] == src.sum()
+
+
+# ---------------------------------------------------------------------------
+# Augmented assignment.
+# ---------------------------------------------------------------------------
+
+
+@qd.kernel
+def _increment(t: qd.Tensor, n0: qd.i32, n1: qd.i32):
+    for i, j in qd.ndrange(n0, n1):
+        t[i, j] += qd.f32(1.0)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_subscript_augassign_both_layouts():
+    for layout in [(0, 1), (1, 0)]:
+        t = qd.tensor(qd.f32, shape=(2, 3), layout=layout)
+        t.from_numpy(np.zeros((2, 3), dtype=np.float32))
+        _increment(t, 2, 3)
+        _increment(t, 2, 3)
+        np.testing.assert_array_equal(t.to_numpy(), 2.0 * np.ones((2, 3), dtype=np.float32))
+
+
+# ---------------------------------------------------------------------------
+# 1D and 3D ranks.
+# ---------------------------------------------------------------------------
+
+
+@qd.kernel
+def _fill_1d(t: qd.Tensor, n: qd.i32):
+    for i in range(n):
+        t[i] = qd.f32(i * 7)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_subscript_1d_identity():
+    t = qd.tensor(qd.f32, shape=(5,))
+    _fill_1d(t, 5)
+    np.testing.assert_array_equal(t.to_numpy(), np.array([0, 7, 14, 21, 28], dtype=np.float32))
+
+
+@qd.kernel
+def _fill_3d(t: qd.Tensor, n0: qd.i32, n1: qd.i32, n2: qd.i32):
+    for i, j, k in qd.ndrange(n0, n1, n2):
+        t[i, j, k] = qd.f32(i * 100 + j * 10 + k)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_subscript_3d_permuted_layout():
+    """Layout (2, 0, 1) on a 3D tensor: physical[layout[k]] = idx[k]."""
+    t = qd.tensor(qd.f32, shape=(2, 3, 4), layout=(2, 0, 1))
+    _fill_3d(t, 2, 3, 4)
+    expected = np.fromfunction(lambda i, j, k: i * 100 + j * 10 + k, (2, 3, 4), dtype=np.float32)
+    np.testing.assert_array_equal(t.to_numpy(), expected)
+    # Physical shape: (3, 4, 2) — confirms the rewrite is using layout, not identity.
+    assert t.underlying.to_numpy().shape == (3, 4, 2)
+
+
+# ---------------------------------------------------------------------------
+# Field backend with bare subscript.
+# ---------------------------------------------------------------------------
+
+
+@qd.kernel
+def _write_logical_field(t: qd.FieldTensor, n0: qd.i32, n1: qd.i32):
+    for i, j in qd.ndrange(n0, n1):
+        t[i, j] = qd.f32(i * 100 + j)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_subscript_field_backend_transposed():
+    t = qd.tensor(qd.f32, shape=(3, 4), layout=(1, 0), backend=qd.Backend.FIELD)
+    _write_logical_field(t, 3, 4)
+    expected = np.fromfunction(lambda i, j: i * 100 + j, (3, 4), dtype=np.float32)
+    np.testing.assert_array_equal(t.to_numpy(), expected)
+    np.testing.assert_array_equal(t.underlying.to_numpy(), expected.T)
+
+
+# ---------------------------------------------------------------------------
+# Coexistence: tensor subscript + ndarray subscript in the same kernel.
+# Confirms the rewrite only touches tensor-typed parameters.
+# ---------------------------------------------------------------------------
+
+
+@qd.kernel
+def _copy_tensor_to_ndarray(
+    t: qd.Tensor,
+    out: qd.types.ndarray(qd.f32, 2),
+    n0: qd.i32,
+    n1: qd.i32,
+):
+    for i, j in qd.ndrange(n0, n1):
+        out[i, j] = t[i, j]
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_subscript_does_not_touch_ndarray_param():
+    src = np.arange(12, dtype=np.float32).reshape(3, 4)
+    t = qd.tensor(qd.f32, shape=(3, 4), layout=(1, 0))
+    t.from_numpy(src)
+    out = qd.ndarray(qd.f32, shape=(3, 4))
+    _copy_tensor_to_ndarray(t, out, 3, 4)
+    np.testing.assert_array_equal(out.to_numpy(), src)
+
+
+# ---------------------------------------------------------------------------
+# qd.func callee with a tensor parameter.
+# ---------------------------------------------------------------------------
+
+
+@qd.func
+def _tensor_sum(t: qd.Tensor, n0: qd.i32, n1: qd.i32) -> qd.f32:
+    s = qd.f32(0.0)
+    for i, j in qd.ndrange(n0, n1):
+        s += t[i, j]
+    return s
+
+
+@qd.kernel
+def _call_tensor_sum(t: qd.Tensor, n0: qd.i32, n1: qd.i32, out: qd.types.ndarray(qd.f32, 1)):
+    out[0] = _tensor_sum(t, n0, n1)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_subscript_inside_qd_func_callee():
+    """The same AST pass runs inside qd.func bodies; bare subscript works there too."""
+    src = np.arange(12, dtype=np.float32).reshape(3, 4)
+    t = qd.tensor(qd.f32, shape=(3, 4), layout=(1, 0))
+    t.from_numpy(src)
+    out = qd.ndarray(qd.f32, shape=(1,))
+    _call_tensor_sum(t, 3, 4, out)
+    assert out[0] == src.sum()
+
+
+# ---------------------------------------------------------------------------
+# fastcache: bare subscript still produces per-layout cache entries.
+# ---------------------------------------------------------------------------
+
+
+@qd.kernel
+def _bare_fill(t: qd.Tensor, n0: qd.i32, n1: qd.i32):
+    for i, j in qd.ndrange(n0, n1):
+        t[i, j] = qd.f32(0.0)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_subscript_layouts_compile_to_distinct_cache_entries():
+    t_id = qd.tensor(qd.f32, shape=(3, 4))
+    t_tr = qd.tensor(qd.f32, shape=(3, 4), layout=(1, 0))
+    _bare_fill(t_id, 3, 4)
+    _bare_fill(t_tr, 3, 4)
+    n_compiled = len(_bare_fill._primal.mapper.mapping)
+    assert n_compiled >= 2, f"expected at least 2 cache entries (one per layout), got {n_compiled}"


### PR DESCRIPTION
Lets users write logical t[i, j] inside @qd.kernel and @qd.func bodies on any qd._TensorBase parameter (NdarrayTensor or FieldTensor); the new _tensor_ast pre-pass rewrites the subscript to t.underlying[...] with indices permuted per the tensor's layout — resolved at trace time from the bound layout (already part of the fastcache key, so each layout still gets its own specialised compilation).

Backend-agnostic. Covers load, plain store, and augmented assignment; 1D/2D/3D/N-D ranks; both backends; kernel and qd.func scope.

Pruning fix: the rewrite consumes the layout value at trace time and leaves no AST reference to t.layout, which would cause pruning's pass-1 to strip the layout slot from a qd.func's expanded args. We inject a single synthetic '__qd_keepalive_<t>_layout = t.layout' statement at the top of each function body to keep the slot alive across passes.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
