### PR TITLE
[CI] Fix Vulkan debugPrintf flake with session-scoped warmup

### DIFF
--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -61,6 +61,9 @@ def _vulkan_debug_warmup():
     process: vkQueueWaitIdle() can return before the callback fires. A full init/dispatch/sync/reset cycle here warms
     the driver-level debug infrastructure so subsequent inits work reliably.
     """
+    if sys.platform == "darwin":
+        return
+
     from tests import test_utils
 
     if qd.vulkan not in test_utils.expected_archs():

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -53,6 +53,39 @@ def run_gc_after_test():
     gc.collect()
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _vulkan_debug_warmup():
+    """Prime the Vulkan debugPrintf callback pipeline once per worker process.
+
+    The validation layer's debugPrintf callback delivery has a race condition on
+    the first kernel dispatch in a new process: vkQueueWaitIdle() can return
+    before the callback fires. A full init/dispatch/sync/reset cycle here warms
+    the driver-level debug infrastructure so subsequent inits work reliably.
+    """
+    from tests import test_utils
+
+    if qd.vulkan not in test_utils.expected_archs():
+        return
+
+    try:
+        qd.init(arch=qd.vulkan, debug=True, enable_fallback=False, print_full_traceback=True)
+
+        @qd.kernel
+        def _warmup() -> qd.i8:
+            return qd.i8(64) + qd.i8(64)
+
+        _warmup()
+        qd.sync()
+        sys.stdout.flush()
+    except Exception:
+        pass
+    finally:
+        try:
+            qd.reset()
+        except Exception:
+            pass
+
+
 @pytest.fixture(autouse=True)
 def wanted_arch(request, req_arch, req_options):
     if req_arch is not None:

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -57,9 +57,8 @@ def run_gc_after_test():
 def _vulkan_debug_warmup():
     """Prime the Vulkan debugPrintf callback pipeline once per worker process.
 
-    The validation layer's debugPrintf callback delivery has a race condition on
-    the first kernel dispatch in a new process: vkQueueWaitIdle() can return
-    before the callback fires. A full init/dispatch/sync/reset cycle here warms
+    The validation layer's debugPrintf callback delivery has a race condition on the first kernel dispatch in a new
+    process: vkQueueWaitIdle() can return before the callback fires. A full init/dispatch/sync/reset cycle here warms
     the driver-level debug infrastructure so subsequent inits work reliably.
     """
     from tests import test_utils


### PR DESCRIPTION
The validation layer's debugPrintf callback has a race condition on the first kernel dispatch in a fresh process: vkQueueWaitIdle() can return before the callback fires, causing empty captured stdout. This only manifests under pytest-xdist with multiple workers contending for the GPU.

Run one throwaway overflow kernel, for each worker that runs vulkan tests with debug=True, to prime the callback pipeline before real tests run. Validated with 10 consecutive rounds passing on T4 CI runner, where previously ~60% of rounds failed.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
