### PR TITLE
[SPIRV] Hoist dsyevq3 fallback out of conditional in _sym_eig3x3 (NVIDIA Vulkan workaround)

### DIFF
--- a/python/quadrants/_funcs.py
+++ b/python/quadrants/_funcs.py
@@ -455,8 +455,30 @@ def _sym_eig3x3(A, dt):
     else:
         u = t * t
     error = 256.0 * DBL_EPSILON * u * u
-    Q = Matrix.zero(dt, 3, 3)
+
+    # Call dsyevq3 (the QL-with-implicit-shift fallback) unconditionally. The
+    # result is only USED when the main-path Cardano construction of Q below
+    # degenerates (i.e. a column's norm is below `error`). Hoisting this call
+    # out of the degeneracy-test branches is a workaround for an NVIDIA
+    # proprietary Vulkan driver shader-compiler bug: when dsyevq3 (which
+    # contains nested unbounded `while True` structured loops) is emitted as
+    # a function call / inlined body *inside* a structured conditional, the
+    # driver's SPIR-V->NVVM compiler crashes (SIGSEGV inside
+    # libnvidia-gpucomp.so / libnvidia-glvkspirv.so during
+    # vkCreateComputePipelines) on otherwise spec-valid SPIR-V. Hoisting the
+    # call out to unconditional top-level flow avoids the pattern and lets
+    # NVIDIA's driver compile the kernel. dsyevq3's runtime cost is a few
+    # QL sweeps on a 3x3 tridiagonal and is negligible; the cost of the
+    # always-on fallback is much smaller than the value of having sym_eig
+    # work on Vulkan at all. On CUDA / CPU / Metal this hoist is equivalent
+    # in behavior to the previous conditional version because the selection
+    # logic below still picks the main-path result whenever the Cardano
+    # construction is well-conditioned.
     Q_final = Matrix.zero(dt, 3, 3)
+    eigenvalues_final = Vector([0.0, 0.0, 0.0], dt=dt)
+    Q_final, eigenvalues_final = dsyevq3(A, Q_final, eigenvalues_final, dt)
+
+    Q = Matrix.zero(dt, 3, 3)
     Q[0, 1] = A[0, 1] * A[1, 2] - A[0, 2] * A[1, 1]
     Q[1, 1] = A[0, 2] * A[0, 1] - A[1, 2] * A[0, 0]
     Q[2, 1] = A[0, 1] * A[0, 1]
@@ -467,7 +489,6 @@ def _sym_eig3x3(A, dt):
     norm = Q[0, 0] * Q[0, 0] + Q[1, 0] * Q[1, 0] + Q[2, 0] * Q[2, 0]
     early_ret = 0
     if norm <= error:
-        Q_final, eigenvalues_final = dsyevq3(A, Q, eigenvalues, dt)
         early_ret = 1
     else:
         norm = ops.sqrt(1.0 / norm)
@@ -475,13 +496,11 @@ def _sym_eig3x3(A, dt):
         Q[1, 0] *= norm
         Q[2, 0] *= norm
 
-    if not early_ret:
         Q[0, 1] = Q[0, 1] + A[0, 2] * eigenvalues[1]
         Q[1, 1] = Q[1, 1] + A[1, 2] * eigenvalues[1]
         Q[2, 1] = (A[0, 0] - eigenvalues[1]) * (A[1, 1] - eigenvalues[1]) - Q[2, 1]
         norm = Q[0, 1] * Q[0, 1] + Q[1, 1] * Q[1, 1] + Q[2, 1] * Q[2, 1]
         if norm <= error:
-            Q_final, eigenvalues_final = dsyevq3(A, Q, eigenvalues, dt)
             early_ret = 1
         else:
             norm = ops.sqrt(1.0 / norm)
@@ -489,9 +508,9 @@ def _sym_eig3x3(A, dt):
             Q[1, 1] *= norm
             Q[2, 1] *= norm
 
-        Q[0, 2] = Q[1, 0] * Q[2, 1] - Q[2, 0] * Q[1, 1]
-        Q[1, 2] = Q[2, 0] * Q[0, 1] - Q[0, 0] * Q[2, 1]
-        Q[2, 2] = Q[0, 0] * Q[1, 1] - Q[1, 0] * Q[0, 1]
+            Q[0, 2] = Q[1, 0] * Q[2, 1] - Q[2, 0] * Q[1, 1]
+            Q[1, 2] = Q[2, 0] * Q[0, 1] - Q[0, 0] * Q[2, 1]
+            Q[2, 2] = Q[0, 0] * Q[1, 1] - Q[1, 0] * Q[0, 1]
 
     if early_ret:
         Q = Q_final

--- a/quadrants/codegen/spirv/spirv_ir_builder.cpp
+++ b/quadrants/codegen/spirv/spirv_ir_builder.cpp
@@ -398,6 +398,26 @@ SType IRBuilder::get_array_type(const SType &_value_type, uint32_t num_elems) {
     ib_.begin(spv::OpTypeRuntimeArray).add_seq(arr_type, value_type).commit(&global_);
   }
 
+  // NOTE: We intentionally do NOT emit OpDecorate ArrayStride here.
+  // Per the Vulkan "standalone SPIR-V" rules (VUID-StandaloneSpirv-None-10684),
+  // explicit-layout decorations like ArrayStride are only permitted on types
+  // used in explicit-layout storage classes (StorageBuffer / Uniform /
+  // PushConstant / etc. via a Block/BufferBlock struct). Emitting ArrayStride
+  // on an array type that is then used as a Function- or Workgroup-scope
+  // OpVariable produces invalid SPIR-V that spirv-val rejects and that the
+  // NVIDIA proprietary Vulkan driver's SPIR-V->NVVM compiler crashes on
+  // (observed as a SIGSEGV inside libnvidia-glvkspirv.so during
+  // vkCreateComputePipelines when compiling e.g. the 3x3 sym_eig kernel,
+  // which allocates Function-scope Matrix3x3 tmp variables).
+  // Callers that need a laid-out array (get_struct_array_type below, used for
+  // Block/BufferBlock structs) add the decoration themselves.
+
+  return arr_type;
+}
+
+SType IRBuilder::get_struct_array_type(const SType &value_type, uint32_t num_elems) {
+  SType arr_type = get_array_type(value_type, num_elems);
+
   uint32_t nbytes;
   if (value_type.flag == TypeKind::kPrimitive) {
     const auto nbits = data_type_bits(value_type.dt);
@@ -416,14 +436,9 @@ SType IRBuilder::get_array_type(const SType &_value_type, uint32_t num_elems) {
     }
   }
 
-  // decorate the array type
+  // Wrap the array in a Block/BufferBlock struct; that context requires
+  // explicit layout, so ArrayStride must be decorated here.
   this->decorate(spv::OpDecorate, arr_type, spv::DecorationArrayStride, nbytes);
-
-  return arr_type;
-}
-
-SType IRBuilder::get_struct_array_type(const SType &value_type, uint32_t num_elems) {
-  SType arr_type = get_array_type(value_type, num_elems);
 
   // declare struct of array
   SType struct_type;


### PR DESCRIPTION
Issue: #

### Brief Summary

## Summary
  Workaround for an NVIDIA proprietary Vulkan driver shader-compiler bug
  that crashes `vkCreateComputePipelines` when `qd.sym_eig` is invoked on
  a 3x3 matrix.
  ## Symptom
  On Linux + NVIDIA RTX 5090 + driver `580.76.05`, any kernel that calls
  `qd.sym_eig(A_3x3)` SIGSEGVs at compile time. `gdb` backtrace points
  into `libnvidia-glvkspirv.so` → `_nv002nvvm` → `libnvidia-gpucomp.so`,
  i.e. NVIDIA's closed-source SPIR-V → NVVM shader compiler. The SPIR-V
  that quadrants emits is spec-valid (`spirv-val --target-env vulkan1.3`
  is clean after #<arraystride PR>).
  The 11 `tests/python/test_eig.py::test_sym_eig3x3_f32[arch=vulkan-*]`
  parametrizations and `test_sym_eig3x3_identity_f32[arch=vulkan]` all
  crash with SIGSEGV on this configuration. CI doesn't see this because
  `test_linux_vulkan` runs on a T4 (Turing), and the NVIDIA shader
  compiler takes a different codepath there that doesn't trigger the
  bug.
  ## Diagnosis
  Bisected the kernel down to a minimal reproducer: calling `dsyevq3`
  (the QL-with-implicit-shift fallback used by `_sym_eig3x3` when the
  Cardano construction degenerates) from inside an `if` block crashes
  the NVIDIA compiler. Calling the same `dsyevq3` unconditionally at
  top level compiles fine. The crashing factor is `dsyevq3`'s nested
  unbounded `while True` structured loops being inlined into a
  conditionally-executed block.
  The emitted SPIR-V passes `spirv-val`, so this is genuinely a bug in
  NVIDIA's driver, not in our codegen. We can't fix the driver, but we
  can route around the pattern.
  ## Fix
  Rewrite `_sym_eig3x3` so that `dsyevq3` is called once,
  unconditionally, at top level. The two existing degeneracy-test
  branches (`if norm <= error`) are kept, but they no longer call
  `dsyevq3` themselves — they just set an `early_ret` flag. After the
  main-path Cardano construction finishes, the existing
  `if early_ret: Q = Q_final; eigenvalues = eigenvalues_final` block
  still picks the fallback result whenever the main path was
  ill-conditioned. Behavior on every backend (CUDA / CPU / x64 / Metal
  / Vulkan) is identical to before whenever the main path is
  well-conditioned, and identical to the previous fallback when it
  wasn't.
  ## Cost
  One extra QL factorization (a few sweeps on a 3x3 tridiagonal) per
  `_sym_eig3x3` call on every backend, even when the main path
  succeeds. This is small relative to the Cardano + cross-product main
  path itself and is the price of getting `sym_eig3x3` to compile on
  NVIDIA Vulkan at all.

copilot:summary

### Walkthrough

copilot:walkthrough
