### PR TITLE
[Test] Add --maxfail CLI option to run_tests.py (default 20)

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -48,6 +48,8 @@ def _test_python(args, default_dir="python"):
             pytest_args += ["--failed-first"]
         if args.fail_fast:
             pytest_args += ["--exitfirst"]
+        elif args.maxfail > 0:
+            pytest_args += [f"--maxfail={args.maxfail}"]
         if args.timeout > 0:
             pytest_args += [
                 "--durations=15",
@@ -157,6 +159,14 @@ def test():
         dest="fail_fast",
         action="store_true",
         help="Exit instantly on the first failed test",
+    )
+    parser.add_argument(
+        "--maxfail",
+        required=False,
+        default=20,
+        type=int,
+        dest="maxfail",
+        help="Stop after this many test failures (default: 20, 0 = no limit)",
     )
     parser.add_argument(
         "-C",


### PR DESCRIPTION
## Summary
- Adds `--maxfail` argument to `run_tests.py` (default: 20, pass `--maxfail=0` to disable)
- Stops the test session early after 20 failures so CI doesn't waste time on the remaining tests after a major breakage

## Test plan
- `python tests/run_tests.py -v` stops after 20 failures
- `python tests/run_tests.py -v --maxfail=5` stops after 5
- `python tests/run_tests.py -v --maxfail=0` runs all tests regardless of failures

Made with [Cursor](https://cursor.com)