### PR TITLE
[CI] Add CI check for unnecessarily deleted comments

### DIFF
--- a/.github/workflows/check_deleted_comments.yml
+++ b/.github/workflows/check_deleted_comments.yml
@@ -23,8 +23,10 @@ jobs:
 
       - name: Get diff of changed files
         id: changed
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git diff origin/${{ github.base_ref }}...HEAD \
+          git diff "origin/$BASE_REF...HEAD" \
             -- '*.py' '*.cpp' '*.h' '*.hpp' '*.c' '*.cc' \
             > /tmp/pr_diff.patch
 
@@ -69,6 +71,6 @@ jobs:
           )" --model claude-4.6-opus-high-thinking --mode ask --output-format text --trust)
 
           echo "$RESULT"
-          if echo "$RESULT" | grep -q "^FAIL"; then
+          if echo "$RESULT" | grep -qE "^FAIL([[:space:]]|$)"; then
             exit 1
           fi

--- a/.github/workflows/check_deleted_comments.yml
+++ b/.github/workflows/check_deleted_comments.yml
@@ -1,0 +1,74 @@
+name: Check deleted comments
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+jobs:
+  check-deleted-comments:
+    name: Check deleted comments
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Wait using dead-reckoning for builds to finish, before running, to save AI cost, if someone pushes many commits in a row
+        run: sleep 1800
+
+      - name: Get diff of changed files
+        id: changed
+        run: |
+          git diff origin/${{ github.base_ref }}...HEAD \
+            -- '*.py' '*.cpp' '*.h' '*.hpp' '*.c' '*.cc' \
+            > /tmp/pr_diff.patch
+
+          if [ ! -s /tmp/pr_diff.patch ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No relevant files changed."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Diff written ($(wc -l < /tmp/pr_diff.patch) lines)"
+          fi
+
+      - name: Install Cursor CLI
+        if: steps.changed.outputs.skip != 'true'
+        run: |
+          curl https://cursor.com/install -fsS | bash
+          echo "$HOME/.cursor/bin" >> $GITHUB_PATH
+
+      - name: Check for unnecessarily deleted comments
+        if: steps.changed.outputs.skip != 'true'
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_KEY_HUGH }}
+        run: |
+          RESULT=$(agent -p "$(cat <<'PROMPT'
+          The file /tmp/pr_diff.patch contains a unified diff of changes in this PR. Check for comments or docstrings that have been deleted (lines starting with -) without good reason.
+
+          A deletion is UNNECESSARY if:
+          - A comment explaining non-obvious logic, a trade-off, or a constraint was removed, and the code it described is still present
+          - A docstring was removed or significantly reduced without the function being deleted
+
+          A deletion is FINE if:
+          - The code the comment described was also deleted
+          - The comment is no longer correct
+
+          Use the @@ hunk headers and --- file headers to determine file paths and line numbers.
+          Do NOT modify any files.
+          Be precise: only flag clear violations, not borderline cases.
+          Stop after finding 10 violations.
+
+          If there are NO violations, your final output must start with the word PASS.
+          If there ARE violations, your final output must start with the word FAIL, followed by a list of violations (up to 10) in the format: <filepath>:<line_number>: <brief description>
+          PROMPT
+          )" --model claude-4.6-opus-high-thinking --mode ask --output-format text --trust)
+
+          echo "$RESULT"
+          if echo "$RESULT" | grep -q "^FAIL"; then
+            exit 1
+          fi

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -138,6 +138,4 @@ The check runs only on lines changed in the PR and reports up to 3 violations.
 
 ### Deleted comments check (`check_deleted_comments.yml`)
 
-Uses an AI agent to check that comments and docstrings have not been unnecessarily deleted.
-
-The check reports up to 10 violations.
+Uses an AI agent to check that comments and docstrings have not been unnecessarily deleted. Reports up to 10 violations.

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -134,8 +134,8 @@ Uses an AI agent to check that lines in changed files follow wrapping convention
 - **Markdown files (`.md`)**: lines should not be hard-wrapped. Each paragraph should be a single long line.
 - **Code comments and docstrings**: lines should be wrapped at 120 characters, not at 80.
 
-The check runs only on lines changed in the PR and reports up to 3 violations.
+The check runs only on lines changed in the PR and reports up to 3 violations. This check is delayed by 30 minutes, to avoid running repeatedly if multiple commits pushed with a short delay between each.
 
 ### Deleted comments check (`check_deleted_comments.yml`)
 
-Uses an AI agent to check that comments and docstrings have not been unnecessarily deleted. Reports up to 10 violations.
+Uses an AI agent to check that comments and docstrings have not been unnecessarily deleted. Reports up to 10 violations. This check is delayed by 30 minutes, to avoid running repeatedly if multiple commits pushed with a short delay between each.

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -134,4 +134,10 @@ Uses an AI agent to check that lines in changed files follow wrapping convention
 - **Markdown files (`.md`)**: lines should not be hard-wrapped. Each paragraph should be a single long line.
 - **Code comments and docstrings**: lines should be wrapped at 120 characters, not at 80.
 
-The check runs only on files changed in the PR and reports up to 3 violations.
+The check runs only on lines changed in the PR and reports up to 3 violations.
+
+### Deleted comments check (`check_deleted_comments.yml`)
+
+Uses an AI agent to check that comments and docstrings have not been unnecessarily deleted. A deletion is flagged if a comment explaining non-obvious logic, a trade-off, or a constraint was removed while the code it described is still present. Deletions are fine if the code the comment described was also deleted, or if the comment is no longer correct.
+
+The check runs only on the PR diff and reports up to 10 violations.

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -140,4 +140,4 @@ The check runs only on lines changed in the PR and reports up to 3 violations.
 
 Uses an AI agent to check that comments and docstrings have not been unnecessarily deleted.
 
-The check runs only on the PR diff and reports up to 10 violations.
+The check reports up to 10 violations.

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -138,6 +138,6 @@ The check runs only on lines changed in the PR and reports up to 3 violations.
 
 ### Deleted comments check (`check_deleted_comments.yml`)
 
-Uses an AI agent to check that comments and docstrings have not been unnecessarily deleted. A deletion is flagged if a comment explaining non-obvious logic, a trade-off, or a constraint was removed while the code it described is still present. Deletions are fine if the code the comment described was also deleted, or if the comment is no longer correct.
+Uses an AI agent to check that comments and docstrings have not been unnecessarily deleted.
 
 The check runs only on the PR diff and reports up to 10 violations.

--- a/tests/python/test_fail_device_memory_allocation.py
+++ b/tests/python/test_fail_device_memory_allocation.py
@@ -14,8 +14,8 @@ from tests import test_utils
 def test_huge_allocation_fail_at_allocate_time():
     """Ensure huge allocation fails at allocate time and not at memset to 0"""
     # No match= filter: the exact error message varies across backends
-    # (LLVM pool, CUDA malloc_async, Vulkan). We only care that OOM raises
-    # a RuntimeError rather than crashing or silently succeeding.
+    # (LLVM pool, CUDA malloc_async, Vulkan). We only care that OOM raises a RuntimeError rather than crashing or
+    # silently succeeding.
     with pytest.raises(RuntimeError):
         allocations = []
         while True:

--- a/tests/python/test_fail_device_memory_allocation.py
+++ b/tests/python/test_fail_device_memory_allocation.py
@@ -7,7 +7,9 @@ import quadrants as qd
 from tests import test_utils
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="macOS unified memory swaps to disk instead of OOMing, causing this test to hang")
+@pytest.mark.skipif(
+    sys.platform == "darwin", reason="macOS unified memory swaps to disk instead of OOMing, causing this test to hang"
+)
 @test_utils.test(arch=qd.gpu)
 def test_huge_allocation_fail_at_allocate_time():
     """Ensure huge allocation fails at allocate time and not at memset to 0"""

--- a/tests/python/test_fail_device_memory_allocation.py
+++ b/tests/python/test_fail_device_memory_allocation.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 import quadrants as qd
@@ -5,12 +7,13 @@ import quadrants as qd
 from tests import test_utils
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="macOS unified memory swaps to disk instead of OOMing, causing this test to hang")
 @test_utils.test(arch=qd.gpu)
 def test_huge_allocation_fail_at_allocate_time():
     """Ensure huge allocation fails at allocate time and not at memset to 0"""
     # No match= filter: the exact error message varies across backends
-    # (LLVM pool, CUDA malloc_async, Metal, Vulkan). We only care that
-    # OOM raises a RuntimeError rather than crashing or silently succeeding.
+    # (LLVM pool, CUDA malloc_async, Vulkan). We only care that OOM raises
+    # a RuntimeError rather than crashing or silently succeeding.
     with pytest.raises(RuntimeError):
         allocations = []
         while True:

--- a/tests/python/test_fail_device_memory_allocation.py
+++ b/tests/python/test_fail_device_memory_allocation.py
@@ -15,8 +15,8 @@ from tests import test_utils
 def test_huge_allocation_fail_at_allocate_time():
     """Ensure huge allocation fails at allocate time and not at memset to 0"""
     # No match= filter: the exact error message varies across backends
-    # (LLVM pool, CUDA malloc_async, Vulkan). We only care that OOM raises a RuntimeError rather than crashing or
-    # silently succeeding.
+    # (LLVM pool, CUDA malloc_async, Metal, Vulkan). We only care that
+    # OOM raises a RuntimeError rather than crashing or silently succeeding.
     with pytest.raises(RuntimeError):
         allocations = []
         while True:


### PR DESCRIPTION
Uses a Cursor agent to review the PR diff for comments or docstrings that were removed without the corresponding code being deleted.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
