### PR TITLE
[CI] Add CI job to check line wrapping of comments and docs

### DIFF
--- a/.github/workflows/check_wrapping.yml
+++ b/.github/workflows/check_wrapping.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Wait for other CI jobs to finish
+        run: sleep 1800
+
       - name: Get changed files
         id: changed
         run: |

--- a/.github/workflows/check_wrapping.yml
+++ b/.github/workflows/check_wrapping.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Wait for other CI jobs to finish
+      - name: Wait using dead-reckoning for builds to finish, before running, to save AI cost, if someone pushes many commits in a row
         run: sleep 1800
 
       - name: Get changed files

--- a/.github/workflows/check_wrapping.yml
+++ b/.github/workflows/check_wrapping.yml
@@ -1,0 +1,65 @@
+name: Check line wrapping
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+jobs:
+  check-wrapping:
+    name: Check line wrapping
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed
+        run: |
+          FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD \
+            -- '*.md' '*.py' '*.cpp' '*.h' '*.hpp' '*.c' '*.cc' \
+            | head -200)
+          if [ -z "$FILES" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No relevant files changed."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "$FILES" > /tmp/changed_files.txt
+            echo "Changed files:"
+            cat /tmp/changed_files.txt
+          fi
+
+      - name: Install Cursor CLI
+        if: steps.changed.outputs.skip != 'true'
+        run: |
+          curl https://cursor.com/install -fsS | bash
+          echo "$HOME/.cursor/bin" >> $GITHUB_PATH
+
+      - name: Check wrapping with Cursor agent
+        if: steps.changed.outputs.skip != 'true'
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_KEY_HUGH }}
+        run: |
+          RESULT=$(agent -p "$(cat <<'PROMPT'
+          Check the files listed in /tmp/changed_files.txt for wrapping issues:
+          - In .md files, lines should not be wrapped at all
+          - In code comments and docstrings, lines should be wrapped at 120 characters, NOT at 80
+
+          Only check files listed in /tmp/changed_files.txt. Do NOT modify any files.
+          Be precise: only flag clear violations, not borderline cases.
+          Stop after finding 3 violations.
+
+          If there are NO violations, your final output must start with the word PASS.
+          If there ARE violations, your final output must start with the word FAIL, followed by a list of violations (up to 3) in the format: <filepath>:<line_number>: <brief description>
+          PROMPT
+          )" --model claude-4.6-opus-high-thinking --mode ask --output-format text --trust)
+
+          echo "$RESULT"
+          if echo "$RESULT" | grep -q "^FAIL"; then
+            exit 1
+          fi

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -102,3 +102,36 @@ Quadrants comprises at least three important parts:
 Sometimes, it could be useful to have a `LLVM` version that allows to print intermediate passes or with debug symbols to find out where and why LLVM fails (for example, when Instruction Selection fails). To do so you would have to build LLVM by yourself. If so, you should take some inspiration from our [CI pipeline to build LLVM](https://github.com/Genesis-Embodied-AI/quadrants-sdk-builds/blob/main/.github/workflows/llvm-ci.yml) to tweak a little bit to your liking (and not enable/disable options that would create discrepancies).
 
 You can then use `LLVM_DIR` to point to the `LLVM` build directory.
+
+## CI checks
+
+Pull requests are validated by several CI jobs. Most run automatically; a failing check blocks merge.
+
+### Pre-commit / linters (`linters.yml`)
+
+Runs `pre-commit run -a` which enforces:
+
+- **black** — Python formatting with a 120-character line limit
+- **clang-format** — C/C++ formatting
+- **trailing-whitespace** and **end-of-file-fixer** — whitespace hygiene
+- **ruff** — Python linting
+- **pylint** — additional Python linting (scoped to `python/quadrants/`)
+
+You can run these locally with `pre-commit run -a` after `pip install pre-commit`.
+
+### Other CI jobs
+
+- **pyright** (`pyright_linter.yml`) — Python type checking
+- **clang-tidy** (`clang_tidy.yml`) — C++ static analysis
+- **check-markup-links** (`check_markup_links.yml`) — validates links in documentation
+- **linux / macosx / win** — build and test on each platform
+- **test-gpu** — GPU-specific tests
+
+### Line wrapping check (`check_wrapping.yml`)
+
+Uses an AI agent to check that lines in changed files follow wrapping conventions:
+
+- **Markdown files (`.md`)**: lines should not be hard-wrapped. Each paragraph should be a single long line.
+- **Code comments and docstrings**: lines should be wrapped at 120 characters, not at 80.
+
+The check runs only on files changed in the PR and reports up to 3 violations.


### PR DESCRIPTION
Checks .md files for unwanted hard-wrapping and code comments/docstrings for wrapping at 80 instead of 120 characters.

- waits 30 minutes before running, in case someone pushes many commits in a row

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
