### PR TITLE
[Test] Fix missing `import sys` in test_fail_device_memory_allocation

### DIFF
--- a/tests/python/test_fail_device_memory_allocation.py
+++ b/tests/python/test_fail_device_memory_allocation.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 import quadrants as qd


### PR DESCRIPTION
The skipif decorator references `sys.platform` but `sys` was never imported.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
