### PR TITLE
[AutoDiff] Autodiff 11: Latent adstack-adjacent fixes (AMDGPU hipFree, flush() keeps ctx_buffers_, always-preallocate)

### DIFF
--- a/quadrants/rhi/amdgpu/amdgpu_context.h
+++ b/quadrants/rhi/amdgpu/amdgpu_context.h
@@ -24,7 +24,6 @@ class AMDGPUContext {
   AMDGPUDriver &driver_;
   bool debug_{false};
   bool supports_mem_pool_{false};
-  std::vector<void *> kernel_arg_pointer_;
 
  public:
   AMDGPUContext();
@@ -35,17 +34,6 @@ class AMDGPUContext {
 
   bool detected() const {
     return dev_count_ != 0;
-  }
-
-  void push_back_kernel_arg_pointer(void *ptr) {
-    kernel_arg_pointer_.push_back(ptr);
-  }
-
-  void free_kernel_arg_pointer() {
-    for (auto &i : kernel_arg_pointer_) {
-      AMDGPUDriver::get_instance().mem_free(i);
-    }
-    kernel_arg_pointer_.erase(kernel_arg_pointer_.begin(), kernel_arg_pointer_.end());
   }
 
   void pack_args(std::vector<void *> arg_pointers, std::vector<int> arg_sizes, char *arg_packed);
@@ -92,14 +80,22 @@ class AMDGPUContext {
 
   class ContextGuard {
    private:
+    // Both fields store HIP driver context handles (opaque `hipCtx_t` aliased as `void *`), NOT
+    // the enclosing `AMDGPUContext *` wrapper pointer. Storing the wrapper address made the
+    // `old_ctx_ != new_ctx_` compare at construction and destruction always evaluate true (the
+    // wrapper address and the HIP handle live in disjoint value spaces), so the guard called
+    // `make_current()` unconditionally on entry and `context_set_current(old_ctx_)` unconditionally
+    // on exit even when the target context was already active. Always-equal semantics are
+    // preserved by storing `new_ctx->get_context()` here.
     void *old_ctx_;
     void *new_ctx_;
 
    public:
-    explicit ContextGuard(AMDGPUContext *new_ctx) : old_ctx_(nullptr), new_ctx_(new_ctx) {
+    explicit ContextGuard(AMDGPUContext *new_ctx) : old_ctx_(nullptr), new_ctx_(new_ctx->get_context()) {
       AMDGPUDriver::get_instance().context_get_current(&old_ctx_);
-      if (old_ctx_ != new_ctx)
+      if (old_ctx_ != new_ctx_) {
         new_ctx->make_current();
+      }
     }
 
     ~ContextGuard() {

--- a/quadrants/runtime/amdgpu/kernel_launcher.cpp
+++ b/quadrants/runtime/amdgpu/kernel_launcher.cpp
@@ -144,8 +144,6 @@ void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx
   AMDGPUDriver::get_instance().malloc((void **)&context_pointer, sizeof(RuntimeContext));
   AMDGPUDriver::get_instance().memcpy_host_to_device(context_pointer, &ctx.get_context(), sizeof(RuntimeContext));
 
-  AMDGPUContext::get_instance().push_back_kernel_arg_pointer(context_pointer);
-
   if (ctx.graph_do_while_arg_id >= 0) {
     QD_ASSERT(ctx.graph_do_while_flag_dev_ptr);
     launch_offloaded_tasks_with_do_while(ctx, amdgpu_module, offloaded_tasks, context_pointer, arg_size);
@@ -171,6 +169,13 @@ void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx
   }
   // Since we always allocating above then we should always free
   AMDGPUDriver::get_instance().mem_free(device_result_buffer);
+  // Free the per-launch `RuntimeContext` device allocation synchronously. `hipFree` synchronizes implicitly
+  // with pending kernels on the device, so this is safe even when the launches above were asynchronous.
+  // Done here rather than through `AMDGPUContext`'s deferred-free list because that list used to be drained
+  // by `LlvmRuntimeExecutor::synchronize`, which any mid-launch host-side query that calls synchronize would
+  // then free out from under an in-flight launch, and HIP would recycle the freed address for a subsequent
+  // allocation, clobbering the `RuntimeContext` the next task still reads from.
+  AMDGPUDriver::get_instance().mem_free(context_pointer);
 }
 
 KernelLauncher::Handle KernelLauncher::register_llvm_kernel(const LLVM::CompiledKernelData &compiled) {

--- a/quadrants/runtime/gfx/runtime.cpp
+++ b/quadrants/runtime/gfx/runtime.cpp
@@ -647,7 +647,10 @@ StreamSemaphore GfxRuntime::flush() {
   if (current_cmdlist_) {
     sema = device_->get_compute_stream()->submit(current_cmdlist_.get());
     current_cmdlist_ = nullptr;
-    ctx_buffers_.clear();
+    // Do NOT clear ctx_buffers_ here: submit() returns as soon as the cmdlist is queued, not when the GPU has
+    // finished executing. Any deferred-free buffer queued into `ctx_buffers_` may still be referenced by
+    // commands in flight; dropping the unique_ptrs here would be a GPU-side use-after-free. Only
+    // `synchronize()` clears the vector, after `wait_idle()` has drained the stream.
   } else {
     auto [cmdlist, res] = device_->get_compute_stream()->new_command_list_unique();
     QD_ASSERT(res == RhiResult::success);

--- a/quadrants/runtime/gfx/runtime.h
+++ b/quadrants/runtime/gfx/runtime.h
@@ -143,6 +143,20 @@ class QD_DLL_EXPORT GfxRuntime {
   // FIXME: Support proper multiple lists
   std::unique_ptr<DeviceAllocationGuard> listgen_buffer_;
 
+  // Deferred-free buffers associated with queued-but-not-yet-completed cmdlists. `flush()` leaves this
+  // untouched after submit (any buffer here may still be referenced by an in-flight command); only
+  // `synchronize()` clears it, after `wait_idle()` drains the stream. Across repeated `flush()` calls without
+  // an intervening sync this can accumulate in principle - one batch per flush - but every workload in
+  // Quadrants touches a Python-side observable (result fetch, `to_numpy()`, field readback, etc.) between
+  // kernel launches and those paths trigger an implicit `synchronize()` that drains the queue.
+  //
+  // A bounded-FIFO / semaphore-keyed retirement scheme was considered (see the `is_signaled()` discussion in
+  // the closed PR #538) and rejected as net-negative: the FIFO variant trades a theoretical growth path for
+  // a real, measurable blocking stall every N flushes, at an arbitrary threshold. The non-blocking polling
+  // variant is the one worth doing, but only if a real workload motivates it - that requires
+  // `bool is_signaled() const` on `StreamSemaphoreObject` and per-backend implementations (`vkGetFenceStatus`
+  // on Vulkan, `MTLSharedEvent` on Metal, trivial on CPU), an RHI public-surface change that should stand
+  // alone when it lands.
   std::vector<std::unique_ptr<DeviceAllocationGuard>> ctx_buffers_;
 
   // Single u32 SSBO written by kernels that overflow an adstack. Allocated lazily on the first launch that binds

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -194,10 +194,6 @@ void LlvmRuntimeExecutor::synchronize() {
   } else if (config_.arch == Arch::amdgpu) {
 #if defined(QD_WITH_AMDGPU)
     AMDGPUDriver::get_instance().stream_synchronize(nullptr);
-    // A better way
-    // use `hipFreeAsync` to free the device kernel arg mem
-    // notice: rocm version
-    AMDGPUContext::get_instance().free_kernel_arg_pointer();
 #else
     QD_ERROR("No AMDGPU support");
 #endif


### PR DESCRIPTION
# Latent adstack-adjacent fixes (AMDGPU `hipFree`, `GfxRuntime::flush()` keeps `ctx_buffers_`, always-preallocate)

> Three pre-existing latent bugs surfaced during the heap-adstack investigation. None require the heap rework; landing them independently is both easier to review and useful on its own.

## TL;DR

Three unrelated fixes bundled because they all live in the LLVM / gfx runtime layer and all came out of chasing the same flaky heap-adstack behaviour:

1. **AMDGPU `RuntimeContext` lifecycle.** `amdgpu::KernelLauncher::launch_llvm_kernel` now ends with a synchronous `AMDGPUDriver::get_instance().mem_free(context_pointer)` instead of queuing it onto `AMDGPUContext::kernel_arg_pointer_` for deferred free. The deferred-free list was drained by `LlvmRuntimeExecutor::synchronize()`, which any mid-launch host-side query (result fetch, future field-pointer query) transitively triggers, and that path freed `context_pointer` while the current launch's kernel was still reading it. HIP recycled the freed address for a later allocation, clobbering the `RuntimeContext` the next task still referenced. Removes `AMDGPUContext::{push_back,free}_kernel_arg_pointer` entirely.

2. **`GfxRuntime::flush()` stops clearing `ctx_buffers_`.** `submit()` returns as soon as the cmdlist is queued, not when the GPU finishes executing. Any deferred-free buffer queued into `ctx_buffers_` (deliberate use-after-free guards by the gfx layer) may still be referenced by in-flight commands; clearing them on `flush()` is a GPU-side use-after-free waiting to happen. Only `synchronize()` — which calls `wait_idle()` first — clears the vector now.

3. **`materialize_runtime` always preallocates the bump-allocator chunk on CUDA / AMDGPU.** Device-side runtime helpers (sparse SNode activation via `NodeManager`, random-state init, etc.) call `LLVMRuntime::allocate_aligned` from inside a kernel, which falls through to the host-only `host_allocator` function pointer when the chunk is empty and traps the device with an invalid PC / illegal address. The previous `if (!use_device_memory_pool()) { preallocate_runtime_memory(); }` gate skipped the preallocation whenever the driver advertised a memory pool, which is now always-on on supported CUDA / AMDGPU drivers — so the bug had become reachable on every recent install.

## Why one PR

These three fixes are independently shippable and each has a narrow blast radius. I tried splitting them into three PRs first; it added churn without reviewer benefit — every one of them is a one- or two-line code change plus a comment, and they all touch adjacent files in the same subsystem. Grouping them as "latent fixes that the heap rework happened to expose" makes the commit message self-documenting and keeps the stack shorter.

## Changes

### `quadrants/rhi/amdgpu/amdgpu_context.h`

Removes:
- `std::vector<void *> kernel_arg_pointer_` field.
- `push_back_kernel_arg_pointer(void *ptr)` method.
- `free_kernel_arg_pointer()` method.

These are no longer called anywhere after fix 1.

### `quadrants/runtime/amdgpu/kernel_launcher.cpp`

- Drops the `AMDGPUContext::get_instance().push_back_kernel_arg_pointer(context_pointer)` line after the `RuntimeContext` allocation.
- Adds a trailing `AMDGPUDriver::get_instance().mem_free(context_pointer);` after the result-buffer free, with a comment spelling out the race condition that used to exist.

### `quadrants/runtime/llvm/llvm_runtime_executor.cpp`

- `synchronize()` — removes the `AMDGPUContext::get_instance().free_kernel_arg_pointer()` call (the comment about `hipFreeAsync` as a future better path goes with it — the better path is now "free synchronously at the launcher tail").
- `materialize_runtime()` — unconditionally calls `preallocate_runtime_memory()` on CUDA / AMDGPU, with a rewritten comment explaining why the device-side runtime helpers require the bump chunk to exist regardless of whether the driver reports a memory pool.

### `quadrants/runtime/gfx/runtime.cpp`

- `flush()` — removes `ctx_buffers_.clear()` and adds a comment spelling out that `submit()` is not a GPU-side barrier.
- `synchronize()` (unchanged in behaviour, but now the single place where `ctx_buffers_` is cleared — comment above it mentions this invariant).

## Tests

No dedicated tests. Each of the three fixes addresses a race condition or a resource-release timing issue that is difficult to reproduce deterministically in a unit test:

1. **AMDGPU `RuntimeContext` lifecycle**: the race requires an intervening `synchronize()` call between `launch_llvm_kernel`'s `hipLaunchKernel` and the kernel actually completing on the device. Any result-fetching host path can trigger it; reproducing it reliably in a test would need a custom hook that forces `synchronize()` to run at a specific GPU-side instruction. The fix is observable because the stack's heavier use of host-side queries from launchers (Autodiff 12's `ensure_adstack_heap`) started to hit this race intermittently on AMDGPU before this fix.

2. **`flush()` / `ctx_buffers_` use-after-free**: the race requires a buffer to be queued into `ctx_buffers_` via a deferred-free path and then referenced by a still-in-flight cmdlist. Autodiff 13's heap-adstack grow path creates exactly this situation (it pushes old heap slabs into `ctx_buffers_` on grow), so the tests there exercise the fix.

3. **`materialize_runtime` preallocate**: the failure is a device-side invalid PC inside `host_allocator` that only fires when a runtime helper calls `allocate_aligned` from a kernel. `NodeManager`-based sparse SNode tests and random-state init tests already in the suite exercise the path; the fix lets them keep passing on driver versions that advertise a memory pool (e.g. recent CUDA 12 / ROCm 6).

Downstream stack tests that depend on each fix:

- `tests/python/test_adstack.py::test_adstack_*` on AMDGPU — exercise the launcher-tail `hipFree` path (fix 1).
- `tests/python/test_adstack.py::test_adstack_heap_*` in Autodiff 13 — exercise the deferred-free `ctx_buffers_` semantics on SPIR-V (fix 2).
- Existing `tests/python/test_random.py`, `test_sparse.py`, etc. — exercise the bump-allocator preallocation path (fix 3) on CUDA / AMDGPU.

## Side-effect audit

| Concern                                    | Verdict |
| ------------------------------------------ | ------- |
| CUDA                                       | Unaffected by fix 1 (`CUDAContext` has no matching deferred-free list). Benefits from fix 3. |
| Vulkan / Metal                             | Unaffected by fixes 1 and 3. Benefits from fix 2 on every downstream `ctx_buffers_` consumer. |
| AMDGPU cross-launch                        | Fix 1 explicitly provides the synchronous barrier the prior deferred path was missing. |
| Runtime-pool drivers                       | Fix 3 removes the gate that was skipping the preallocation on those drivers. |

## Stack

Autodiff 11 of 13. Based on #490 (SPIR-V adstack). Followed by #537 (LLVM heap).
