### PR TITLE
[CI] CI wrap check feeds only diffs to agent

### DIFF
--- a/.github/workflows/check_wrapping.yml
+++ b/.github/workflows/check_wrapping.yml
@@ -21,20 +21,19 @@ jobs:
       - name: Wait using dead-reckoning for builds to finish, before running, to save AI cost, if someone pushes many commits in a row
         run: sleep 1800
 
-      - name: Get changed files
+      - name: Get diff of changed files
         id: changed
         run: |
-          FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD \
+          git diff origin/${{ github.base_ref }}...HEAD \
             -- '*.md' '*.py' '*.cpp' '*.h' '*.hpp' '*.c' '*.cc' \
-            | head -200)
-          if [ -z "$FILES" ]; then
+            > /tmp/pr_diff.patch
+
+          if [ ! -s /tmp/pr_diff.patch ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "No relevant files changed."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "$FILES" > /tmp/changed_files.txt
-            echo "Changed files:"
-            cat /tmp/changed_files.txt
+            echo "Diff written ($(wc -l < /tmp/pr_diff.patch) lines)"
           fi
 
       - name: Install Cursor CLI
@@ -49,11 +48,12 @@ jobs:
           CURSOR_API_KEY: ${{ secrets.CURSOR_KEY_HUGH }}
         run: |
           RESULT=$(agent -p "$(cat <<'PROMPT'
-          Check the files listed in /tmp/changed_files.txt for wrapping issues:
+          The file /tmp/pr_diff.patch contains a unified diff of changes in this PR. Check ONLY the added lines (lines starting with +, excluding the +++ header) for wrapping issues:
           - In .md files, lines should not be wrapped at all
           - In code comments and docstrings, lines should be wrapped at 120 characters, NOT at 80
 
-          Only check files listed in /tmp/changed_files.txt. Do NOT modify any files.
+          Use the @@ hunk headers and +++ file headers to determine file paths and line numbers.
+          Do NOT flag pre-existing code. Do NOT modify any files.
           Be precise: only flag clear violations, not borderline cases.
           Stop after finding 3 violations.
 


### PR DESCRIPTION
Feeds the raw unified diff to the agent so it only checks added/changed lines, not pre-existing code.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
