### PR TITLE
[CI] Migrate coverage report to github Check page

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -107,7 +107,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Python check
         uses: actions/setup-python@v4
@@ -140,14 +139,18 @@ jobs:
             exit 0
           fi
 
+          HEAD_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-9)
+
           python tests/coverage_report.py --report-only \
             --compare-branch=origin/${{ github.base_ref }} \
             --coverage-xml $COV_XMLS \
+            --commit-hash "$HEAD_SHA" \
             --format markdown > coverage-check.md || true
 
           python tests/coverage_report.py --report-only \
             --compare-branch=origin/${{ github.base_ref }} \
             --coverage-xml $COV_XMLS \
+            --commit-hash "$HEAD_SHA" \
             --format markdown-summary > coverage-comment.md || true
       - name: Upload full coverage report
         if: always() && hashFiles('coverage-check.md') != ''

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -142,12 +142,18 @@ jobs:
           python tests/coverage_report.py --report-only \
             --compare-branch=origin/${{ github.base_ref }} \
             --coverage-xml $COV_XMLS \
-            --format markdown > coverage-check.md
+            --format markdown > coverage-check.md || true
 
           python tests/coverage_report.py --report-only \
             --compare-branch=origin/${{ github.base_ref }} \
             --coverage-xml $COV_XMLS \
-            --format markdown-summary > coverage-comment.md
+            --format markdown-summary > coverage-comment.md || true
+      - name: Upload full coverage report
+        if: always() && hashFiles('coverage-check.md') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage-check.md
       - name: Publish coverage check
         if: always() && hashFiles('coverage-check.md') != ''
         id: publish_check
@@ -155,7 +161,16 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const body = fs.readFileSync('coverage-check.md', 'utf8');
+            let body = fs.readFileSync('coverage-check.md', 'utf8');
+            const MAX_TEXT = 65000;
+            let truncated = false;
+            if (body.length > MAX_TEXT) {
+              body = body.substring(0, MAX_TEXT) + '\n\n---\n*Report truncated. Download the full report from the workflow artifacts.*';
+              truncated = true;
+            }
+            const summary = truncated
+              ? 'Per-line coverage annotations (truncated — see artifacts for full report).'
+              : 'See details below for per-line coverage annotations.';
             const check = await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -165,7 +180,7 @@ jobs:
               conclusion: 'success',
               output: {
                 title: 'Diff Coverage Report',
-                summary: 'See details below for per-line coverage annotations.',
+                summary: summary,
                 text: body
               }
             });

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -103,6 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      checks: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -123,7 +124,7 @@ jobs:
         with:
           name: coverage-cuda
           path: coverage-cuda
-      - name: Generate coverage report
+      - name: Generate coverage reports
         continue-on-error: true
         run: |
           COV_XMLS=""
@@ -141,9 +142,50 @@ jobs:
           python tests/coverage_report.py --report-only \
             --compare-branch=origin/${{ github.base_ref }} \
             --coverage-xml $COV_XMLS \
-            --format markdown > coverage-comment.md
+            --format markdown > coverage-check.md
+
+          python tests/coverage_report.py --report-only \
+            --compare-branch=origin/${{ github.base_ref }} \
+            --coverage-xml $COV_XMLS \
+            --format markdown-summary > coverage-comment.md
+      - name: Publish coverage check
+        if: always() && hashFiles('coverage-check.md') != ''
+        id: publish_check
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('coverage-check.md', 'utf8');
+            const check = await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: context.payload.pull_request.head.sha,
+              name: 'Coverage Report',
+              status: 'completed',
+              conclusion: 'success',
+              output: {
+                title: 'Diff Coverage Report',
+                summary: 'See details below for per-line coverage annotations.',
+                text: body
+              }
+            });
+            core.setOutput('check-url', check.data.html_url);
       - name: Post coverage comment
         if: always() && hashFiles('coverage-comment.md') != ''
-        run: gh pr comment ${{ github.event.pull_request.number }} --body-file coverage-comment.md
+        uses: actions/github-script@v8
         env:
-          GH_TOKEN: ${{ github.token }}
+          REPORT_URL: ${{ steps.publish_check.outputs.check-url }}
+        with:
+          script: |
+            const fs = require('fs');
+            let body = fs.readFileSync('coverage-comment.md', 'utf8');
+            const url = process.env.REPORT_URL;
+            if (url) {
+              body += `\n\n[Full annotated report](${url})`;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: body
+            });

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -107,6 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Python check
         uses: actions/setup-python@v4

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -126,6 +126,7 @@ You can run these locally with `pre-commit run -a` after `pip install pre-commit
 - **check-markup-links** (`check_markup_links.yml`) — validates links in documentation
 - **linux / macosx / win** — build and test on each platform
 - **test-gpu** — GPU-specific tests
+- **coverage report** — a diff coverage summary is posted as a PR comment on each push, with a link to the full annotated report. This includes kernel-level branch coverage. See [Kernel code coverage](kernel_coverage.md) for details.
 
 ### Line wrapping check (`check_wrapping.yml`)
 

--- a/docs/source/user_guide/kernel_coverage.md
+++ b/docs/source/user_guide/kernel_coverage.md
@@ -96,6 +96,8 @@ Coverage probes change the compiled kernel, so the offline cache will see them a
 
 The CI workflow posts a compact coverage summary as a PR comment on each push, showing per-file coverage percentages and missing line ranges. The full annotated report (with per-line hit/miss markers) is published as a GitHub Check — the PR comment includes a link to it. A **new comment** is created each time (rather than editing the previous one) so that the PR timeline shows a clear chronological sequence of commits and their corresponding coverage results.
 
+The report covers only Python files (`.py`) and only lines added or modified in the PR diff — unchanged lines are not reported. C++ files are not included in the coverage report.
+
 ## Under the hood
 
 When `QD_KERNEL_COVERAGE=1` is set, quadrants rewrites the Python AST of each `@qd.kernel` and `@qd.func` before compilation. It inserts lightweight probe statements (`field[probe_id] = 1`) at each source line. These probes compile as ordinary field stores and execute on the device alongside your kernel code.

--- a/docs/source/user_guide/kernel_coverage.md
+++ b/docs/source/user_guide/kernel_coverage.md
@@ -94,7 +94,7 @@ Coverage probes change the compiled kernel, so the offline cache will see them a
 
 ## CI integration
 
-The CI workflow posts a diff coverage report as a PR comment on each push. A **new comment** is created each time (rather than editing the previous one) so that the PR timeline shows a clear chronological sequence of commits and their corresponding coverage results.
+The CI workflow posts a compact coverage summary as a PR comment on each push, showing per-file coverage percentages and missing line ranges. The full annotated report (with per-line hit/miss markers) is published as a GitHub Check — the PR comment includes a link to it. A **new comment** is created each time (rather than editing the previous one) so that the PR timeline shows a clear chronological sequence of commits and their corresponding coverage results.
 
 ## Under the hood
 

--- a/tests/coverage_report.py
+++ b/tests/coverage_report.py
@@ -132,37 +132,90 @@ class _AnnotatedRenderer(_TerminalRenderer):
                 print(f"{color} {marker} {lineno:4d}{RESET} {color}{text}{RESET}")
 
 
+def _get_commit_hash():
+    return subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    ).stdout.strip()
+
+
 class _MarkdownRenderer(_Renderer):
+    """Full annotated markdown report (for GitHub Check body)."""
+
     _STATUS_MARKER = {"hit": "🟢", "miss": "🔴", "no_data": "  "}
 
+    def __init__(self):
+        self._buf = []
+
+    def _print(self, text=""):
+        self._buf.append(text)
+
     def begin(self, total_hit, total_miss, total_pct):
-        commit = subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
-            capture_output=True,
-            text=True,
-            cwd=REPO_ROOT,
-        ).stdout.strip()
+        commit = _get_commit_hash()
         heading = f"## Coverage Report (`{commit}`)\n" if commit else "## Coverage Report\n"
-        print(heading)
-        print("| Metric | Value |")
-        print("|--------|-------|")
-        print(f"| **Diff coverage** (changed lines only) | **{total_pct:.0f}%** |")
+        self._print(heading)
+        self._print("| Metric | Value |")
+        self._print("|--------|-------|")
+        self._print(f"| **Diff coverage** (changed lines only) | **{total_pct:.0f}%** |")
         overall = _get_overall_coverage()
         if overall:
-            print(f"| Overall project coverage | {overall} |")
-        print()
-        print(f"**Total**: {total_hit + total_miss} lines, {total_miss} missing, {total_pct:.0f}% covered\n")
+            self._print(f"| Overall project coverage | {overall} |")
+        self._print()
+        self._print(f"**Total**: {total_hit + total_miss} lines, {total_miss} missing, {total_pct:.0f}% covered\n")
 
     def begin_file(self, filename, pct, missing):
         icon = "🟢" if pct >= 80 else "🔴"
-        print(f"<details><summary>{icon} <code>{filename}</code> ({pct:.0f}%)</summary>\n")
-        print("```")
+        self._print(f"<details><summary>{icon} <code>{filename}</code> ({pct:.0f}%)</summary>\n")
+        self._print("```")
 
     def write_line(self, lineno, text, status):
-        print(f"{self._STATUS_MARKER[status]} {lineno:4d}  {text}")
+        self._print(f"{self._STATUS_MARKER[status]} {lineno:4d}  {text}")
 
     def end_file(self):
-        print("```\n</details>\n")
+        self._print("```\n</details>\n")
+
+    def output(self):
+        return "\n".join(self._buf)
+
+
+class _MarkdownSummaryRenderer(_Renderer):
+    """Compact markdown summary (for PR comment, under 65K limit)."""
+
+    def __init__(self):
+        self._buf = []
+
+    def _print(self, text=""):
+        self._buf.append(text)
+
+    def begin(self, total_hit, total_miss, total_pct):
+        self._total_hit, self._total_miss, self._total_pct = total_hit, total_miss, total_pct
+        self._files: list[tuple[str, float, list[int]]] = []
+        commit = _get_commit_hash()
+        heading = f"## Coverage Report (`{commit}`)\n" if commit else "## Coverage Report\n"
+        self._print(heading)
+
+    def begin_file(self, filename, pct, missing):
+        self._files.append((filename, pct, missing))
+
+    def finish(self):
+        overall = _get_overall_coverage()
+        self._print("| File | Coverage | Missing |")
+        self._print("|------|----------|---------|")
+        for filename, pct, missing in self._files:
+            icon = "🟢" if pct >= 80 else "🔴"
+            missing_str = _format_ranges(missing) if missing else ""
+            self._print(f"| {icon} `{filename}` | {pct:.0f}% | {missing_str} |")
+        self._print()
+        parts = [f"**Diff coverage: {self._total_pct:.0f}%**"]
+        if overall:
+            parts.append(f"Overall: {overall}")
+        parts.append(f"{self._total_hit + self._total_miss} lines, {self._total_miss} missing")
+        self._print(" · ".join(parts))
+
+    def output(self):
+        return "\n".join(self._buf)
 
 
 _HTML_CSS = """\
@@ -246,6 +299,7 @@ _RENDERERS = {
     "terminal": _TerminalRenderer,
     "annotated": _AnnotatedRenderer,
     "markdown": _MarkdownRenderer,
+    "markdown-summary": _MarkdownSummaryRenderer,
     "html": _HtmlRenderer,
 }
 
@@ -363,6 +417,10 @@ def generate_report(compare_branch, coverage_xmls, output_format="terminal", out
         renderer.end_file()
     renderer.finish()
 
+    rendered = renderer.output()
+    if rendered is not None:
+        print(rendered)
+
     return total_pct
 
 
@@ -427,7 +485,7 @@ def main():
         "--format",
         dest="output_format",
         default="html",
-        choices=["html", "terminal", "annotated", "markdown"],
+        choices=["html", "terminal", "annotated", "markdown", "markdown-summary"],
         help="Output format (default: html)",
     )
     parser.add_argument(

--- a/tests/coverage_report.py
+++ b/tests/coverage_report.py
@@ -132,7 +132,12 @@ class _AnnotatedRenderer(_TerminalRenderer):
                 print(f"{color} {marker} {lineno:4d}{RESET} {color}{text}{RESET}")
 
 
+_COMMIT_HASH_OVERRIDE = None
+
+
 def _get_commit_hash():
+    if _COMMIT_HASH_OVERRIDE:
+        return _COMMIT_HASH_OVERRIDE
     return subprocess.run(
         ["git", "rev-parse", "--short", "HEAD"],
         capture_output=True,
@@ -494,8 +499,16 @@ def main():
         default=None,
         help="Output file path for HTML format (default: coverage-report.html in repo root)",
     )
+    parser.add_argument(
+        "--commit-hash",
+        default=None,
+        help="Override the commit hash shown in the report heading (default: git rev-parse HEAD)",
+    )
 
     args = parser.parse_args()
+
+    global _COMMIT_HASH_OVERRIDE
+    _COMMIT_HASH_OVERRIDE = args.commit_hash
 
     if not args.report_only:
         combine_coverage()

--- a/tests/python/test_fail_device_memory_allocation.py
+++ b/tests/python/test_fail_device_memory_allocation.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 import quadrants as qd
@@ -5,12 +7,15 @@ import quadrants as qd
 from tests import test_utils
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin", reason="macOS unified memory swaps to disk instead of OOMing, causing this test to hang"
+)
 @test_utils.test(arch=qd.gpu)
 def test_huge_allocation_fail_at_allocate_time():
     """Ensure huge allocation fails at allocate time and not at memset to 0"""
     # No match= filter: the exact error message varies across backends
-    # (LLVM pool, CUDA malloc_async, Metal, Vulkan). We only care that
-    # OOM raises a RuntimeError rather than crashing or silently succeeding.
+    # (LLVM pool, CUDA malloc_async, Vulkan). We only care that OOM raises a RuntimeError rather than crashing or
+    # silently succeeding.
     with pytest.raises(RuntimeError):
         allocations = []
         while True:

--- a/tests/python/test_fail_device_memory_allocation.py
+++ b/tests/python/test_fail_device_memory_allocation.py
@@ -15,8 +15,8 @@ from tests import test_utils
 def test_huge_allocation_fail_at_allocate_time():
     """Ensure huge allocation fails at allocate time and not at memset to 0"""
     # No match= filter: the exact error message varies across backends
-    # (LLVM pool, CUDA malloc_async, Vulkan). We only care that OOM raises a RuntimeError rather than crashing or
-    # silently succeeding.
+    # (LLVM pool, CUDA malloc_async, Metal, Vulkan). We only care that
+    # OOM raises a RuntimeError rather than crashing or silently succeeding.
     with pytest.raises(RuntimeError):
         allocations = []
         while True:


### PR DESCRIPTION
Post full annotated coverage (with per-line 🟢/🔴 markers) as a GitHub Check instead of a PR comment to avoid the 65K character limit.  The PR comment now shows only a compact summary table with a link to the full check report.

- Add _MarkdownSummaryRenderer for compact PR comment output
- Refactor _MarkdownRenderer to buffer output instead of printing
- Use checks.create() + issues.createComment() in CI workflow

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
