### PR TITLE
[CI] Suppress reportPrivateImportUsage in torch-using files

### DIFF
--- a/python/quadrants/lang/_func_base.py
+++ b/python/quadrants/lang/_func_base.py
@@ -1,3 +1,6 @@
+# pyright: reportPrivateImportUsage=false
+# Reason: torch.zeros_like is public torch API, but pyright 1.1.409+ flags
+# it as private because torch's stubs don't re-export it via __all__.
 import ast
 import inspect
 import math

--- a/python/quadrants/lang/_py_tensor.py
+++ b/python/quadrants/lang/_py_tensor.py
@@ -2,6 +2,11 @@
 Torch tensor wrapper for the python backend.
 """
 
+# pyright: reportPrivateImportUsage=false
+# Reason: torch.zeros / torch.from_numpy are public torch API, but pyright
+# 1.1.409+ flags them as private because torch's stubs don't re-export
+# them via __all__.
+
 from __future__ import annotations
 
 from functools import partial

--- a/python/quadrants/lang/field.py
+++ b/python/quadrants/lang/field.py
@@ -1,3 +1,6 @@
+# pyright: reportPrivateImportUsage=false
+# Reason: torch.zeros is public torch API, but pyright 1.1.409+ flags it as
+# private because torch's stubs don't re-export it via __all__.
 from typing import TYPE_CHECKING, cast
 
 import quadrants.lang

--- a/python/quadrants/lang/util.py
+++ b/python/quadrants/lang/util.py
@@ -1,3 +1,8 @@
+# pyright: reportPrivateImportUsage=false
+# Reason: this file accesses public torch API (torch.zeros, torch.float32,
+# torch.bool, ...) which the torch stubs (as of pyright 1.1.409) flag as
+# private because they are not explicitly re-exported via __all__ /
+# `from ... import ... as ...`. The accesses are intended public API.
 import functools
 import os
 import traceback


### PR DESCRIPTION
pyright 1.1.409 starts flagging public torch API accesses (torch.zeros, torch.zeros_like, torch.from_numpy, the dtype aliases torch.float32 / torch.bool / etc.) as reportPrivateImportUsage, because torch's stubs do not re-export those names via __all__.

The accesses are intended public torch API. Add file-level pyright pragma to disable reportPrivateImportUsage in the four files that use torch.* attribute access:

  - python/quadrants/lang/util.py        (35 sites: dtype aliases)
  - python/quadrants/lang/_py_tensor.py  (3 sites:  zeros, from_numpy)
  - python/quadrants/lang/_func_base.py  (1 site:   zeros_like)
  - python/quadrants/lang/field.py       (1 site:   zeros)

Each file's pragma includes a brief comment explaining the rationale so a future torch-stubs fix or refactor can find and remove it. The rule remains enabled globally so legitimate private-import bugs elsewhere in the codebase are still caught.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
