### PR TITLE
[Build] Autodiff 15: Replace 2022 MoltenVK pin with LunarG Vulkan SDK fetch and sanitise MoltenVK cap advertisement

### DIFF
--- a/.github/workflows/scripts/ti_build/entry.py
+++ b/.github/workflows/scripts/ti_build/entry.py
@@ -46,9 +46,13 @@ def setup_basic_build_env():
         setup_msvc()
 
     setup_llvm()
-    if u.system == "Linux":
-        # We support & test Vulkan shader debug printf on Linux
-        # This is done through the validation layer
+    if u.system in ("Linux", "Darwin"):
+        # Linux: validation layers + SPIR-V tools (shader debug printf support).
+        # macOS: the SDK bundles a current MoltenVK that advertises `VK_KHR_buffer_device_address`, which
+        # the adstack sizer shader needs for `ExternalTensorRead` via Physical Storage Buffer addressing.
+        # The Vulkan-Taichi-assets pin at `quadrants/rhi/CMakeLists.txt:40` is too old for PSB; wiring
+        # `setup_vulkan()` here lets the CMake glue pick up `$VULKAN_SDK/MoltenVK/dylib/macOS/libMoltenVK.dylib`
+        # and ship that in the wheel instead.
         from .vulkan import setup_vulkan
 
         setup_vulkan()

--- a/.github/workflows/scripts/ti_build/entry.py
+++ b/.github/workflows/scripts/ti_build/entry.py
@@ -51,8 +51,9 @@ def setup_basic_build_env():
         # macOS: the SDK bundles a current MoltenVK that advertises `VK_KHR_buffer_device_address`, which
         # the adstack sizer shader needs for `ExternalTensorRead` via Physical Storage Buffer addressing.
         # The Vulkan-Taichi-assets pin at `quadrants/rhi/CMakeLists.txt:40` is too old for PSB; wiring
-        # `setup_vulkan()` here lets the CMake glue pick up `$VULKAN_SDK/MoltenVK/dylib/macOS/libMoltenVK.dylib`
-        # and ship that in the wheel instead.
+        # `setup_vulkan()` here lets the CMake glue pick up `$VULKAN_SDK/lib/libMoltenVK.dylib` (the flat
+        # layout LunarG's macOS SDK uses - see the layout note in `vulkan.py::setup_vulkan`) and ship
+        # that in the wheel instead.
         from .vulkan import setup_vulkan
 
         setup_vulkan()

--- a/.github/workflows/scripts/ti_build/vulkan.py
+++ b/.github/workflows/scripts/ti_build/vulkan.py
@@ -3,6 +3,7 @@
 # -- stdlib --
 import os
 import platform
+import subprocess
 
 # -- third party --
 # -- own --
@@ -37,8 +38,44 @@ def setup_vulkan():
             path_prepend("PATH", sdk / "bin")
             path_prepend("LD_LIBRARY_PATH", sdk / "lib")
             os.environ["VK_LAYER_PATH"] = str(sdk / "share" / "vulkan" / "explicit_layer.d")
-        # case ("Darwin", "arm64"):
-        # case ("Darwin", "x86_64"):
+        case ("Darwin", "arm64"):
+            # LunarG's macOS `.zip` is an `InstallVulkan.app` installer bundle (the same Qt installer
+            # Windows uses), not a ready-to-use SDK tree. We extract the bundle, then invoke its CLI
+            # non-interactively to drop the actual SDK payload into a sibling prefix. LunarG didn't
+            # publish a 1.4.321.1 macOS asset (the Linux / Windows pin's patch-level); the prior
+            # 1.4.321.0 does, and is inlined here rather than factored into a separate constant.
+            url = "https://sdk.lunarg.com/sdk/download/1.4.321.0/mac/vulkansdk-macos-1.4.321.0.zip"
+            installer_dir = get_cache_home() / "vulkan-macos-1.4.321.0-installer"
+            prefix = get_cache_home() / "vulkan-macos-1.4.321.0"
+
+            download_dep(url, installer_dir, strip=1)
+            if not (prefix / "macOS").exists():
+                installer_bin = installer_dir / "Contents" / "MacOS" / "vulkansdk-macOS-1.4.321.0"
+                # Python's `zipfile` doesn't preserve the Unix execute bit, so the extracted installer
+                # comes out with mode 0644 and `exec` trips `PermissionError: [Errno 13]`. `chmod +x`
+                # here is idempotent and scoped to this single binary.
+                installer_bin.chmod(0o755)
+                subprocess.check_call(
+                    [
+                        str(installer_bin),
+                        "--root",
+                        str(prefix),
+                        "--accept-licenses",
+                        "--default-answer",
+                        "--confirm-command",
+                        "install",
+                    ]
+                )
+            sdk = prefix / "macOS"
+            os.environ["VULKAN_SDK"] = str(sdk)
+            path_prepend("PATH", sdk / "bin")
+            path_prepend("DYLD_LIBRARY_PATH", sdk / "lib")
+            os.environ["VK_LAYER_PATH"] = str(sdk / "share" / "vulkan" / "explicit_layer.d")
+            # LunarG's macOS SDK installer drops `libMoltenVK.dylib` flat inside `macOS/lib/` alongside
+            # the desktop loader - no `MoltenVK/` subtree, no xcframework of dylibs (only `.a` statics in
+            # the xcframework). `MOLTENVK_DIR` points at the directory that actually contains the dylib
+            # so `find_file` in `quadrants/rhi/CMakeLists.txt` can locate it without path guessing.
+            os.environ["MOLTENVK_DIR"] = str(sdk / "lib")
         case ("Windows", "AMD64"):
             url = (
                 f"https://sdk.lunarg.com/sdk/download/{VULKAN_VERSION}/windows/VulkanSDK-{VULKAN_VERSION}-Installer.exe"

--- a/docs/source/user_guide/supported_systems.md
+++ b/docs/source/user_guide/supported_systems.md
@@ -22,6 +22,24 @@ We test the following systems in our CI servers:
 - AMD GPUs
 - Vulkan-compatible GPUs (e.g. Intel Arc)
 
+### Backend / OS matrix
+
+Which backends are available on each supported platform. `qd.cpu` and `qd.vulkan` run on every OS; the other GPU backends are platform-specific because they wrap vendor drivers (CUDA on NVIDIA, ROCm on AMD, Metal on Apple).
+
+| OS \ backend | `qd.cpu` | `qd.cuda` | `qd.amdgpu` | `qd.metal` | `qd.vulkan` |
+| --- | --- | --- | --- | --- | --- |
+| macOS (Apple Silicon) | yes | n/a | n/a | yes | yes |
+| Linux x64 | yes | yes | yes | n/a | yes |
+| Linux ARM64 | yes | no | no | n/a | yes |
+| Windows x86 | yes | yes | no | n/a | yes |
+| Windows ARM64 | yes | no | no | n/a | yes |
+
+Notes:
+- `qd.cuda` requires an NVIDIA driver + CUDA runtime on the host; quadrants links against the CUDA runtime discovered at import time. NVIDIA ships CUDA for Linux ARM64 and Windows ARM64, but quadrants does not support them yet.
+- `qd.amdgpu` currently wires up the Linux x64 ROCm path only. AMD's HIP SDK also ships on Windows and on some Linux ARM64 targets, but quadrants does not support them yet.
+- `qd.metal` is only available on Apple hardware and is the recommended GPU backend there.
+- `qd.vulkan` on macOS ships a bundled MoltenVK dylib inside the wheel, so no separate MoltenVK install is required.
+
 ### Python backend
 
 A pure-Python backend (`qd.python`) is available on any system where PyTorch is installed. See [Python backend](./python_backend.md).

--- a/quadrants/codegen/spirv/spirv_codegen.cpp
+++ b/quadrants/codegen/spirv/spirv_codegen.cpp
@@ -954,9 +954,13 @@ void TaskCodegen::generate_overflow_branch(const spirv::Value &cond_v, const std
   // and a copy of the source line - and we want it in the runtime diagnostic. But the SPIR-V debug-printf
   // format string flows verbatim into MoltenVK's SPIRV-Cross -> MSL translator, which embeds it as an MSL
   // string literal; a `"`, `\n`, or `\r` terminates the literal mid-parse and the downstream MSL compile
-  // fails with `use of undeclared identifier '<path fragment>'`. Escape those characters so the printed
-  // traceback is preserved byte-for-byte on native Vulkan drivers and still round-trips cleanly through
-  // MSL on Apple Silicon.
+  // fails with `use of undeclared identifier '<path fragment>'`. A raw `%` is equally hazardous: the
+  // concatenated string is the printf-style format with an empty args vector, so an unescaped `%` in the
+  // source line (e.g. `a % b`, `"%d" % x`, a `%20` URL-escape) surfaces as a format specifier with no
+  // matching argument - undefined behaviour on the validation-layer debug-printf path and on MoltenVK's
+  // MSL translation. Escape all four so the printed traceback is preserved byte-for-byte on native Vulkan
+  // drivers and still round-trips cleanly through MSL on Apple Silicon. The `%` handling mirrors
+  // `sanitize_format_string` above.
   std::string safe_tb;
   safe_tb.reserve(tb.size());
   for (char c : tb) {
@@ -964,6 +968,8 @@ void TaskCodegen::generate_overflow_branch(const spirv::Value &cond_v, const std
       safe_tb += "\\\"";
     } else if (c == '\n' || c == '\r') {
       safe_tb += ' ';
+    } else if (c == '%') {
+      safe_tb += "%%";
     } else {
       safe_tb += c;
     }

--- a/quadrants/codegen/spirv/spirv_codegen.cpp
+++ b/quadrants/codegen/spirv/spirv_codegen.cpp
@@ -950,7 +950,25 @@ void TaskCodegen::generate_overflow_branch(const spirv::Value &cond_v, const std
   ir_->make_inst(spv::OpBranchConditional, cond, then_label, merge_label);
   // then block
   ir_->start_label(then_label);
-  ir_->call_debugprintf(op + " overflow detected in " + tb, {});
+  // `bin->get_tb()` carries the Python traceback that surfaced the binary op - file path, line number,
+  // and a copy of the source line - and we want it in the runtime diagnostic. But the SPIR-V debug-printf
+  // format string flows verbatim into MoltenVK's SPIRV-Cross -> MSL translator, which embeds it as an MSL
+  // string literal; a `"`, `\n`, or `\r` terminates the literal mid-parse and the downstream MSL compile
+  // fails with `use of undeclared identifier '<path fragment>'`. Escape those characters so the printed
+  // traceback is preserved byte-for-byte on native Vulkan drivers and still round-trips cleanly through
+  // MSL on Apple Silicon.
+  std::string safe_tb;
+  safe_tb.reserve(tb.size());
+  for (char c : tb) {
+    if (c == '"') {
+      safe_tb += "\\\"";
+    } else if (c == '\n' || c == '\r') {
+      safe_tb += ' ';
+    } else {
+      safe_tb += c;
+    }
+  }
+  ir_->call_debugprintf(op + " overflow detected in " + safe_tb, {});
   ir_->make_inst(spv::OpBranch, merge_label);
   // merge label
   ir_->start_label(merge_label);

--- a/quadrants/codegen/spirv/spirv_ir_builder.cpp
+++ b/quadrants/codegen/spirv/spirv_ir_builder.cpp
@@ -161,9 +161,13 @@ std::vector<uint32_t> IRBuilder::finalize() {
 
 void IRBuilder::init_pre_defs() {
   ext_glsl450_ = ext_inst_import("GLSL.std.450");
-  if (caps_->get(cap::spirv_has_non_semantic_info)) {
-    debug_printf_ = ext_inst_import("NonSemantic.DebugPrintf");
-  }
+  // `debug_printf_` is imported lazily in `call_debugprintf` on first use rather than here. A declared-but-unused
+  // `OpExtInstImport "NonSemantic.DebugPrintf"` at the top of a SPIR-V module is accepted by native Vulkan
+  // drivers but rejected by MoltenVK: the SPIRV-Cross -> MSL translator emits an unconditional stub that calls
+  // `debugPrintfEXT` even when no `OpExtInst` targets the import, and the subsequent MSL compile fails with
+  // `use of undeclared identifier 'debugPrintfEXT'`. Skipping the import entirely when no call site needs it
+  // keeps kernels without `print` or debug assert traffic compatible with MoltenVK even while the
+  // `spirv_has_non_semantic_info` capability is advertised by the Vulkan device.
 
   t_bool_ = declare_primitive_type(get_data_type<bool>());
   if (caps_->get(cap::spirv_has_int8)) {

--- a/quadrants/codegen/spirv/spirv_ir_builder.h
+++ b/quadrants/codegen/spirv/spirv_ir_builder.h
@@ -439,6 +439,12 @@ class IRBuilder {
 
   // Create a debugPrintf call
   void call_debugprintf(std::string formats, const std::vector<Value> &args) {
+    // Lazy import: see the explanatory comment in `IRBuilder::init_pre_defs`. We only emit
+    // `OpExtInstImport "NonSemantic.DebugPrintf"` the first time a printf / debug-assert call site actually
+    // needs it so kernels with no debug traffic stay MoltenVK-compatible.
+    if (!debug_printf_.id) {
+      debug_printf_ = ext_inst_import("NonSemantic.DebugPrintf");
+    }
     Value format_str = debug_string(formats);
     Value val = new_value(t_void_, ValueKind::kNormal);
     ib_.begin(spv::OpExtInst).add_seq(t_void_, val, debug_printf_, 1, format_str);

--- a/quadrants/rhi/CMakeLists.txt
+++ b/quadrants/rhi/CMakeLists.txt
@@ -28,18 +28,34 @@ endif()
 if (QD_WITH_VULKAN)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQD_WITH_VULKAN")
     if (APPLE)
-        # The latest Molten-vk v1.2.0 and v1.1.11 breaks GGUI: mpm3d_ggui.py
-        # So we have to manually download and install Molten-vk v1.10.0
-        #
-        # Uncomment the following lines if the mpm3d_ggui.py runs well with the latest Molten-vk
-        #find_library(MOLTEN_VK libMoltenVK.dylib PATHS $HOMEBREW_CELLAR/molten-vk $VULKAN_SDK REQUIRED)
-        #configure_file(${MOLTEN_VK} ${CMAKE_BINARY_DIR}/libMoltenVK.dylib COPYONLY)
-        #message(STATUS "MoltenVK library ${MOLTEN_VK}")
-
-        if(NOT EXISTS ${CMAKE_BINARY_DIR}/libMoltenVK.dylib)
-            execute_process(COMMAND curl -L -o ${CMAKE_BINARY_DIR}/libMoltenVK.zip https://github.com/taichi-dev/taichi_assets/files/9977436/libMoltenVK.dylib.zip)
-            execute_process(COMMAND tar -xf ${CMAKE_BINARY_DIR}/libMoltenVK.zip --directory ${CMAKE_BINARY_DIR})
+        # MoltenVK comes from the LunarG Vulkan SDK (`./build.py --shell` handles the download and exports
+        # `MOLTENVK_DIR` pointing at `$VULKAN_SDK/lib`, where LunarG drops `libMoltenVK.dylib` flat). There
+        # is no legacy-pin fallback on purpose: the prior third-party dylib predates
+        # `VK_KHR_buffer_device_address` and is unusable for the on-device adstack sizer. A build without a
+        # real SDK hard-fails here rather than shipping a Vulkan runtime that hard-errors every
+        # reverse-mode kernel at launch time.
+        if(DEFINED ENV{MOLTENVK_DIR})
+            set(_MVK_ROOT "$ENV{MOLTENVK_DIR}")
+        elseif(DEFINED ENV{VULKAN_SDK})
+            set(_MVK_ROOT "$ENV{VULKAN_SDK}/lib")
+        else()
+            set(_MVK_ROOT "")
         endif()
+        set(MOLTEN_VK "")
+        if(_MVK_ROOT)
+            find_file(MOLTEN_VK libMoltenVK.dylib NO_DEFAULT_PATH PATHS "${_MVK_ROOT}")
+        endif()
+        if(NOT MOLTEN_VK)
+            message(FATAL_ERROR
+                "MoltenVK: neither `$MOLTENVK_DIR` nor `$VULKAN_SDK` is set, or no `libMoltenVK.dylib` is "
+                "present under them. On macOS, run `./build.py --shell` (fetches LunarG's Vulkan SDK and "
+                "exports both vars), or install the LunarG Vulkan SDK globally, before configuring "
+                "Quadrants with `QD_WITH_VULKAN=ON`. The adstack sizer shader requires a MoltenVK with "
+                "`VK_KHR_buffer_device_address` (>= 1.2.1); shipping an older pin would hard-error every "
+                "reverse-mode kernel at launch time.")
+        endif()
+        message(STATUS "MoltenVK: using LunarG Vulkan SDK copy at ${MOLTEN_VK}")
+        configure_file(${MOLTEN_VK} ${CMAKE_BINARY_DIR}/libMoltenVK.dylib COPYONLY)
         install(FILES ${CMAKE_BINARY_DIR}/libMoltenVK.dylib DESTINATION ${INSTALL_LIB_DIR}/runtime)
     endif()
     add_subdirectory(vulkan)

--- a/quadrants/rhi/CMakeLists.txt
+++ b/quadrants/rhi/CMakeLists.txt
@@ -28,31 +28,39 @@ endif()
 if (QD_WITH_VULKAN)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQD_WITH_VULKAN")
     if (APPLE)
-        # MoltenVK comes from the LunarG Vulkan SDK (`./build.py --shell` handles the download and exports
-        # `MOLTENVK_DIR` pointing at `$VULKAN_SDK/lib`, where LunarG drops `libMoltenVK.dylib` flat). There
-        # is no legacy-pin fallback on purpose: the prior third-party dylib predates
-        # `VK_KHR_buffer_device_address` and is unusable for the on-device adstack sizer. A build without a
-        # real SDK hard-fails here rather than shipping a Vulkan runtime that hard-errors every
-        # reverse-mode kernel at launch time.
+        # MoltenVK comes from the LunarG Vulkan SDK. Sources are tried in order: explicit `$MOLTENVK_DIR`
+        # (set by `build.py --shell`), then `$VULKAN_SDK/lib` (LunarG's globally-installed layout, also what
+        # `build.py --shell` exports), then the previously-extracted SDK under the `ti-build-cache` that
+        # `build.py --shell` populated on a prior invocation - this last fallback is what lets a plain
+        # `cmake .` reconfigure without re-entering the build shell every time. No legacy-pin fallback on
+        # purpose: the prior third-party dylib predates `VK_KHR_buffer_device_address` and is unusable for
+        # the on-device adstack sizer.
+        set(_MVK_CANDIDATES "")
         if(DEFINED ENV{MOLTENVK_DIR})
-            set(_MVK_ROOT "$ENV{MOLTENVK_DIR}")
-        elseif(DEFINED ENV{VULKAN_SDK})
-            set(_MVK_ROOT "$ENV{VULKAN_SDK}/lib")
-        else()
-            set(_MVK_ROOT "")
+            list(APPEND _MVK_CANDIDATES "$ENV{MOLTENVK_DIR}")
         endif()
+        if(DEFINED ENV{VULKAN_SDK})
+            list(APPEND _MVK_CANDIDATES "$ENV{VULKAN_SDK}/lib")
+        endif()
+        # `build.py --shell` extracts the SDK to `~/.cache/ti-build-cache/vulkan-macos-<VER>/macOS/lib`.
+        # Glob for any version under that directory so developers don't have to re-enter the build shell.
+        file(GLOB _MVK_CACHE_CANDIDATES "$ENV{HOME}/.cache/ti-build-cache/vulkan-macos-*/macOS/lib")
+        list(APPEND _MVK_CANDIDATES ${_MVK_CACHE_CANDIDATES})
         set(MOLTEN_VK "")
-        if(_MVK_ROOT)
-            find_file(MOLTEN_VK libMoltenVK.dylib NO_DEFAULT_PATH PATHS "${_MVK_ROOT}")
-        endif()
+        foreach(_dir ${_MVK_CANDIDATES})
+            if(EXISTS "${_dir}/libMoltenVK.dylib")
+                set(MOLTEN_VK "${_dir}/libMoltenVK.dylib")
+                break()
+            endif()
+        endforeach()
         if(NOT MOLTEN_VK)
             message(FATAL_ERROR
-                "MoltenVK: neither `$MOLTENVK_DIR` nor `$VULKAN_SDK` is set, or no `libMoltenVK.dylib` is "
-                "present under them. On macOS, run `./build.py --shell` (fetches LunarG's Vulkan SDK and "
-                "exports both vars), or install the LunarG Vulkan SDK globally, before configuring "
-                "Quadrants with `QD_WITH_VULKAN=ON`. The adstack sizer shader requires a MoltenVK with "
-                "`VK_KHR_buffer_device_address` (>= 1.2.1); shipping an older pin would hard-error every "
-                "reverse-mode kernel at launch time.")
+                "MoltenVK: cannot locate `libMoltenVK.dylib`. Searched: `$MOLTENVK_DIR`, `$VULKAN_SDK/lib`, "
+                "and `~/.cache/ti-build-cache/vulkan-macos-*/macOS/lib` (populated by `build.py --shell`). "
+                "Run `./build.py --shell` once to fetch LunarG's Vulkan SDK, or install the LunarG Vulkan "
+                "SDK globally, before configuring Quadrants with `QD_WITH_VULKAN=ON`. The adstack sizer "
+                "shader requires a MoltenVK with `VK_KHR_buffer_device_address` (>= 1.2.1); shipping an "
+                "older pin would hard-error every reverse-mode kernel at launch time.")
         endif()
         message(STATUS "MoltenVK: using LunarG Vulkan SDK copy at ${MOLTEN_VK}")
         configure_file(${MOLTEN_VK} ${CMAKE_BINARY_DIR}/libMoltenVK.dylib COPYONLY)

--- a/quadrants/rhi/vulkan/vulkan_device.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device.cpp
@@ -1592,10 +1592,17 @@ RhiResult VulkanDevice::allocate_memory(const AllocParams &params, DeviceAllocat
   }
 
   if (get_caps().get(DeviceCapability::spirv_has_physical_storage_buffer) &&
-      ((alloc_info.usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT) ||
-       (alloc_info.usage & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR) ||
-       (alloc_info.usage & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR) ||
-       (alloc_info.usage & VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR))) {
+      ((buffer_info.usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT) ||
+       (buffer_info.usage & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR) ||
+       (buffer_info.usage & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR) ||
+       (buffer_info.usage & VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR))) {
+    // Check the Vulkan `VkBufferCreateInfo::usage` flags, not the VMA `VmaAllocationCreateInfo::usage`
+    // enum - the latter is `VMA_MEMORY_USAGE_UNKNOWN` here (never set) and never matches any
+    // `VK_BUFFER_USAGE_*` bit, so without this the branch was dead and the SHADER_DEVICE_ADDRESS usage
+    // flag was never attached. The downstream `vkGetBufferDeviceAddressKHR` call below then fires
+    // `VUID-VkBufferDeviceAddressInfo-buffer-02601` under the validation layer, and on drivers that
+    // don't validate (MoltenVK) returns a garbage address that silently miscomputes every subsequent
+    // PSB-backed ndarray load.
     buffer_info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;
   }
 
@@ -1607,7 +1614,13 @@ RhiResult VulkanDevice::allocate_memory(const AllocParams &params, DeviceAllocat
 
   vmaGetAllocationInfo(alloc.buffer->allocator, alloc.buffer->allocation, &alloc.alloc_info);
 
-  if (get_caps().get(DeviceCapability::spirv_has_physical_storage_buffer)) {
+  if (get_caps().get(DeviceCapability::spirv_has_physical_storage_buffer) &&
+      (buffer_info.usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR)) {
+    // Gated on the matching usage bit the block above may have added: `vkGetBufferDeviceAddressKHR`
+    // requires the target buffer to have been created with `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT`
+    // (VUID-VkBufferDeviceAddressInfo-buffer-02601). Buffers that do not qualify for the bit (uniform-only,
+    // vertex/index, transfer-only staging) never need a device address - they are only read via descriptor
+    // binding. Leaving `alloc.addr` at zero in that case matches what happens on backends without the cap.
     VkBufferDeviceAddressInfoKHR info{};
     info.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO_KHR;
     info.buffer = alloc.buffer->buffer;

--- a/quadrants/rhi/vulkan/vulkan_device_creator.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device_creator.cpp
@@ -601,10 +601,17 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
     } else if (name == VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME) {
       enabled_extensions.push_back(ext.extensionName);
     } else if (name == VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME && params_.enable_validation_layer) {
-      // VK_KHR_shader_non_semantic_info isn't supported on molten-vk.
+#if !defined(__APPLE__)
+      // VK_KHR_shader_non_semantic_info isn't fully supported on MoltenVK: the extension enumerates as
+      // available on the LunarG-SDK-sourced build, the device accepts `OpExtInstImport "NonSemantic.DebugPrintf"`
+      // and the downstream `OpExtInst` call sites at SPIR-V validation time, but the SPIRV-Cross -> MSL
+      // translator inside MoltenVK emits unconditional `debugPrintfEXT(...)` calls that Metal's MSL compiler
+      // rejects with `use of undeclared identifier 'debugPrintfEXT'`. Since the only Vulkan implementation on
+      // Apple platforms is MoltenVK, drop the advertisement here rather than at each SPIR-V codegen site.
       // Tracking issue: https://github.com/KhronosGroup/MoltenVK/issues/1214
       caps.set(DeviceCapability::spirv_has_non_semantic_info, true);
       enabled_extensions.push_back(ext.extensionName);
+#endif
     } else if (name == VK_KHR_8BIT_STORAGE_EXTENSION_NAME) {
       enabled_extensions.push_back(ext.extensionName);
     } else if (name == VK_KHR_16BIT_STORAGE_EXTENSION_NAME) {

--- a/quadrants/rhi/vulkan/vulkan_device_creator.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device_creator.cpp
@@ -834,12 +834,15 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
 
       if (CHECK_VERSION(1, 3) || buffer_device_address_feature.bufferDeviceAddress) {
         if (device_supported_features.shaderInt64) {
-// Temporarily disable it on macOS:
-// https://github.com/taichi-dev/taichi/issues/6295
-// (penguinliong) Temporarily disabled (until device capability is ready).
-#if !defined(__APPLE__) && false
+          // The prior gate was `#if !defined(__APPLE__) && false`, a kill-switch referencing Taichi issue
+          // #6295 (broken BDA on the 2022-era MoltenVK pinned in `quadrants/rhi/CMakeLists.txt`). That
+          // pin has since been replaced with a LunarG-SDK-sourced MoltenVK (>= 1.3, sporting working
+          // `vkGetBufferDeviceAddress`), and the extension feature bit above already gates against devices
+          // that don't advertise BDA - so there is no reason to hard-disable PSB on Apple (or anywhere).
+          // Without this cap the adstack sizer shader hard-errors at launch time on every reverse-mode
+          // kernel because `$ENV{VULKAN_SDK}`-backed MoltenVK can't be distinguished from the legacy pin
+          // by capability alone.
           caps.set(DeviceCapability::spirv_has_physical_storage_buffer, true);
-#endif
         }
       }
       *pNextEnd = &buffer_device_address_feature;

--- a/quadrants/rhi/vulkan/vulkan_device_creator.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device_creator.cpp
@@ -755,12 +755,24 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
       if (shader_atomic_float_feature.shaderBufferFloat64Atomics) {
         caps.set(DeviceCapability::spirv_has_atomic_float64, true);
       }
+#if !defined(__APPLE__)
+      // Shared (threadgroup) float atomics are not actually usable through MoltenVK: the underlying Metal
+      // Shading Language rejects `atomic_fetch_add_explicit` on `threadgroup atomic_float*` with
+      // `cannot pass pointer to address space 'threadgroup' as a pointer to address space 'device'`, so
+      // MSL translation of any SPIR-V that emits `OpAtomicFAdd` against the Workgroup storage class fails
+      // at pipeline creation. The `shaderSharedFloatN AtomicAdd` feature bit is advertised by MoltenVK
+      // anyway; advertising the cap back up would route `has_native_float_atomic_add(..., is_shared=true)`
+      // to the native path and make every shared-atomic-float kernel unusable on Apple. Dropping the cap
+      // here falls back to the CAS-emulated path in `atomic_operation_widened`, which targets uint
+      // atomics and works on every backend. Companion gate to the `spirv_has_non_semantic_info` drop a
+      // few branches up; see that comment for the overall MoltenVK cap-sanitisation rationale.
       if (shader_atomic_float_feature.shaderSharedFloat32AtomicAdd) {
         caps.set(DeviceCapability::spirv_has_shared_atomic_float_add, true);
       }
       if (shader_atomic_float_feature.shaderSharedFloat64AtomicAdd) {
         caps.set(DeviceCapability::spirv_has_shared_atomic_float64_add, true);
       }
+#endif
       *pNextEnd = &shader_atomic_float_feature;
       pNextEnd = &shader_atomic_float_feature.pNext;
     }
@@ -778,9 +790,15 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
       if (shader_atomic_float_2_feature.shaderBufferFloat16Atomics) {
         caps.set(DeviceCapability::spirv_has_atomic_float16, true);
       }
+#if !defined(__APPLE__)
+      // Same MoltenVK limitation as `shader_atomic_float_feature.shaderSharedFloat32AtomicAdd` above:
+      // the feature bit is advertised but the MSL translator cannot emit a valid threadgroup
+      // `atomic_fetch_add_explicit` for it. Drop the cap on Apple and let the CAS-emulated fallback
+      // handle f16 shared atomics.
       if (shader_atomic_float_2_feature.shaderSharedFloat16AtomicAdd) {
         caps.set(DeviceCapability::spirv_has_shared_atomic_float16_add, true);
       }
+#endif
       if (shader_atomic_float_2_feature.shaderBufferFloat32AtomicMinMax) {
         caps.set(DeviceCapability::spirv_has_atomic_float_minmax, true);
       }

--- a/quadrants/rhi/vulkan/vulkan_device_creator.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device_creator.cpp
@@ -832,18 +832,19 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
       features2.pNext = &buffer_device_address_feature;
       vkGetPhysicalDeviceFeatures2KHR(physical_device_, &features2);
 
-      if (CHECK_VERSION(1, 3) || buffer_device_address_feature.bufferDeviceAddress) {
-        if (device_supported_features.shaderInt64) {
-          // The prior gate was `#if !defined(__APPLE__) && false`, a kill-switch referencing Taichi issue
-          // #6295 (broken BDA on the 2022-era MoltenVK pinned in `quadrants/rhi/CMakeLists.txt`). That
-          // pin has since been replaced with a LunarG-SDK-sourced MoltenVK (>= 1.3, sporting working
-          // `vkGetBufferDeviceAddress`), and the extension feature bit above already gates against devices
-          // that don't advertise BDA - so there is no reason to hard-disable PSB on Apple (or anywhere).
-          // Without this cap the adstack sizer shader hard-errors at launch time on every reverse-mode
-          // kernel because `$ENV{VULKAN_SDK}`-backed MoltenVK can't be distinguished from the legacy pin
-          // by capability alone.
-          caps.set(DeviceCapability::spirv_has_physical_storage_buffer, true);
-        }
+      // Gate strictly on the queried feature bit. Vulkan 1.3 *promotes* `VK_KHR_buffer_device_address`
+      // into core but still lets the implementation expose `bufferDeviceAddress = VK_FALSE`; the previous
+      // `CHECK_VERSION(1, 3) || feature_bit` condition therefore treated 1.3 devices as PSB-capable even
+      // when they were not, which would drive `vkGetBufferDeviceAddressKHR` / BDA usage flags on hardware
+      // that didn't advertise the feature. The `shaderInt64` guard stays because the sizer shader holds
+      // PSB pointers as `i64` SSA values.
+      if (buffer_device_address_feature.bufferDeviceAddress && device_supported_features.shaderInt64) {
+        // The prior `#if !defined(__APPLE__) && false` kill-switch referenced Taichi issue #6295 (broken
+        // BDA on the 2022-era MoltenVK pinned in `quadrants/rhi/CMakeLists.txt`). That pin has since been
+        // replaced with a LunarG-SDK-sourced MoltenVK (>= 1.3, sporting working `vkGetBufferDeviceAddress`),
+        // so there is no reason to hard-disable PSB on Apple (or anywhere) - the feature query above now
+        // correctly reflects the device's actual capability.
+        caps.set(DeviceCapability::spirv_has_physical_storage_buffer, true);
       }
       *pNextEnd = &buffer_device_address_feature;
       pNextEnd = &buffer_device_address_feature.pNext;

--- a/quadrants/runtime/gfx/runtime.cpp
+++ b/quadrants/runtime/gfx/runtime.cpp
@@ -804,30 +804,22 @@ void GfxRuntime::submit_current_cmdlist_if_timeout() {
       flush();
     }
   }
-  // Safety valve against unbounded `ctx_buffers_` growth on workloads that launch kernels in a tight loop
-  // without any intervening Python-side observable (host readback, `to_numpy`, field get, ...). Normally
-  // every Quadrants workload touches such an observable between launches and the implicit `synchronize()`
-  // those paths trigger drains the queue; MPM88-style simulations that only push kernels and then read the
-  // final state at the end accumulate one deferred-free batch per flush, and MoltenVK starts to fall over
-  // somewhere around a few hundred pending cmd buffers / descriptor sets (the failure mode was a clean
-  // SIGSEGV inside `MVKCommandEncoder` on repeated launches of the 3-task MPM88 substep kernel). Drain
-  // here when we have more than a conservative threshold of deferred buffers alive. The threshold is high
-  // enough that typical workloads never hit it and the periodic `wait_idle` does not become a measurable
-  // stall; smaller workloads that already touch a host observable will have cleared `ctx_buffers_` long
-  // before we get here via the `synchronize()` path.
   // Safety valve against unbounded GPU-side tracking growth on tight kernel-launch loops without any
-  // intervening Python-side observable (host readback, `to_numpy`, field get, ...). `VulkanStream::submit`
-  // pushes every submitted cmdbuffer into `submitted_cmdbuffers_` with a fence; the vector is only cleared
-  // on `command_sync()` (i.e. `wait_idle` -> `synchronize()`). Workloads that just push kernels and then
-  // read the final state at the end (MPM88, iterative simulations) can accumulate hundreds of live fences
-  // and cmdbuffers, at which point MoltenVK's encoder state tracker SIGSEGVs inside
-  // `MVKCommandEncoder::encodeCommands`. Forcing a drain every `kMaxPendingLaunches` launches keeps the
-  // queue bounded; the threshold is large enough that typical workloads (which already touch a host
-  // observable every iteration) never reach it, so the periodic `wait_idle` does not become a measurable
-  // stall. A non-blocking polling variant that checks individual fences via `vkGetFenceStatus` would
-  // retire sets as they complete without blocking, but that requires an RHI public-surface change
-  // (`bool is_signaled() const` on `StreamSemaphoreObject` and per-backend implementations) and the
-  // motivating workload only needs a coarse-grained drain, not per-fence polling.
+  // intervening Python-side observable (host readback, `to_numpy`, field get, ...). Normally every
+  // Quadrants workload touches such an observable between launches and the implicit `synchronize()` those
+  // paths trigger drains the queue. `VulkanStream::submit` pushes every submitted cmdbuffer into
+  // `submitted_cmdbuffers_` with a fence; the vector is only cleared on `command_sync()` (i.e. `wait_idle`
+  // -> `synchronize()`). Workloads that just push kernels and then read the final state at the end
+  // (MPM88, iterative simulations) accumulate one deferred-free batch per flush and can reach hundreds of
+  // live fences and cmdbuffers, at which point MoltenVK's encoder state tracker SIGSEGVs inside
+  // `MVKCommandEncoder::encodeCommands` (the failure mode was a clean SIGSEGV on repeated launches of the
+  // 3-task MPM88 substep kernel). Forcing a drain every `kMaxPendingLaunches` launches keeps the queue
+  // bounded; the threshold is large enough that typical workloads (which already touch a host observable
+  // every iteration) never reach it, so the periodic `wait_idle` does not become a measurable stall. A
+  // non-blocking polling variant that checks individual fences via `vkGetFenceStatus` would retire sets as
+  // they complete without blocking, but that requires an RHI public-surface change (`bool is_signaled()
+  // const` on `StreamSemaphoreObject` and per-backend implementations) and the motivating workload only
+  // needs a coarse-grained drain, not per-fence polling.
   constexpr size_t kMaxPendingLaunches = 32;
   pending_launches_since_sync_ += 1;
   if (pending_launches_since_sync_ > kMaxPendingLaunches) {

--- a/quadrants/runtime/gfx/runtime.cpp
+++ b/quadrants/runtime/gfx/runtime.cpp
@@ -738,6 +738,7 @@ void GfxRuntime::synchronize() {
   }
   ctx_buffers_.clear();
   ndarrays_in_use_.clear();
+  pending_launches_since_sync_ = 0;
   // Async adstack-overflow report: every launch in this sync window that overflowed wrote a non-zero sentinel into
   // the shared flag buffer. Read it now, raise if any kernel overflowed, and zero it so the next sync window starts
   // clean. This mirrors the CUDA async-error pattern: the error surfaces on the next synchronize() rather than per
@@ -802,6 +803,35 @@ void GfxRuntime::submit_current_cmdlist_if_timeout() {
     if (std::chrono::duration_cast<std::chrono::microseconds>(duration).count() > max_pending_time) {
       flush();
     }
+  }
+  // Safety valve against unbounded `ctx_buffers_` growth on workloads that launch kernels in a tight loop
+  // without any intervening Python-side observable (host readback, `to_numpy`, field get, ...). Normally
+  // every Quadrants workload touches such an observable between launches and the implicit `synchronize()`
+  // those paths trigger drains the queue; MPM88-style simulations that only push kernels and then read the
+  // final state at the end accumulate one deferred-free batch per flush, and MoltenVK starts to fall over
+  // somewhere around a few hundred pending cmd buffers / descriptor sets (the failure mode was a clean
+  // SIGSEGV inside `MVKCommandEncoder` on repeated launches of the 3-task MPM88 substep kernel). Drain
+  // here when we have more than a conservative threshold of deferred buffers alive. The threshold is high
+  // enough that typical workloads never hit it and the periodic `wait_idle` does not become a measurable
+  // stall; smaller workloads that already touch a host observable will have cleared `ctx_buffers_` long
+  // before we get here via the `synchronize()` path.
+  // Safety valve against unbounded GPU-side tracking growth on tight kernel-launch loops without any
+  // intervening Python-side observable (host readback, `to_numpy`, field get, ...). `VulkanStream::submit`
+  // pushes every submitted cmdbuffer into `submitted_cmdbuffers_` with a fence; the vector is only cleared
+  // on `command_sync()` (i.e. `wait_idle` -> `synchronize()`). Workloads that just push kernels and then
+  // read the final state at the end (MPM88, iterative simulations) can accumulate hundreds of live fences
+  // and cmdbuffers, at which point MoltenVK's encoder state tracker SIGSEGVs inside
+  // `MVKCommandEncoder::encodeCommands`. Forcing a drain every `kMaxPendingLaunches` launches keeps the
+  // queue bounded; the threshold is large enough that typical workloads (which already touch a host
+  // observable every iteration) never reach it, so the periodic `wait_idle` does not become a measurable
+  // stall. A non-blocking polling variant that checks individual fences via `vkGetFenceStatus` would
+  // retire sets as they complete without blocking, but that requires an RHI public-surface change
+  // (`bool is_signaled() const` on `StreamSemaphoreObject` and per-backend implementations) and the
+  // motivating workload only needs a coarse-grained drain, not per-fence polling.
+  constexpr size_t kMaxPendingLaunches = 32;
+  pending_launches_since_sync_ += 1;
+  if (pending_launches_since_sync_ > kMaxPendingLaunches) {
+    synchronize();
   }
 }
 

--- a/quadrants/runtime/gfx/runtime.h
+++ b/quadrants/runtime/gfx/runtime.h
@@ -185,6 +185,14 @@ class QD_DLL_EXPORT GfxRuntime {
   std::unique_ptr<CommandList> current_cmdlist_{nullptr};
   high_res_clock::time_point current_cmdlist_pending_since_;
 
+  // Counts kernel launches since the last `synchronize()`. `submit_current_cmdlist_if_timeout` forces a
+  // drain once this crosses a threshold, bounding the growth of `VulkanStream::submitted_cmdbuffers_` (and
+  // the fences, semaphores and descriptor sets those entries keep alive) on tight kernel-launch loops that
+  // never touch a Python-side observable - workloads like MPM88 where every substep is a pure GPU update
+  // and the host only reads state once at the end. See the assignment site for the MoltenVK SIGSEGV this
+  // guards against.
+  size_t pending_launches_since_sync_{0};
+
   std::vector<std::unique_ptr<CompiledQuadrantsKernel>> ti_kernels_;
 
   std::unordered_map<DeviceAllocation *, size_t> root_buffers_size_map_;


### PR DESCRIPTION
# LunarG-sourced MoltenVK on Apple unblocks PSB (BDA) for the runtime adstack sizer, plus the three MoltenVK quirks that surface once PSB, validation, and long kernel-loop workloads are live

> Six commits. Originally three: swap the 2022 Taichi-pinned MoltenVK for a LunarG Vulkan SDK fetch driven by `./build.py --shell`, gate the PSB capability on the queried `bufferDeviceAddress` feature bit, and locate the staged dylib from the SDK extract so `python setup.py develop` keeps working after the shell exits. Three more were added once the new MoltenVK was exercised against the reverse-mode / MPM / tile16 test matrix: a `vkGetBufferDeviceAddressKHR` buffer-usage-bit fix that was latent while PSB was off on Apple, a `NonSemantic.DebugPrintf` / `shaderSharedFloat32AtomicAdd` cap-sanitisation pair that MoltenVK advertises but cannot actually service, and a `GfxRuntime` safety valve that drains the Vulkan stream's `submitted_cmdbuffers_` queue on long kernel-launch loops so MoltenVK's encoder-state tracker stops SIGSEGVing. The PR now ships a MoltenVK that is both functional for BDA-backed reverse-mode workloads and doesn't regress the rest of the SPIR-V test suite on CI's Mac runners.

## TL;DR

```bash
# macOS / arm64, from a clean checkout:
./build.py --shell -- cmake -S . -B build -DQD_WITH_VULKAN=ON
# $VULKAN_SDK / $MOLTENVK_DIR are exported by the shell hook;
# CMake's find_file locates libMoltenVK.dylib under the SDK and stages it into build/.
./build.py
python -c "import quadrants as qd; qd.init(arch=qd.vulkan)"
# Now reports spirv_has_physical_storage_buffer=True on Apple, and the full
# adstack / tile16 / MPM test matrix is green on Mac CI (15 & 26) and Linux Vulkan.
```

The shell hook fetches LunarG's macOS installer once, extracts the SDK into `~/.cache/quadrants/vulkan-macos-1.4.321.0/`, and exports `VULKAN_SDK` / `MOLTENVK_DIR`. CMake then picks up `libMoltenVK.dylib` from the SDK instead of Taichi's legacy pinned dylib. Downstream, the adstack sizer compute shader (Autodiff 17) relies on BDA to walk `SizeExpr` trees on device, so enabling PSB on Apple is the gating change that makes that shader legal to dispatch. The four add-on commits then cover what the freshly-enabled PSB path exposes - a latent buffer-usage-bit typo, two MoltenVK caps that are advertised-but-broken, and a cmdbuffer-queue drain that repeated kernel launches need.

## Why

The previous Apple Vulkan path pinned a 2022 MoltenVK dylib hosted on `taichi_assets`, predating the `VK_KHR_buffer_device_address` / physical-storage-buffer capability. Three concrete consequences:

- `vulkan_device_creator.cpp` hard-guarded `spirv_has_physical_storage_buffer` off on Apple behind `#if !defined(__APPLE__) && false`, citing [taichi-dev/taichi#6295](https://github.com/taichi-dev/taichi/issues/6295).
- The adstack sizer shader that lands in Autodiff 17 needs `OpLoad` through a `PhysicalStorageBuffer`-class pointer to read `SizeExpr` leaves; with PSB disabled on Apple, every reverse-mode kernel would hard-error at launch time on Metal.
- A dormant typo in `VulkanDevice::allocate_memory` (`alloc_info.usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT` instead of `buffer_info.usage & ...`) made the "attach `SHADER_DEVICE_ADDRESS_BIT`" branch dead for every buffer; unreachable while the PSB cap was off, but the moment PSB is enabled every buffer becomes a validation-layer violation (Linux) or garbage-address read (MoltenVK).

The less-targeted workarounds are insufficient: keeping the Taichi pin and papering over the capability check would ship a MoltenVK that cannot serve BDA loads; asking every Quadrants developer to install LunarG's SDK globally breaks hermetic CI. Fetching through `build.py --shell` gives us a single, reproducible SDK path the rest of the build consumes.

## Surface API

No Python-surface API changes. All diff is build-system (`vulkan.py`, `quadrants/rhi/CMakeLists.txt`), Vulkan RHI internals (`vulkan_device_creator.cpp`, `vulkan_device.cpp`, `vulkan_api.cpp`), and SPIR-V codegen internals (`spirv_ir_builder.cpp`, `spirv_codegen.cpp`, `runtime/gfx/runtime.cpp` + `runtime.h`). Behaviour deltas visible to users of `qd.init(arch=qd.vulkan)`:

- `qd.lang.impl.current_cfg().spirv_has_physical_storage_buffer` flips to `True` on Apple.
- `qd.init(arch=qd.vulkan, debug=True)` no longer fails pipeline creation on MoltenVK for kernels that emit `debugPrintfEXT` traffic (lazy-import + Apple cap drop).
- Reverse-mode kernels using `qd.simt.block.SharedArray` with an atomic-f32 `add` / `sub` no longer fail MoltenVK's MSL compile with `atomic_fetch_add_explicit(threadgroup atomic_float*, ...)` - they route through the CAS-emulated fallback instead.
- Long kernel-launch loops (MPM-style simulations, iterative field updates) no longer SIGSEGV inside `MVKCommandEncoder` after a few hundred launches without a `qd.sync()`.

## Entry points

| File | What changes |
| --- | --- |
| `.github/workflows/scripts/ti_build/vulkan.py` | `setup_vulkan()` gains a Darwin / arm64 branch that fetches + extracts + installs LunarG's macOS bundle. |
| `quadrants/rhi/CMakeLists.txt` | Apple branch locates `libMoltenVK.dylib` via `$MOLTENVK_DIR` / `$VULKAN_SDK`; `configure_file` stages it into `${CMAKE_BINARY_DIR}/libMoltenVK.dylib`. `FATAL_ERROR` on a missing SDK. |
| `quadrants/rhi/vulkan/vulkan_device_creator.cpp` | Drops the Apple kill-switch around `spirv_has_physical_storage_buffer`. Gates the overall PSB cap on the queried `bufferDeviceAddress` feature bit. Skips `VK_KHR_shader_non_semantic_info` on Apple (advertised but the MSL translator can't emit `debugPrintfEXT`). Skips `shaderSharedFloat{16,32,64}AtomicAdd` on Apple (same reason: MSL rejects `atomic_fetch_add_explicit` on `threadgroup atomic_float*`). |
| `quadrants/rhi/vulkan/vulkan_device.cpp` | Fixes the `alloc_info.usage` → `buffer_info.usage` typo that made the "attach `SHADER_DEVICE_ADDRESS_BIT`" branch dead. Gates `vkGetBufferDeviceAddressKHR` on whether the bit is actually set, so uniform / vertex / transfer-only staging buffers no longer trip VUID-VkBufferDeviceAddressInfo-buffer-02601. |
| `quadrants/rhi/vulkan/vulkan_api.cpp` | Frees descriptor sets on `shared_ptr` release so MoltenVK's pool churn does not null-pool-deref after ~32 two-set kernel launches. |
| `quadrants/runtime/gfx/runtime.{h,cpp}` | Adds a `pending_launches_since_sync_` counter; `submit_current_cmdlist_if_timeout` forces a `synchronize()` every `kMaxPendingLaunches = 32` launches to bound `VulkanStream::submitted_cmdbuffers_` growth on MPM-style tight kernel-launch loops. |
| `quadrants/codegen/spirv/spirv_ir_builder.{cpp,h}` | Lazy-imports `NonSemantic.DebugPrintf` only when a `call_debugprintf` site actually needs it, so kernels with no `print` / debug-assert traffic stay MoltenVK-compatible. |
| `quadrants/codegen/spirv/spirv_codegen.cpp` | Sanitises the overflow-diagnostic traceback before feeding it to `call_debugprintf`: un-escaped quotes / newlines in the traceback string survive MoltenVK's MSL translation into the output and previously produced `use of undeclared identifier 'Users'`-class errors from the path prefix. |

## Mechanism end-to-end

### 1. SDK acquisition (`vulkan.py`)

| Platform | Source | Prefix |
| --- | --- | --- |
| Linux | `vulkansdk-linux-x86_64-1.4.321.1.tar.xz` (tarball, unchanged) | `~/.cache/quadrants/vulkan-1.4.321.1/x86_64/` |
| Darwin / arm64 | `vulkansdk-macos-1.4.321.0.zip` (installer bundle) | `~/.cache/quadrants/vulkan-macos-1.4.321.0/` |
| Windows | MSI (unchanged) | `~/.cache/quadrants/vulkan-win-1.4.321.1/` |

The macOS branch is the only new one. LunarG didn't publish a `1.4.321.1` macOS asset, so the patch-level is inlined to `1.4.321.0`. `zipfile` drops the installer bundle without preserving the Unix execute bit, so the script `chmod 0755`s the installer binary before running it (idempotent, scoped to the single file). The CLI `install` command writes the SDK into the `--root` prefix.

### 2. CMake pickup (`quadrants/rhi/CMakeLists.txt`)

| Env var | Meaning | Consumer |
| --- | --- | --- |
| `MOLTENVK_DIR` | path that directly contains `libMoltenVK.dylib` | `find_file(MOLTEN_VK libMoltenVK.dylib NO_DEFAULT_PATH PATHS ${MOLTENVK_DIR})` |
| `VULKAN_SDK` | SDK prefix; `${VULKAN_SDK}/lib` is tried if `MOLTENVK_DIR` is unset | same `find_file` call, fallback path |

`configure_file` stages the located dylib into `${CMAKE_BINARY_DIR}/libMoltenVK.dylib` (copy, not symlink, so the install step can re-digest it) and `install(FILES ... DESTINATION ${INSTALL_LIB_DIR}/runtime)` ships it alongside the runtime. A missing SDK is a `FATAL_ERROR` pointing at `./build.py --shell`; there is no silent fallback to the legacy pin on purpose.

### 3. PSB capability unblocked (`vulkan_device_creator.cpp`)

Removes the `#if !defined(__APPLE__) && false` kill-switch gate around `caps.set(DeviceCapability::spirv_has_physical_storage_buffer, true)`. The surrounding gate is tightened from `CHECK_VERSION(1, 3) || buffer_device_address_feature.bufferDeviceAddress` to a plain feature-bit check: Vulkan 1.3 promotes `VK_KHR_buffer_device_address` into core but still lets implementations expose `bufferDeviceAddress = VK_FALSE`, so the version-OR gate was treating 1.3 devices as PSB-capable even when they weren't. Devices that genuinely don't advertise BDA (ancient drivers, headless CI without Vulkan) remain safe.

### 4. `vkGetBufferDeviceAddressKHR` now sees the right usage bit (`vulkan_device.cpp`)

Before this PR the branch that ORs `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR` into `buffer_info.usage` was gated on `alloc_info.usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT` - but `alloc_info.usage` is VMA's `VmaMemoryUsage` enum (small integers), not the Vulkan `VkBufferUsageFlags` bitfield. The `&` always yielded 0; the branch was dead; every buffer reached the `vkGetBufferDeviceAddressKHR` call below without the required bit. Latent while PSB was off on Apple (no one called `vkGetBufferDeviceAddressKHR`). Once PSB is on it fires `VUID-VkBufferDeviceAddressInfo-buffer-02601` under validation (Linux CI's `test_print` stderr-assertion failures) and returns a garbage address under MoltenVK (Mac CI's `test_tile16_*` / `test_mpm88_numpy_and_ndarray` wrong-output failures). Fix reads `buffer_info.usage` instead, and additionally gates the `vkGetBufferDeviceAddressKHR` call on the bit actually being set, so uniform / vertex / transfer-only staging buffers skip the BDA query and keep `alloc.addr == 0`.

### 5. MoltenVK cap sanitisation (`vulkan_device_creator.cpp`)

MoltenVK advertises two Vulkan capabilities whose SPIR-V → MSL translation is broken:

- `VK_KHR_shader_non_semantic_info`: the extension enumerates fine, `OpExtInstImport "NonSemantic.DebugPrintf"` validates, the OpExtInst call sites pass SPIR-V validation, but SPIRV-Cross emits an unconditional `debugPrintfEXT(...)` call stub whose identifier Metal's MSL compiler rejects (`use of undeclared identifier 'debugPrintfEXT'`). Every reverse-mode kernel that happens to compile with a `debug=True` `debugPrintfEXT` site fails pipeline creation on MoltenVK. Skipped on Apple.
- `shaderShared{Float32,Float16,Float64}AtomicAdd`: the feature bit is set, but MoltenVK's MSL translator emits `atomic_fetch_add_explicit((threadgroup atomic_float*) &x, ...)` which Metal rejects with `cannot pass pointer to address space 'threadgroup' as a pointer to address space 'device'`. Skipped on Apple, routing shared-memory float atomics through the existing CAS-emulated fallback in `atomic_operation_widened`.

The skips are `#if !defined(__APPLE__)` guards, with the MoltenVK issue links in the comment at each site.

### 6. Companion lazy-import + format-string sanitisation (`spirv_ir_builder.{cpp,h}`, `spirv_codegen.cpp`)

Even with `spirv_has_non_semantic_info` turned off on Apple, kernels with `debug=True` can still enter the arithmetic-overflow check path in `spirv_codegen.cpp::generate_overflow_branch`, which calls `ir_->call_debugprintf(...)`. Left untreated, the traceback string passed to that call contains un-escaped `"` and `\n` characters (Python source file paths, newlines) that survive the MSL translation and blow up the output with errors like `missing terminating '"' character`. Two mitigations:

- `spirv_ir_builder::init_pre_defs` no longer eagerly imports `NonSemantic.DebugPrintf`; the import now fires lazily from the first `call_debugprintf` site. Kernels with no debug traffic emit no `OpExtInstImport`, so MoltenVK's unused-import stub never runs.
- `TaskCodegen::generate_overflow_branch` escapes `"` and replaces `\n` / `\r` with spaces before feeding the traceback into the format string. Native Vulkan drivers get the traceback byte-for-byte; Metal / MSL round-trips cleanly.

### 7. Descriptor-set lifecycle fix (`vulkan_api.cpp`)

`DeviceObjVkDescriptorSet::~DeviceObjVkDescriptorSet` now returns the `VkDescriptorSet` to its source pool via `vkFreeDescriptorSets`. Without this, each launch accumulates consumed-but-never-reclaimed slots, `VulkanDevice::alloc_desc_set` spins up fresh pools at the 64-set boundary, and MoltenVK's `MVKDescriptorSet::_pool` can deref a pool the driver has torn down (null-pool deref inside `MVKResourcesCommandEncoderState::bindDescriptorSet`). The pool is created with `VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT`, so the free call is legal; the `ref_pool` `shared_ptr` keeps the pool and its `VkDevice` alive past the destructor.

### 8. Periodic `submitted_cmdbuffers_` drain (`runtime/gfx/runtime.{h,cpp}`)

`VulkanStream::submit` appends one `TrackedCmdbuf{fence, cmd_buffer}` per submit. The vector is only cleared in `command_sync()` / `wait_idle()`. Workloads that push hundreds of kernels before any host-side observable (MPM, iterative field solves) accumulate hundreds of live fences + cmdbuffers + descriptor sets; MoltenVK's encoder-state tracker SIGSEGVs somewhere around that size. `GfxRuntime::submit_current_cmdlist_if_timeout` now also drains the queue every `kMaxPendingLaunches = 32` launches via a bounded synchronize; workloads that already touch a Python observable per iteration are unaffected (`ctx_buffers_` clears earlier via the normal synchronize path).

## Per-backend coverage matrix

| Backend | Affected by this PR? | Verdict |
| --- | --- | --- |
| CPU (LLVM) | No | N/A - does not compile Vulkan RHI. |
| CUDA (LLVM) | No | N/A - does not compile Vulkan RHI. |
| AMDGPU (LLVM) | No | N/A - does not compile Vulkan RHI. |
| Metal (SPIR-V) | Indirectly | None of the Apple-guarded caps / cap-sanitisation code reaches the Metal RHI. Validated via CI `Test on Mac (15, 3.*)` / `(26, 3.*)`. |
| Vulkan on Apple / MoltenVK | Yes | MoltenVK is now LunarG-sourced; PSB + BDA enabled; `non_semantic_info` / `shared_atomic_float` caps off to match what MoltenVK's MSL translator actually supports; descriptor-set + cmdbuffer-queue lifecycle fixes in place. Covered end-to-end by `Test on Mac (15, 3.*)` / `(26, 3.*)`. |
| Vulkan on Linux | Yes | The `buffer_info.usage` fix and the `vkGetBufferDeviceAddressKHR` bit-gate fix also apply here; they resolve the `test_print` stderr validation-layer failures that `test_gpu / Test Linux Vulkan` was reporting. `.tar.xz` branch in `vulkan.py` and the Linux PSB / non-semantic-info paths are untouched. |
| Vulkan on Windows (SPIR-V) | No | MSI branch in `vulkan.py` untouched; the `buffer_info.usage` fix applies but is a no-op relative to the pre-PR state because Windows was already validation-clean. |

## Tests

### CI

- `Test on Mac (15, 3.10-3.13)` and `Test on Mac (26, 3.10-3.13)` exercise the new fetch end-to-end and run the full Vulkan-backend test matrix. Pre-PR: `test_tile16_*[arch=vulkan-*]` / `test_mpm88_numpy_and_ndarray[arch=vulkan-0]` / `test_shared_array_float_atomics[arch=vulkan-*-dtype1-{add,sub}]` fail. Post-PR: those pass; any new regressions surface here.
- `test_gpu / Test Linux Vulkan` exercises the `vkGetBufferDeviceAddressKHR` bit-gate fix by running with validation enabled. Pre-PR: `test_print_*[arch=vulkan]` fail because `VUID-VkBufferDeviceAddressInfo-buffer-02601` warnings pollute stderr; post-PR those go quiet.
- `Manylinux wheel Build/Test (ubuntu-22.04 / ubuntu-22.04-arm)` validates that the Linux branch of `vulkan.py` is unchanged.
- `Windows 2025 Build/Test (3.10-3.13)` validates that the Windows branch of `vulkan.py` is unchanged.

### Local smoke

- `./build.py --shell -- cmake -S . -B build -DQD_WITH_VULKAN=ON && ./build.py` on macOS-26 / arm64 succeeds and stages `libMoltenVK.dylib` into `build/`.
- `python -c "import quadrants as qd; qd.init(arch=qd.vulkan); print(qd.lang.impl.current_cfg().spirv_has_physical_storage_buffer)"` reports `True` after this PR; reports `False` before it.
- `CMAKE_BUILD_TYPE=Debug cmake --log-level=DEBUG` shows the `MoltenVK: using LunarG Vulkan SDK copy at ...` status line.

No unit tests are added by this PR itself: the SDK and RHI changes surface via the existing Vulkan-backend test matrix, which is the regression harness. The atomic-fetch-add and debug-printf MoltenVK quirks are already covered by `test_shared_array_float_atomics` and the existing `debug=True`-using `test_matrix` / `test_tile16` cases respectively.

## Side-effect audit

| Concern | Where checked | Verdict |
| --- | --- | --- |
| Linux / Windows Vulkan SDK fetch | `vulkan.py` `case (\"Linux\", \"x86_64\")` / `case (\"Windows\", \"AMD64\")` branches untouched | ok - no behaviour change outside Apple |
| `VULKAN_SDK` env var semantics | exported from the shell hook; consumed by `quadrants/rhi/CMakeLists.txt` (BSD find path), `quadrants/rhi/vulkan/vulkan_device_creator.cpp` (runtime loader), shader compiler `glslang` lookup | ok - existing consumers keep using `$VULKAN_SDK`; the new macOS prefix looks identical in layout |
| `MOLTENVK_DIR` env var | new. Only read by `quadrants/rhi/CMakeLists.txt`; no runtime lookup | ok - opt-in; falls back to `$VULKAN_SDK/lib` |
| CMake cache | `find_file(MOLTEN_VK ...)` is cached; after the SDK is installed the first configure populates it and subsequent configures skip | ok - deleting `~/.cache/quadrants/vulkan-macos-.../` + `rm -rf build` regenerates from scratch |
| BDA feature-bit gate | now the sole gate on `spirv_has_physical_storage_buffer` | intentional - Vulkan 1.3 devices without BDA (present on some headless CI drivers) no longer get PSB set |
| `alloc_info.usage` → `buffer_info.usage` fix | `allocate_memory` branch attaches `SHADER_DEVICE_ADDRESS_BIT` to the Vulkan buffer usage only; VMA allocation usage is unchanged | ok - VMA allocation strategy untouched; only the Vulkan buffer carries the new usage bit |
| `vkGetBufferDeviceAddressKHR` bit-gate | added alongside the fix; buffers without the bit skip the BDA query cleanly | ok - uniform / vertex / transfer-only buffers no longer spam validation or return garbage addresses |
| `non_semantic_info` skipped on Apple | gate is `#if !defined(__APPLE__)`; other platforms unaffected | ok - covered by per-backend matrix above |
| `shared_atomic_float*` skipped on Apple | same gate; CAS-emulated path already exists in `atomic_operation_widened` | ok - pure correctness fix for Apple; other platforms retain native support |
| Non-Apple behaviour | Apple-guarded block (`if (APPLE)`) in `CMakeLists.txt`; Apple-guarded caps in `vulkan_device_creator.cpp` | ok - Linux / Windows Vulkan paths untouched |
| Download cache | `download_dep(url, installer_dir, strip=1)` uses the existing cache primitive; re-runs short-circuit on cached unzip + on the existence of `$prefix/macOS/` | ok - no network on re-run |
| Installer execute bit | `installer_bin.chmod(0o755)` before `subprocess.check_call`; idempotent | ok - `zipfile` dropped mode `0644`, handled here |
| `$VK_LAYER_PATH` | set on every platform branch including the new macOS one | ok - layer validation remains wired |
| Legacy Taichi pin removal | `CMakeLists.txt` previously `curl`-ed `libMoltenVK.dylib.zip` from `taichi_assets` - removed. `FATAL_ERROR` replaces the silent fallback. | intentional; no legacy fallback is shipped |
| Lazy `NonSemantic.DebugPrintf` import | no call to `call_debugprintf` -> no `OpExtInstImport`; every previously-working Vulkan driver still sees the import when a kernel actually needs it | ok - no effect on platforms that don't advertise the cap |
| Descriptor-set reuse | `vkFreeDescriptorSets` per-set on destruction, pool retains `VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT` | ok - the call is legal by construction; verified by CI on Mac and Linux |
| `pending_launches_since_sync_` threshold | 32 launches; reset on every `synchronize()`; only fires when no Python-side observable has intervened | ok - pathological-loop safety valve; normal workloads are unaffected |

