### PR TITLE
[Test] Suppress stock pytest-timeout to avoid conflict with pytest_hardtle

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -52,6 +52,8 @@ def _test_python(args, default_dir="python"):
             pytest_args += [
                 "--durations=15",
                 "-p",
+                "no:timeout",
+                "-p",
                 "pytest_hardtle",
                 f"--timeout={args.timeout}",
             ]

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -51,8 +51,14 @@ def _test_python(args, default_dir="python"):
         if args.timeout > 0:
             pytest_args += [
                 "--durations=15",
+                # Suppress stock pytest-timeout if installed — it conflicts
+                # with pytest_hardtle (both register the same hook specs).
                 "-p",
                 "no:timeout",
+                # pytest_hardtle uses a CFFI-compiled C watchdog that calls
+                # _exit(1) from a native signal handler, so it can kill tests
+                # hung in native GPU calls even when the GIL is held.
+                # Stock pytest-timeout's signal method cannot do this.
                 "-p",
                 "pytest_hardtle",
                 f"--timeout={args.timeout}",


### PR DESCRIPTION
## Summary
- Adds `-p no:timeout` before `-p pytest_hardtle` in `run_tests.py` to prevent stock `pytest-timeout` from loading when it's present in the Python environment.
- Fixes the `ValueError: Hook 'pytest_timeout_cancel_timer' is already registered` crash seen on the AMD GPU runner, where `pytest-timeout` was left over in the tool cache.

## Test plan
- [x] Verify AMD GPU CI passes (previously failing with `ValueError`)

Made with [Cursor](https://cursor.com)