### PR TITLE
[Vulkan] Use SDK validation layer for debugPrintf instead of apt package

### DIFF
--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -137,9 +137,18 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: install vulkan validation layer
+      - name: install vulkan SDK
         run: |
-          sudo apt-get install -y vulkan-validationlayers
+          VULKAN_VERSION=1.4.321.1
+          PREFIX=$HOME/.cache/vulkan-sdk
+          mkdir -p $PREFIX
+          curl -fsSL "https://sdk.lunarg.com/sdk/download/$VULKAN_VERSION/linux/vulkansdk-linux-x86_64-$VULKAN_VERSION.tar.xz" \
+            | tar -xJ -C $PREFIX --strip-components=1
+          SDK_DIR=$PREFIX/x86_64
+          echo "VULKAN_SDK=$SDK_DIR" >> $GITHUB_ENV
+          echo "VK_LAYER_PATH=$SDK_DIR/share/vulkan/explicit_layer.d" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$SDK_DIR/lib:${LD_LIBRARY_PATH:-}" >> $GITHUB_ENV
+          echo "$SDK_DIR/bin" >> $GITHUB_PATH
       - name: install quadrants
         run: |
           set -x

--- a/quadrants/rhi/vulkan/vulkan_device_creator.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device_creator.cpp
@@ -40,7 +40,7 @@ bool check_validation_layer_support() {
 }
 
 static const std::unordered_set<std::string> ignored_messages = {
-    "UNASSIGNED-DEBUG-PRINTF",
+    "VVL-DEBUG-PRINTF",
     "VUID_Undefined",
     // (penguinliong): Attempting to map a non-host-visible piece of memory.
     // `VulkanDevice::map()` returns `RhiResult::invalid_usage` in this case.
@@ -61,11 +61,9 @@ VKAPI_ATTR VkBool32 VKAPI_CALL vk_debug_callback(VkDebugUtilsMessageSeverityFlag
                                                  void *p_user_data) {
   if (message_type == VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT &&
       message_severity == VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT &&
-      strstr(p_callback_data->pMessage, "DEBUG-PRINTF") != nullptr) {
-    // Message format is "BLABLA | MessageID=xxxxx | <DEBUG_PRINT_MSG>"
-    std::string msg(p_callback_data->pMessage);
-    auto const pos = msg.find_last_of("|");
-    std::cout << msg.substr(pos + 2);
+      p_callback_data->pMessageIdName != nullptr &&
+      strstr(p_callback_data->pMessageIdName, "DEBUG-PRINTF") != nullptr) {
+    std::cout << p_callback_data->pMessage;
   }
 
   if (message_severity > VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {

--- a/quadrants/rhi/vulkan/vulkan_device_creator.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device_creator.cpp
@@ -60,8 +60,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL vk_debug_callback(VkDebugUtilsMessageSeverityFlag
                                                  const VkDebugUtilsMessengerCallbackDataEXT *p_callback_data,
                                                  void *p_user_data) {
   if (message_type == VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT &&
-      message_severity == VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT &&
-      p_callback_data->pMessageIdName != nullptr &&
+      message_severity == VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT && p_callback_data->pMessageIdName != nullptr &&
       strstr(p_callback_data->pMessageIdName, "DEBUG-PRINTF") != nullptr) {
     std::cout << p_callback_data->pMessage;
   }


### PR DESCRIPTION
The apt-provided vulkan-validationlayers (1.3.x) uses a different message format than the SDK validation layer (1.4.x): the old format embedded the message ID in pMessage as "UNASSIGNED-DEBUG-PRINTF | MessageID=xxx | <msg>", while the new format puts "VVL-DEBUG-PRINTF" in pMessageIdName and the raw printf output directly in pMessage.

Update the debug callback to use pMessageIdName for identification and pMessage directly for output. Update CI to download the Vulkan SDK (1.4.321.1) instead of installing vulkan-validationlayers via apt, matching the version used during the build.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
