### PR TITLE
[AutoDiff] determine_ad_stack_size: replace whole-CFG Bellman-Ford with SCC + DAG DP

### DIFF
--- a/quadrants/ir/control_flow_graph.cpp
+++ b/quadrants/ir/control_flow_graph.cpp
@@ -1258,24 +1258,36 @@ std::unordered_set<SNode *> ControlFlowGraph::gather_loaded_snodes() {
 
 void ControlFlowGraph::determine_ad_stack_size() {
   /**
-   * Determine all adaptive AD-stacks' necessary size using the Bellman-Ford
-   * algorithm. Stacks whose forward kernel contains a positive cycle (pushes > pops around a
-   * loop) are left at `max_size = 0`; the caller routes them through the structural bounded-loop
-   * pre-pass for a symbolic `SizeExpr`, and hard-errors if the grammar cannot resolve them. There
-   * is no compile-time size fallback. The time complexity is
-   * O(num_statements + num_stacks * num_edges * num_nodes).
+   * Determine the necessary size of every adaptive AD-stack on the control-flow graph (CFG). The
+   * problem reduces to finding, for each AD-stack, the maximum running net push count along any
+   * walk from the kernel entry. We solve it with a Bellman-Ford-style longest-path computation
+   * variant; AD-stacks whose forward kernel contains a positive cycle (pushes > pops around a
+   * loop) are left at `max_size = 0`, and the caller routes them through the structural bounded-
+   * loop pre-pass for a symbolic `SizeExpr`, hard-erroring if the grammar still cannot resolve
+   * them. There is no compile-time size fallback.
    *
-   * Implementation notes: the per-stack data is keyed by a contiguous stack id and stored in
-   * vector<vector<int>> rather than unordered_map<AdStackAllocaStmt*, vector<int>>, the BF visit
-   * loop hoists the per-stack vectors as local references, and outgoing edge node ids are
-   * precomputed once per source node. These keep the dominant inner loop free of hash lookups,
-   * which large reverse-mode kernels are sensitive to.
+   * Implementation notes for compile-time perf on large reverse-mode kernels:
+   *   1. Per-stack per-node pre-aggregates (`max_increased_size`, `increased_size`) are stored
+   *      in dense `vector<vector<int>>` indexed by a contiguous int stack id, instead of a
+   *      `unordered_map<AdStackAllocaStmt*, vector<int>>` -- this removes hash traffic from the
+   *      hot inner loop.
+   *   2. Stacks whose `(increased_size, max_increased_size)` row pair is bit-identical share a
+   *      single Bellman-Ford run -- typical kernels generate one alloca per autodiff variable in
+   *      the same loop body, so most rows collapse to a few representatives.
+   *   3. The CFG is condensed via Tarjan into strongly connected components (SCCs); the per-stack
+   *      computation is a topological-order dynamic programming (DP) sweep over the SCC
+   *      condensation, with a Shortest-Path-Faster-Algorithm (SPFA, the queue-based Bellman-Ford
+   *      variant) bounded inside each cyclic SCC. Cycle detection is local to the SCC, so stacks
+   *      pay only for the cycles they actually touch and the global O(V * E) Bellman-Ford worst
+   *      case is gone.
+   * Per-stack cost becomes O(V + E + sum_{cyclic S} |S| * |E_S|), where V/E are CFG node/edge
+   * counts; the overall cost is O(V + E + R * (V + E + sum_{cyclic S} |S| * |E_S|)) with R the
+   * number of distinct row-pair representatives.
    */
   const int num_nodes = size();
 
-  // Map AdStackAllocaStmt* to a contiguous int index. Only stacks whose `max_size` is still 0
-  // (i.e. unresolved by an earlier pass) participate in BF; resolved stacks are skipped so the
-  // pass cannot clobber them.
+  // Map AdStackAllocaStmt* to a contiguous int index. Only stacks whose `max_size` is still 0 (i.e. unresolved by an
+  // earlier pass) participate in Bellman-Ford; resolved stacks are skipped so the pass cannot clobber them.
   std::unordered_map<AdStackAllocaStmt *, int> stack_id;
   std::vector<AdStackAllocaStmt *> stacks;
 
@@ -1302,16 +1314,15 @@ void ControlFlowGraph::determine_ad_stack_size() {
     return;
   }
 
-  // max_increased_size[s][j] is the maximum number of (pushes - pops) of stack |s| among all
-  // prefixes of the CFGNode |j|. increased_size[s][j] is the net (pushes - pops) of stack |s| in
-  // the CFGNode |j|. Both are indexed by contiguous stack id (cheap vector access in the BF hot
-  // loop).
+  // max_increased_size[s][j] is the maximum number of (pushes - pops) of stack |s| among all prefixes of the
+  // CFGNode |j|. increased_size[s][j] is the net (pushes - pops) of stack |s| in the CFGNode |j|. Both are indexed
+  // by contiguous stack id, so the per-stack DP loop reads them with cheap vector access.
   std::vector<std::vector<int>> max_increased_size(num_stacks, std::vector<int>(num_nodes, 0));
   std::vector<std::vector<int>> increased_size(num_stacks, std::vector<int>(num_nodes, 0));
 
-  // Track which stacks actually participate in any push/pop in the CFG. Stacks with no
-  // push/pop end with `max_size = 0` regardless of BF (every node has zero increase), so we
-  // skip BF for them and reproduce the original "Unused autodiff stack" warning here.
+  // Track which stacks actually participate in any push/pop in the CFG. Stacks with no push/pop end with
+  // `max_size = 0` regardless of Bellman-Ford (every node has zero increase), so we skip Bellman-Ford for them and
+  // reproduce the original "Unused autodiff stack" warning here.
   std::vector<bool> stack_active(num_stacks, false);
 
   for (int i = 0; i < num_nodes; i++) {
@@ -1343,8 +1354,8 @@ void ControlFlowGraph::determine_ad_stack_size() {
     }
   }
 
-  // Precompute outgoing-edge node ids once per node so the BF inner loop walks an int vector
-  // instead of hashing `node_ids[next_node]` on every traversal.
+  // Precompute outgoing-edge node ids once per node so the per-stack DP walks an int vector instead of hashing
+  // `node_ids[next_node]` on every traversal.
   std::vector<std::vector<int>> next_ids(num_nodes);
   for (int i = 0; i < num_nodes; i++) {
     auto &dst = next_ids[i];
@@ -1354,12 +1365,119 @@ void ControlFlowGraph::determine_ad_stack_size() {
     }
   }
 
-  // Group stacks whose per-node (increased_size, max_increased_size) rows are bit-identical, so
-  // that BF runs once per equivalence class instead of once per stack. In practice many AD-stacks
-  // in the same kernel share their push/pop schedule (one alloca per autodiff variable in the
-  // same loop body), and BF on a large CFG dwarfs the dedup cost. We hash a sparse fingerprint
-  // (only nodes where the stack actually has push/pop activity) and group by it. Worst case (no
-  // duplicates): one BF run per stack, equivalent to running BF directly per stack.
+  // Tarjan strongly-connected-component (SCC) decomposition of the CFG, computed once and shared across all per-stack
+  // Bellman-Ford runs. Output:
+  //   scc_id[n]    : SCC index of each node (lower index = topologically deeper / sink-side, so sources are at index
+  //                  num_sccs - 1, matching Tarjan's natural emission order which is reverse topological order).
+  //   scc_nodes[s] : list of node ids in SCC s.
+  // We then split each node's outgoing edges into intra-SCC and inter-SCC sets so the per-stack dynamic-programming
+  // sweep iterates each set without filtering inside the hot loop. Cyclic SCCs (|S| > 1 or |S| == 1 with self-loop)
+  // are flagged so cycle detection runs only on those, and only at SCC scope.
+  std::vector<int> scc_id(num_nodes, -1);
+  std::vector<std::vector<int>> scc_nodes;
+  {
+    std::vector<int> tarjan_index(num_nodes, -1);
+    std::vector<int> tarjan_lowlink(num_nodes, 0);
+    std::vector<char> on_stack(num_nodes, 0);
+    std::vector<int> tarjan_stack;
+    tarjan_stack.reserve(num_nodes);
+    std::vector<std::pair<int, std::size_t>> dfs_stack;
+    dfs_stack.reserve(num_nodes);
+    int next_index = 0;
+    int next_scc = 0;
+    for (int origin = 0; origin < num_nodes; origin++) {
+      if (tarjan_index[origin] != -1) {
+        continue;
+      }
+      tarjan_index[origin] = next_index;
+      tarjan_lowlink[origin] = next_index;
+      next_index++;
+      tarjan_stack.push_back(origin);
+      on_stack[origin] = 1;
+      dfs_stack.emplace_back(origin, 0);
+      while (!dfs_stack.empty()) {
+        auto &frame = dfs_stack.back();
+        const int u = frame.first;
+        const auto &nb = next_ids[u];
+        if (frame.second < nb.size()) {
+          const int v = nb[frame.second++];
+          if (tarjan_index[v] == -1) {
+            tarjan_index[v] = next_index;
+            tarjan_lowlink[v] = next_index;
+            next_index++;
+            tarjan_stack.push_back(v);
+            on_stack[v] = 1;
+            dfs_stack.emplace_back(v, 0);
+          } else if (on_stack[v]) {
+            if (tarjan_index[v] < tarjan_lowlink[u]) {
+              tarjan_lowlink[u] = tarjan_index[v];
+            }
+          }
+        } else {
+          if (tarjan_lowlink[u] == tarjan_index[u]) {
+            std::vector<int> component;
+            while (true) {
+              const int w = tarjan_stack.back();
+              tarjan_stack.pop_back();
+              on_stack[w] = 0;
+              scc_id[w] = next_scc;
+              component.push_back(w);
+              if (w == u) {
+                break;
+              }
+            }
+            scc_nodes.push_back(std::move(component));
+            next_scc++;
+          }
+          dfs_stack.pop_back();
+          if (!dfs_stack.empty()) {
+            const int parent = dfs_stack.back().first;
+            if (tarjan_lowlink[u] < tarjan_lowlink[parent]) {
+              tarjan_lowlink[parent] = tarjan_lowlink[u];
+            }
+          }
+        }
+      }
+    }
+  }
+  const int num_sccs = static_cast<int>(scc_nodes.size());
+
+  std::vector<std::vector<int>> next_ids_intra(num_nodes);
+  std::vector<std::vector<int>> next_ids_inter(num_nodes);
+  for (int u = 0; u < num_nodes; u++) {
+    const int su = scc_id[u];
+    for (int v : next_ids[u]) {
+      if (scc_id[v] == su) {
+        next_ids_intra[u].push_back(v);
+      } else {
+        next_ids_inter[u].push_back(v);
+      }
+    }
+  }
+
+  // An SCC is cyclic iff it contains a cycle. By definition that is |S| > 1 (any two nodes lie on a cycle since the
+  // SCC is strongly connected) or |S| == 1 with a self-loop edge.
+  std::vector<char> scc_is_cyclic(num_sccs, 0);
+  for (int s = 0; s < num_sccs; s++) {
+    if (scc_nodes[s].size() > 1) {
+      scc_is_cyclic[s] = 1;
+    } else {
+      const int n = scc_nodes[s][0];
+      for (int v : next_ids_intra[n]) {
+        if (v == n) {
+          scc_is_cyclic[s] = 1;
+          break;
+        }
+      }
+    }
+  }
+
+  // Group AD-stacks whose per-node (increased_size, max_increased_size) rows are bit-identical, so that Bellman-Ford
+  // runs once per equivalence class instead of once per stack. In practice many AD-stacks in the same kernel share
+  // their push/pop schedule (one alloca per autodiff variable in the same loop body), and Bellman-Ford on a large
+  // CFG dwarfs the dedup cost. We hash a sparse fingerprint (only nodes where the stack actually has push/pop
+  // activity) and group by it. Worst case (no duplicates): one Bellman-Ford run per stack, equivalent to running it
+  // directly per stack.
   using Fingerprint = std::vector<std::tuple<int, int, int>>;  // (node_id, is, mis), sorted by node_id
   struct FingerprintHash {
     std::size_t operator()(const Fingerprint &f) const noexcept {
@@ -1398,14 +1516,13 @@ void ControlFlowGraph::determine_ad_stack_size() {
     }
   }
 
-  // BF scratch reused across representatives to avoid reallocating per iteration.
+  // Scratch buffers reused across representatives to avoid reallocating per iteration.
   std::vector<int> max_size_at_node_begin(num_nodes);
   std::vector<char> in_queue(num_nodes);
   std::vector<int> times_pushed_in_queue(num_nodes);
   std::queue<int> to_visit;
 
-  // BF results keyed by representative stack id, broadcast below to every stack that hashed to
-  // this representative.
+  // Per-representative results, broadcast below to every stack that hashed to this representative.
   struct BFResult {
     int max_size;
     bool has_positive_loop;
@@ -1413,15 +1530,17 @@ void ControlFlowGraph::determine_ad_stack_size() {
   std::unordered_map<int, BFResult> rep_results;
   rep_results.reserve(rep_stack_ids.size());
 
-  // The maximum stack size determining algorithm -- run the Bellman-Ford algorithm on each
-  // distinct (increased_size, max_increased_size) row pair.
+  // For each representative stack, walk the SCC condensation in topological order (sources first, since Tarjan emits
+  // SCCs in reverse-topological order so source SCCs end up at the largest indices). Each non-cyclic SCC is processed
+  // in O(1) per node; each cyclic SCC runs a small Shortest-Path-Faster-Algorithm sweep bounded to |S| + 1 queue
+  // pushes per node, with positive-cycle detection scoped to the SCC. Inter-SCC edges only relax forward
+  // (predecessors are already finalized when an SCC is entered), so each is touched O(1) times per stack. Total
+  // per-stack cost is therefore O(V + E + sum_{cyclic S} |S| * |E_S|), independent of the global V * E worst case
+  // that would dominate a Bellman-Ford pass running on the whole CFG.
   for (int rep_sid : rep_stack_ids) {
-    // Hoist references to the per-stack vectors out of the BF visit loop.
     const std::vector<int> &mis_for_stack = max_increased_size[rep_sid];
     const std::vector<int> &is_for_stack = increased_size[rep_sid];
 
-    // Reset BF scratch. `max_size_at_node_begin` starts at -1 to force the first relaxation to
-    // overwrite, matching the original behaviour.
     std::fill(max_size_at_node_begin.begin(), max_size_at_node_begin.end(), -1);
     std::fill(in_queue.begin(), in_queue.end(), 0);
     std::fill(times_pushed_in_queue.begin(), times_pushed_in_queue.end(), 0);
@@ -1429,70 +1548,102 @@ void ControlFlowGraph::determine_ad_stack_size() {
 
     int max_size = 0;
     max_size_at_node_begin[start_node] = 0;
-    to_visit.push(start_node);
-    in_queue[start_node] = 1;
-    times_pushed_in_queue[start_node]++;
 
     bool has_positive_loop = false;
 
-    while (!to_visit.empty()) {
-      int node_id = to_visit.front();
-      to_visit.pop();
-      in_queue[node_id] = 0;
+    for (int s = num_sccs - 1; s >= 0 && !has_positive_loop; s--) {
+      const auto &nodes_in_s = scc_nodes[s];
 
-      // Inside this CFGNode -- update the answer |max_size|
-      const int begin_size = max_size_at_node_begin[node_id];
-      const int current_max_size = begin_size + mis_for_stack[node_id];
-      if (current_max_size > max_size) {
-        max_size = current_max_size;
-      }
-      // At the end of this CFGNode -- update the state |max_size_at_node_begin| of other
-      // CFGNodes
-      const int current_size = begin_size + is_for_stack[node_id];
-      for (int next_node_id : next_ids[node_id]) {
-        if (current_size > max_size_at_node_begin[next_node_id]) {
-          max_size_at_node_begin[next_node_id] = current_size;
-          if (!in_queue[next_node_id]) {
-            if (times_pushed_in_queue[next_node_id] <= num_nodes) {
-              to_visit.push(next_node_id);
-              in_queue[next_node_id] = 1;
-              times_pushed_in_queue[next_node_id]++;
-            } else {
-              // A positive loop is found because a node is going to be pushed into the queue
-              // the (num_nodes + 1)-th time.
-              has_positive_loop = true;
-              break;
-            }
+      if (scc_is_cyclic[s]) {
+        // Bounded Shortest-Path-Faster-Algorithm sweep on the intra-SCC subgraph. All entry nodes (those already
+        // relaxed by earlier SCCs) seed the queue; relaxation only follows intra-SCC edges. The SCC's size bounds
+        // the number of legal pushes per node -- a node entering the queue more than |S| + 1 times means a positive
+        // cycle exists for this stack within the SCC, which is the per-stack failure signal. The cycle detection is
+        // local to the SCC, so positive cycles in unrelated SCCs do not contaminate this one.
+        const int s_size = static_cast<int>(nodes_in_s.size());
+        for (int u : nodes_in_s) {
+          in_queue[u] = 0;
+          times_pushed_in_queue[u] = 0;
+        }
+        for (int u : nodes_in_s) {
+          if (max_size_at_node_begin[u] >= 0) {
+            to_visit.push(u);
+            in_queue[u] = 1;
+            times_pushed_in_queue[u]++;
           }
         }
+        while (!to_visit.empty()) {
+          int u = to_visit.front();
+          to_visit.pop();
+          in_queue[u] = 0;
+          const int exit_val = max_size_at_node_begin[u] + is_for_stack[u];
+          for (int v : next_ids_intra[u]) {
+            if (exit_val > max_size_at_node_begin[v]) {
+              max_size_at_node_begin[v] = exit_val;
+              if (!in_queue[v]) {
+                if (times_pushed_in_queue[v] <= s_size) {
+                  to_visit.push(v);
+                  in_queue[v] = 1;
+                  times_pushed_in_queue[v]++;
+                } else {
+                  has_positive_loop = true;
+                  break;
+                }
+              }
+            }
+          }
+          if (has_positive_loop) {
+            break;
+          }
+        }
+        if (has_positive_loop) {
+          // Drain any residual queue entries so the next iteration starts clean.
+          std::queue<int>().swap(to_visit);
+          break;
+        }
       }
-      if (has_positive_loop) {
-        break;
+
+      // SCC has converged for this stack. Update global max_size from each node's max-prefix contribution and relax
+      // inter-SCC outgoing edges into successor SCCs.
+      for (int u : nodes_in_s) {
+        const int begin = max_size_at_node_begin[u];
+        if (begin < 0) {
+          continue;
+        }
+        const int prefix = begin + mis_for_stack[u];
+        if (prefix > max_size) {
+          max_size = prefix;
+        }
+        const int exit_val = begin + is_for_stack[u];
+        for (int v : next_ids_inter[u]) {
+          if (exit_val > max_size_at_node_begin[v]) {
+            max_size_at_node_begin[v] = exit_val;
+          }
+        }
       }
     }
 
     rep_results[rep_sid] = {max_size, has_positive_loop};
   }
 
-  // Broadcast representative BF results to every active stack.
+  // Broadcast representative results to every active stack.
   for (int sid = 0; sid < num_stacks; sid++) {
     AdStackAllocaStmt *stack = stacks[sid];
     if (!stack_active[sid]) {
-      // No push/pop in the CFG: BF would visit reachable nodes with all-zero edge weights and
-      // settle with `max_size = 0`, no positive loop. Reproduce the post-BF result directly.
+      // No push/pop in the CFG: Bellman-Ford would visit reachable nodes with all-zero edge weights and settle with
+      // `max_size = 0`, no positive loop. Reproduce that result directly.
       QD_WARN("Unused autodiff stack {} should have been eliminated.", stack->name());
       continue;
     }
     const BFResult &res = rep_results[stack_to_rep[sid]];
     if (res.has_positive_loop) {
-      // Leave `max_size = 0` so the structural bounded-loop pre-pass in
-      // `irpass::determine_ad_stack_size` gets a chance to derive a symbolic bound (a
-      // statically-bounded inner loop whose push-only body defeats Bellman-Ford, resolved from
-      // the outer ranges). If it also cannot, the caller emits a hard compile error - there is
+      // Leave `max_size = 0` so the structural bounded-loop pre-pass in `irpass::determine_ad_stack_size` gets a
+      // chance to derive a symbolic bound (a statically-bounded inner loop whose push-only body defeats Bellman-
+      // Ford, resolved from the outer ranges). If it also cannot, the caller emits a hard compile error - there is
       // no compile-time `default_ad_stack_size` fallback.
     } else {
-      // Since we use |max_size| == 0 for adaptive sizes, we do not want stacks with maximum
-      // capacity indeed equal to 0.
+      // Since we use |max_size| == 0 for adaptive sizes, we do not want stacks with maximum capacity indeed equal
+      // to 0.
       QD_WARN_IF(res.max_size == 0, "Unused autodiff stack {} should have been eliminated.", stack->name());
       stack->max_size = res.max_size;
     }

--- a/quadrants/ir/control_flow_graph.cpp
+++ b/quadrants/ir/control_flow_graph.cpp
@@ -1258,36 +1258,40 @@ std::unordered_set<SNode *> ControlFlowGraph::gather_loaded_snodes() {
 
 void ControlFlowGraph::determine_ad_stack_size() {
   /**
-   * Determine the necessary size of every adaptive AD-stack on the control-flow graph (CFG). The
-   * problem reduces to finding, for each AD-stack, the maximum running net push count along any
-   * walk from the kernel entry. We solve it with a Bellman-Ford-style longest-path computation
-   * variant; AD-stacks whose forward kernel contains a positive cycle (pushes > pops around a
-   * loop) are left at `max_size = 0`, and the caller routes them through the structural bounded-
-   * loop pre-pass for a symbolic `SizeExpr`, hard-erroring if the grammar still cannot resolve
-   * them. There is no compile-time size fallback.
+   * Determine the necessary size of every adaptive AD-stack on the control-flow graph (CFG). For each AD-stack we
+   * compute the maximum running net push count along any walk from the kernel entry. AD-stacks whose forward kernel
+   * contains a positive cycle (pushes > pops around a loop) are left at `max_size = 0`, and the caller routes them
+   * through the structural bounded-loop pre-pass for a symbolic `SizeExpr`, hard-erroring if the grammar still
+   * cannot resolve them. There is no compile-time size fallback.
    *
    * Implementation notes for compile-time perf on large reverse-mode kernels:
-   *   1. Per-stack per-node pre-aggregates (`max_increased_size`, `increased_size`) are stored
-   *      in dense `vector<vector<int>>` indexed by a contiguous int stack id, instead of a
-   *      `unordered_map<AdStackAllocaStmt*, vector<int>>` -- this removes hash traffic from the
-   *      hot inner loop.
-   *   2. Stacks whose `(increased_size, max_increased_size)` row pair is bit-identical share a
-   *      single Bellman-Ford run -- typical kernels generate one alloca per autodiff variable in
-   *      the same loop body, so most rows collapse to a few representatives.
-   *   3. The CFG is condensed via Tarjan into strongly connected components (SCCs); the per-stack
-   *      computation is a topological-order dynamic programming (DP) sweep over the SCC
-   *      condensation, with a Shortest-Path-Faster-Algorithm (SPFA, the queue-based Bellman-Ford
-   *      variant) bounded inside each cyclic SCC. Cycle detection is local to the SCC, so stacks
-   *      pay only for the cycles they actually touch and the global O(V * E) Bellman-Ford worst
-   *      case is gone.
-   * Per-stack cost becomes O(V + E + sum_{cyclic S} |S| * |E_S|), where V/E are CFG node/edge
-   * counts; the overall cost is O(V + E + R * (V + E + sum_{cyclic S} |S| * |E_S|)) with R the
-   * number of distinct row-pair representatives.
+   *   1. Per-stack per-node pre-aggregates (`max_increased_size`, `increased_size`) are stored in dense
+   *      `vector<vector<int>>` indexed by a contiguous int stack id, instead of an
+   *      `unordered_map<AdStackAllocaStmt*, vector<int>>` -- this removes hash traffic from the hot inner loop.
+   *   2. Stacks whose `(increased_size, max_increased_size)` row pair is bit-identical share a single dynamic
+   *      programming run -- typical kernels generate one alloca per autodiff variable in the same loop body, so
+   *      most rows collapse to a few representatives.
+   *   3. The CFG is condensed via Tarjan into strongly connected components (SCCs). DFS finish times recorded
+   *      during the same Tarjan pass split each cyclic SCC's intra-edges into a forward set (target finishes
+   *      before source) and a back set (target finishes at or after source). Per representative we run a
+   *      single-pass dynamic-programming (DP) sweep over the forward edges in descending finish-time order, then
+   *      check the back edges once for positive-cycle relaxation. Correctness: any walk inside an SCC decomposes
+   *      into a forward path plus zero or more cycles, and an SCC with no positive cycle has the same max-walk-sum
+   *      as the back-edge-removed DAG; a positive cycle is exactly the case where some back-edge would still relax
+   *      after the forward DP. This drops the per-cyclic-SCC cost from O(|S| * |E_S|) to O(|S| + |E_S|).
+   *   4. Two sign-based fast paths short-circuit the DP for trivial cyclic SCCs: an SCC with `min_is >= 0 && max_is
+   *      > 0` for this stack must contain a positive cycle (every node lies on some cycle, and a cycle through a
+   *      strictly-positive node with all non-negative `is` along it sums positive); an SCC with `min_is == 0 ==
+   *      max_is` has no `is` contribution at all and is handled by spreading the max entry-side
+   *      `max_size_at_node_begin` to every node in O(|S|).
+   * Per-rep cost becomes O(V + E + sum_{cyclic S} |S| * |E_S|) (with the SCC sum dropping to O(|S| + |E_S|) for
+   * the common autodiff push/pop pattern); overall cost is O(V + E + R * (V + E)) with R the number of distinct
+   * row-pair representatives.
    */
   const int num_nodes = size();
 
   // Map AdStackAllocaStmt* to a contiguous int index. Only stacks whose `max_size` is still 0 (i.e. unresolved by an
-  // earlier pass) participate in Bellman-Ford; resolved stacks are skipped so the pass cannot clobber them.
+  // earlier pass) participate in the DP; resolved stacks are skipped so the pass cannot clobber them.
   std::unordered_map<AdStackAllocaStmt *, int> stack_id;
   std::vector<AdStackAllocaStmt *> stacks;
 
@@ -1321,8 +1325,8 @@ void ControlFlowGraph::determine_ad_stack_size() {
   std::vector<std::vector<int>> increased_size(num_stacks, std::vector<int>(num_nodes, 0));
 
   // Track which stacks actually participate in any push/pop in the CFG. Stacks with no push/pop end with
-  // `max_size = 0` regardless of Bellman-Ford (every node has zero increase), so we skip Bellman-Ford for them and
-  // reproduce the original "Unused autodiff stack" warning here.
+  // `max_size = 0` regardless of the DP (every node has zero increase), so we skip the DP for them and reproduce
+  // the original "Unused autodiff stack" warning here.
   std::vector<bool> stack_active(num_stacks, false);
 
   for (int i = 0; i < num_nodes; i++) {
@@ -1366,14 +1370,17 @@ void ControlFlowGraph::determine_ad_stack_size() {
   }
 
   // Tarjan strongly-connected-component (SCC) decomposition of the CFG, computed once and shared across all per-stack
-  // Bellman-Ford runs. Output:
+  // dynamic-programming runs. Output:
   //   scc_id[n]    : SCC index of each node (lower index = topologically deeper / sink-side, so sources are at index
   //                  num_sccs - 1, matching Tarjan's natural emission order which is reverse topological order).
   //   scc_nodes[s] : list of node ids in SCC s.
-  // We then split each node's outgoing edges into intra-SCC and inter-SCC sets so the per-stack dynamic-programming
-  // sweep iterates each set without filtering inside the hot loop. Cyclic SCCs (|S| > 1 or |S| == 1 with self-loop)
-  // are flagged so cycle detection runs only on those, and only at SCC scope.
+  //   dfs_finish[n]: DFS post-order index, used below to split each cyclic SCC's intra-edges into a forward and a
+  //                  back set without a separate edge classification pass.
+  // We then split each node's outgoing edges into intra-SCC and inter-SCC sets so the per-stack DP iterates each
+  // set without filtering inside the hot loop. Cyclic SCCs (|S| > 1 or |S| == 1 with self-loop) are flagged so
+  // cycle detection runs only on those, and only at SCC scope.
   std::vector<int> scc_id(num_nodes, -1);
+  std::vector<int> dfs_finish(num_nodes, -1);  // DFS post-order index per node; ancestors finish AFTER descendants.
   std::vector<std::vector<int>> scc_nodes;
   {
     std::vector<int> tarjan_index(num_nodes, -1);
@@ -1384,6 +1391,7 @@ void ControlFlowGraph::determine_ad_stack_size() {
     std::vector<std::pair<int, std::size_t>> dfs_stack;
     dfs_stack.reserve(num_nodes);
     int next_index = 0;
+    int next_finish = 0;
     int next_scc = 0;
     for (int origin = 0; origin < num_nodes; origin++) {
       if (tarjan_index[origin] != -1) {
@@ -1429,6 +1437,7 @@ void ControlFlowGraph::determine_ad_stack_size() {
             scc_nodes.push_back(std::move(component));
             next_scc++;
           }
+          dfs_finish[u] = next_finish++;
           dfs_stack.pop_back();
           if (!dfs_stack.empty()) {
             const int parent = dfs_stack.back().first;
@@ -1442,13 +1451,22 @@ void ControlFlowGraph::determine_ad_stack_size() {
   }
   const int num_sccs = static_cast<int>(scc_nodes.size());
 
-  std::vector<std::vector<int>> next_ids_intra(num_nodes);
+  // Each intra-SCC edge is either a "forward" edge in the DFS spanning sense (source finishes after target, so source
+  // can be processed before target with a single topological pass) or a "back" edge (source finishes before target,
+  // closing a cycle). The forward set carries the per-stack DAG dynamic programming; back-edges only need a single
+  // post-DP relaxation check to detect positive cycles. Inter-SCC edges always relax forward in topological order.
+  std::vector<std::vector<int>> next_ids_intra_fwd(num_nodes);
+  std::vector<std::vector<int>> next_ids_intra_back(num_nodes);
   std::vector<std::vector<int>> next_ids_inter(num_nodes);
   for (int u = 0; u < num_nodes; u++) {
     const int su = scc_id[u];
     for (int v : next_ids[u]) {
       if (scc_id[v] == su) {
-        next_ids_intra[u].push_back(v);
+        if (dfs_finish[v] < dfs_finish[u]) {
+          next_ids_intra_fwd[u].push_back(v);
+        } else {
+          next_ids_intra_back[u].push_back(v);
+        }
       } else {
         next_ids_inter[u].push_back(v);
       }
@@ -1456,28 +1474,38 @@ void ControlFlowGraph::determine_ad_stack_size() {
   }
 
   // An SCC is cyclic iff it contains a cycle. By definition that is |S| > 1 (any two nodes lie on a cycle since the
-  // SCC is strongly connected) or |S| == 1 with a self-loop edge.
+  // SCC is strongly connected) or |S| == 1 with a self-loop edge. For cyclic SCCs we also precompute a topological
+  // ordering of the SCC's nodes (descending DFS finish time) so the per-stack DAG DP visits each node once with all
+  // forward predecessors already finalized.
   std::vector<char> scc_is_cyclic(num_sccs, 0);
+  std::vector<std::vector<int>> scc_topo(num_sccs);
   for (int s = 0; s < num_sccs; s++) {
-    if (scc_nodes[s].size() > 1) {
+    auto &nodes_in_s = scc_nodes[s];
+    if (nodes_in_s.size() > 1) {
       scc_is_cyclic[s] = 1;
     } else {
-      const int n = scc_nodes[s][0];
-      for (int v : next_ids_intra[n]) {
+      const int n = nodes_in_s[0];
+      // A singleton SCC is cyclic iff it has a self-loop. Self-loops are classified as back-edges above
+      // (dfs_finish[v] == dfs_finish[u]), so check there.
+      for (int v : next_ids_intra_back[n]) {
         if (v == n) {
           scc_is_cyclic[s] = 1;
           break;
         }
       }
     }
+    if (scc_is_cyclic[s]) {
+      auto topo = nodes_in_s;
+      std::sort(topo.begin(), topo.end(), [&](int a, int b) { return dfs_finish[a] > dfs_finish[b]; });
+      scc_topo[s] = std::move(topo);
+    }
   }
 
-  // Group AD-stacks whose per-node (increased_size, max_increased_size) rows are bit-identical, so that Bellman-Ford
-  // runs once per equivalence class instead of once per stack. In practice many AD-stacks in the same kernel share
-  // their push/pop schedule (one alloca per autodiff variable in the same loop body), and Bellman-Ford on a large
-  // CFG dwarfs the dedup cost. We hash a sparse fingerprint (only nodes where the stack actually has push/pop
-  // activity) and group by it. Worst case (no duplicates): one Bellman-Ford run per stack, equivalent to running it
-  // directly per stack.
+  // Group AD-stacks whose per-node (increased_size, max_increased_size) rows are bit-identical, so that the DP runs
+  // once per equivalence class instead of once per stack. In practice many AD-stacks in the same kernel share their
+  // push/pop schedule (one alloca per autodiff variable in the same loop body), and the DP on a large CFG dwarfs
+  // the dedup cost. We hash a sparse fingerprint (only nodes where the stack actually has push/pop activity) and
+  // group by it. Worst case (no duplicates): one DP run per stack, equivalent to running it directly per stack.
   using Fingerprint = std::vector<std::tuple<int, int, int>>;  // (node_id, is, mis), sorted by node_id
   struct FingerprintHash {
     std::size_t operator()(const Fingerprint &f) const noexcept {
@@ -1516,35 +1544,25 @@ void ControlFlowGraph::determine_ad_stack_size() {
     }
   }
 
-  // Scratch buffers reused across representatives to avoid reallocating per iteration.
+  // Scratch buffer reused across representatives to avoid reallocating per iteration.
   std::vector<int> max_size_at_node_begin(num_nodes);
-  std::vector<char> in_queue(num_nodes);
-  std::vector<int> times_pushed_in_queue(num_nodes);
-  std::queue<int> to_visit;
 
   // Per-representative results, broadcast below to every stack that hashed to this representative.
-  struct BFResult {
+  struct DPResult {
     int max_size;
     bool has_positive_loop;
   };
-  std::unordered_map<int, BFResult> rep_results;
+  std::unordered_map<int, DPResult> rep_results;
   rep_results.reserve(rep_stack_ids.size());
 
   // For each representative stack, walk the SCC condensation in topological order (sources first, since Tarjan emits
-  // SCCs in reverse-topological order so source SCCs end up at the largest indices). Each non-cyclic SCC is processed
-  // in O(1) per node; each cyclic SCC runs a small Shortest-Path-Faster-Algorithm sweep bounded to |S| + 1 queue
-  // pushes per node, with positive-cycle detection scoped to the SCC. Inter-SCC edges only relax forward
-  // (predecessors are already finalized when an SCC is entered), so each is touched O(1) times per stack. Total
-  // per-stack cost is therefore O(V + E + sum_{cyclic S} |S| * |E_S|), independent of the global V * E worst case
-  // that would dominate a Bellman-Ford pass running on the whole CFG.
+  // SCCs in reverse-topological order so source SCCs end up at the largest indices). Inter-SCC edges only relax
+  // forward (predecessors are already finalized when an SCC is entered), so each is touched O(1) times per stack.
   for (int rep_sid : rep_stack_ids) {
     const std::vector<int> &mis_for_stack = max_increased_size[rep_sid];
     const std::vector<int> &is_for_stack = increased_size[rep_sid];
 
     std::fill(max_size_at_node_begin.begin(), max_size_at_node_begin.end(), -1);
-    std::fill(in_queue.begin(), in_queue.end(), 0);
-    std::fill(times_pushed_in_queue.begin(), times_pushed_in_queue.end(), 0);
-    std::queue<int>().swap(to_visit);
 
     int max_size = 0;
     max_size_at_node_begin[start_node] = 0;
@@ -1555,51 +1573,82 @@ void ControlFlowGraph::determine_ad_stack_size() {
       const auto &nodes_in_s = scc_nodes[s];
 
       if (scc_is_cyclic[s]) {
-        // Bounded Shortest-Path-Faster-Algorithm sweep on the intra-SCC subgraph. All entry nodes (those already
-        // relaxed by earlier SCCs) seed the queue; relaxation only follows intra-SCC edges. The SCC's size bounds
-        // the number of legal pushes per node -- a node entering the queue more than |S| + 1 times means a positive
-        // cycle exists for this stack within the SCC, which is the per-stack failure signal. The cycle detection is
-        // local to the SCC, so positive cycles in unrelated SCCs do not contaminate this one.
-        const int s_size = static_cast<int>(nodes_in_s.size());
+        // Sign-based fast paths sidestep the cyclic-SCC dynamic programming when the stack's `is` contribution
+        // inside this SCC is structurally trivial. Two cases short-circuit:
+        //   1. min_is >= 0 with max_is > 0: every node in the SCC lies on some cycle (SCC property), and a cycle
+        //      through a strictly-positive node with all non-negative `is` along it sums to a positive value, so a
+        //      positive cycle exists for this stack. This is the autodiff push-only-in-SCC pattern.
+        //   2. min_is == 0 == max_is (no `is` contribution in this SCC at all): the DP would only spread the maximum
+        //      entry-side `max_size_at_node_begin` value to every node in S; we do that directly in O(|S|).
+        int min_is = INT_MAX;
+        int max_is = INT_MIN;
         for (int u : nodes_in_s) {
-          in_queue[u] = 0;
-          times_pushed_in_queue[u] = 0;
-        }
-        for (int u : nodes_in_s) {
-          if (max_size_at_node_begin[u] >= 0) {
-            to_visit.push(u);
-            in_queue[u] = 1;
-            times_pushed_in_queue[u]++;
+          const int v = is_for_stack[u];
+          if (v < min_is) {
+            min_is = v;
+          }
+          if (v > max_is) {
+            max_is = v;
           }
         }
-        while (!to_visit.empty()) {
-          int u = to_visit.front();
-          to_visit.pop();
-          in_queue[u] = 0;
-          const int exit_val = max_size_at_node_begin[u] + is_for_stack[u];
-          for (int v : next_ids_intra[u]) {
-            if (exit_val > max_size_at_node_begin[v]) {
-              max_size_at_node_begin[v] = exit_val;
-              if (!in_queue[v]) {
-                if (times_pushed_in_queue[v] <= s_size) {
-                  to_visit.push(v);
-                  in_queue[v] = 1;
-                  times_pushed_in_queue[v]++;
-                } else {
-                  has_positive_loop = true;
-                  break;
-                }
+        if (min_is >= 0 && max_is > 0) {
+          has_positive_loop = true;
+          break;
+        }
+        if (min_is == 0 && max_is == 0) {
+          int max_begin = -1;
+          for (int u : nodes_in_s) {
+            if (max_size_at_node_begin[u] > max_begin) {
+              max_begin = max_size_at_node_begin[u];
+            }
+          }
+          if (max_begin >= 0) {
+            for (int u : nodes_in_s) {
+              if (max_size_at_node_begin[u] < max_begin) {
+                max_size_at_node_begin[u] = max_begin;
               }
+            }
+          }
+        } else {
+          // Mixed-sign case: single-pass dynamic programming on the SCC's forward edges (processed in descending DFS
+          // finish-time so every forward predecessor is finalized before its successor relaxes), followed by one
+          // relaxation check on the back-edges. Correctness: every walk inside the SCC decomposes into a forward
+          // path (along non-back edges) plus zero or more closed cycles formed by a back-edge plus a forward path.
+          // For SCCs with no positive cycle, traversing a cycle adds a non-positive amount to the running size and
+          // so cannot improve max_size beyond what the forward DP already computed. The back-edge relaxation check
+          // after the DP detects the only failure mode (some back-edge would still improve a forward predecessor's
+          // value, which can only happen if a positive cycle exists for this stack).
+          for (int u : scc_topo[s]) {
+            const int begin = max_size_at_node_begin[u];
+            if (begin < 0) {
+              continue;
+            }
+            const int exit_val = begin + is_for_stack[u];
+            for (int v : next_ids_intra_fwd[u]) {
+              if (exit_val > max_size_at_node_begin[v]) {
+                max_size_at_node_begin[v] = exit_val;
+              }
+            }
+          }
+          for (int u : nodes_in_s) {
+            const int begin = max_size_at_node_begin[u];
+            if (begin < 0) {
+              continue;
+            }
+            const int exit_val = begin + is_for_stack[u];
+            for (int v : next_ids_intra_back[u]) {
+              if (exit_val > max_size_at_node_begin[v]) {
+                has_positive_loop = true;
+                break;
+              }
+            }
+            if (has_positive_loop) {
+              break;
             }
           }
           if (has_positive_loop) {
             break;
           }
-        }
-        if (has_positive_loop) {
-          // Drain any residual queue entries so the next iteration starts clean.
-          std::queue<int>().swap(to_visit);
-          break;
         }
       }
 
@@ -1630,17 +1679,17 @@ void ControlFlowGraph::determine_ad_stack_size() {
   for (int sid = 0; sid < num_stacks; sid++) {
     AdStackAllocaStmt *stack = stacks[sid];
     if (!stack_active[sid]) {
-      // No push/pop in the CFG: Bellman-Ford would visit reachable nodes with all-zero edge weights and settle with
+      // No push/pop in the CFG: the DP would visit reachable nodes with all-zero edge weights and settle with
       // `max_size = 0`, no positive loop. Reproduce that result directly.
       QD_WARN("Unused autodiff stack {} should have been eliminated.", stack->name());
       continue;
     }
-    const BFResult &res = rep_results[stack_to_rep[sid]];
+    const DPResult &res = rep_results[stack_to_rep[sid]];
     if (res.has_positive_loop) {
       // Leave `max_size = 0` so the structural bounded-loop pre-pass in `irpass::determine_ad_stack_size` gets a
-      // chance to derive a symbolic bound (a statically-bounded inner loop whose push-only body defeats Bellman-
-      // Ford, resolved from the outer ranges). If it also cannot, the caller emits a hard compile error - there is
-      // no compile-time `default_ad_stack_size` fallback.
+      // chance to derive a symbolic bound (a statically-bounded inner loop whose push-only body defeats the
+      // longest-path computation, resolved from the outer ranges). If it also cannot, the caller emits a hard
+      // compile error - there is no compile-time `default_ad_stack_size` fallback.
     } else {
       // Since we use |max_size| == 0 for adaptive sizes, we do not want stacks with maximum capacity indeed equal
       // to 0.

--- a/quadrants/ir/control_flow_graph.cpp
+++ b/quadrants/ir/control_flow_graph.cpp
@@ -1264,20 +1264,22 @@ void ControlFlowGraph::determine_ad_stack_size() {
    * pre-pass for a symbolic `SizeExpr`, and hard-errors if the grammar cannot resolve them. There
    * is no compile-time size fallback. The time complexity is
    * O(num_statements + num_stacks * num_edges * num_nodes).
+   *
+   * Implementation notes: the per-stack data is keyed by a contiguous stack id and stored in
+   * vector<vector<int>> rather than unordered_map<AdStackAllocaStmt*, vector<int>>, the BF visit
+   * loop hoists the per-stack vectors as local references, and outgoing edge node ids are
+   * precomputed once per source node. These keep the dominant inner loop free of hash lookups,
+   * which large reverse-mode kernels are sensitive to.
    */
   const int num_nodes = size();
 
-  // max_increased_size[i][j] is the maximum number of (pushes - pops) of
-  // stack |i| among all prefixes of the CFGNode |j|.
-  std::unordered_map<AdStackAllocaStmt *, std::vector<int>> max_increased_size;
-
-  // increased_size[i][j] is the number of (pushes - pops) of stack |i| in
-  // the CFGNode |j|.
-  std::unordered_map<AdStackAllocaStmt *, std::vector<int>> increased_size;
+  // Map AdStackAllocaStmt* to a contiguous int index. Only stacks whose `max_size` is still 0
+  // (i.e. unresolved by an earlier pass) participate in BF; resolved stacks are skipped so the
+  // pass cannot clobber them.
+  std::unordered_map<AdStackAllocaStmt *, int> stack_id;
+  std::vector<AdStackAllocaStmt *> stacks;
 
   std::unordered_map<CFGNode *, int> node_ids;
-  std::unordered_set<AdStackAllocaStmt *> all_stacks;
-
   for (int i = 0; i < num_nodes; i++)
     node_ids[nodes[i].get()] = i;
 
@@ -1285,102 +1287,134 @@ void ControlFlowGraph::determine_ad_stack_size() {
     for (int j = nodes[i]->begin_location; j < nodes[i]->end_location; j++) {
       Stmt *stmt = nodes[i]->block->statements[j].get();
       if (auto *stack = stmt->cast<AdStackAllocaStmt>()) {
-        // Skip stacks whose size has already been resolved by an earlier pass (e.g. the structural
-        // pre-pass in `irpass::determine_ad_stack_size` that handles bounded inner loops without
-        // running Bellman-Ford). Without this guard the Bellman-Ford pass unconditionally
-        // overwrites `stack->max_size` at the bottom of its per-stack loop - with 0 when the stack
-        // has no push/pop in the CFG - clobbering the upstream result.
         if (stack->max_size != 0) {
           continue;
         }
-        all_stacks.insert(stack);
-        max_increased_size.insert(std::make_pair(stack, std::vector<int>(num_nodes, 0)));
-        increased_size.insert(std::make_pair(stack, std::vector<int>(num_nodes, 0)));
+        if (stack_id.emplace(stack, static_cast<int>(stacks.size())).second) {
+          stacks.push_back(stack);
+        }
       }
     }
   }
 
-  // For each basic block we compute the increase of stack size. This is a
-  // pre-processing step for the next maximum stack size determining algorithm.
+  const int num_stacks = static_cast<int>(stacks.size());
+  if (num_stacks == 0) {
+    return;
+  }
+
+  // max_increased_size[s][j] is the maximum number of (pushes - pops) of stack |s| among all
+  // prefixes of the CFGNode |j|. increased_size[s][j] is the net (pushes - pops) of stack |s| in
+  // the CFGNode |j|. Both are indexed by contiguous stack id (cheap vector access in the BF hot
+  // loop).
+  std::vector<std::vector<int>> max_increased_size(num_stacks, std::vector<int>(num_nodes, 0));
+  std::vector<std::vector<int>> increased_size(num_stacks, std::vector<int>(num_nodes, 0));
+
+  // Track which stacks actually participate in any push/pop in the CFG. Stacks with no
+  // push/pop end with `max_size = 0` regardless of BF (every node has zero increase), so we
+  // skip BF for them and reproduce the original "Unused autodiff stack" warning here.
+  std::vector<bool> stack_active(num_stacks, false);
+
   for (int i = 0; i < num_nodes; i++) {
     for (int j = nodes[i]->begin_location; j < nodes[i]->end_location; j++) {
       Stmt *stmt = nodes[i]->block->statements[j].get();
       if (auto *stack_push = stmt->cast<AdStackPushStmt>()) {
         auto *stack = stack_push->stack->as<AdStackAllocaStmt>();
         if (stack->max_size == 0 /*adaptive*/) {
-          increased_size[stack][i]++;
-          if (increased_size[stack][i] > max_increased_size[stack][i]) {
-            max_increased_size[stack][i] = increased_size[stack][i];
+          auto it = stack_id.find(stack);
+          QD_ASSERT(it != stack_id.end());
+          const int sid = it->second;
+          stack_active[sid] = true;
+          int &cur = increased_size[sid][i];
+          cur++;
+          if (cur > max_increased_size[sid][i]) {
+            max_increased_size[sid][i] = cur;
           }
         }
       } else if (auto *stack_pop = stmt->cast<AdStackPopStmt>()) {
         auto *stack = stack_pop->stack->as<AdStackAllocaStmt>();
         if (stack->max_size == 0 /*adaptive*/) {
-          increased_size[stack][i]--;
+          auto it = stack_id.find(stack);
+          QD_ASSERT(it != stack_id.end());
+          const int sid = it->second;
+          stack_active[sid] = true;
+          increased_size[sid][i]--;
         }
       }
     }
   }
 
-  // The maximum stack size determining algorithm -- run the Bellman-Ford
-  // algorithm on each AD-stack separately.
-  for (auto *stack : all_stacks) {
-    // The maximum size of |stack| among all control flows starting at the
-    // beginning of the IR.
+  // Precompute outgoing-edge node ids once per node so the BF inner loop walks an int vector
+  // instead of hashing `node_ids[next_node]` on every traversal.
+  std::vector<std::vector<int>> next_ids(num_nodes);
+  for (int i = 0; i < num_nodes; i++) {
+    auto &dst = next_ids[i];
+    dst.reserve(nodes[i]->next.size());
+    for (auto *next_node : nodes[i]->next) {
+      dst.push_back(node_ids[next_node]);
+    }
+  }
+
+  // BF scratch reused across stacks to avoid reallocating per iteration.
+  std::vector<int> max_size_at_node_begin(num_nodes);
+  std::vector<char> in_queue(num_nodes);
+  std::vector<int> times_pushed_in_queue(num_nodes);
+  std::queue<int> to_visit;
+
+  // The maximum stack size determining algorithm -- run the Bellman-Ford algorithm on each
+  // AD-stack separately.
+  for (int sid = 0; sid < num_stacks; sid++) {
+    AdStackAllocaStmt *stack = stacks[sid];
+    if (!stack_active[sid]) {
+      // No push/pop in the CFG: BF would visit reachable nodes with all-zero edge weights and
+      // settle with `max_size = 0`, no positive loop. Reproduce the post-BF result directly.
+      QD_WARN("Unused autodiff stack {} should have been eliminated.", stack->name());
+      continue;
+    }
+
+    // Hoist references to the per-stack vectors out of the BF visit loop.
+    const std::vector<int> &mis_for_stack = max_increased_size[sid];
+    const std::vector<int> &is_for_stack = increased_size[sid];
+
+    // Reset BF scratch. `max_size_at_node_begin` starts at -1 to force the first relaxation to
+    // overwrite, matching the original behaviour.
+    std::fill(max_size_at_node_begin.begin(), max_size_at_node_begin.end(), -1);
+    std::fill(in_queue.begin(), in_queue.end(), 0);
+    std::fill(times_pushed_in_queue.begin(), times_pushed_in_queue.end(), 0);
+    std::queue<int>().swap(to_visit);
+
     int max_size = 0;
-
-    // max_size_at_node_begin[j] is the maximum size of |stack| among
-    // all control flows starting at the beginning of the IR and ending at the
-    // beginning of the CFGNode |j|. Initialize this array to -1 to make sure
-    // that the first iteration of the Bellman-Ford algorithm fully updates
-    // this array.
-    std::vector<int> max_size_at_node_begin(num_nodes, -1);
-
-    // The queue for the Bellman-Ford algorithm.
-    std::queue<int> to_visit;
-
-    // An optimization for the Bellman-Ford algorithm.
-    std::vector<bool> in_queue(num_nodes);
-
-    // An array for detecting positive loop in the Bellman-Ford algorithm.
-    std::vector<int> times_pushed_in_queue(num_nodes, 0);
-
     max_size_at_node_begin[start_node] = 0;
     to_visit.push(start_node);
-    in_queue[start_node] = true;
+    in_queue[start_node] = 1;
     times_pushed_in_queue[start_node]++;
 
     bool has_positive_loop = false;
 
-    // The Bellman-Ford algorithm.
     while (!to_visit.empty()) {
       int node_id = to_visit.front();
       to_visit.pop();
-      in_queue[node_id] = false;
-      CFGNode *now = nodes[node_id].get();
+      in_queue[node_id] = 0;
 
       // Inside this CFGNode -- update the answer |max_size|
-      const auto max_size_inside_this_node = max_increased_size[stack][node_id];
-      const auto current_max_size = max_size_at_node_begin[node_id] + max_size_inside_this_node;
+      const int begin_size = max_size_at_node_begin[node_id];
+      const int current_max_size = begin_size + mis_for_stack[node_id];
       if (current_max_size > max_size) {
         max_size = current_max_size;
       }
-      // At the end of this CFGNode -- update the state
-      // |max_size_at_node_begin| of other CFGNodes
-      const auto increase_in_this_node = increased_size[stack][node_id];
-      const auto current_size = max_size_at_node_begin[node_id] + increase_in_this_node;
-      for (auto *next_node : now->next) {
-        int next_node_id = node_ids[next_node];
+      // At the end of this CFGNode -- update the state |max_size_at_node_begin| of other
+      // CFGNodes
+      const int current_size = begin_size + is_for_stack[node_id];
+      for (int next_node_id : next_ids[node_id]) {
         if (current_size > max_size_at_node_begin[next_node_id]) {
           max_size_at_node_begin[next_node_id] = current_size;
           if (!in_queue[next_node_id]) {
             if (times_pushed_in_queue[next_node_id] <= num_nodes) {
               to_visit.push(next_node_id);
-              in_queue[next_node_id] = true;
+              in_queue[next_node_id] = 1;
               times_pushed_in_queue[next_node_id]++;
             } else {
-              // A positive loop is found because a node is going to be pushed
-              // into the queue the (num_nodes + 1)-th time.
+              // A positive loop is found because a node is going to be pushed into the queue
+              // the (num_nodes + 1)-th time.
               has_positive_loop = true;
               break;
             }
@@ -1399,8 +1433,8 @@ void ControlFlowGraph::determine_ad_stack_size() {
       // the outer ranges). If it also cannot, the caller emits a hard compile error - there is
       // no compile-time `default_ad_stack_size` fallback.
     } else {
-      // Since we use |max_size| == 0 for adaptive sizes, we do not want stacks
-      // with maximum capacity indeed equal to 0.
+      // Since we use |max_size| == 0 for adaptive sizes, we do not want stacks with maximum
+      // capacity indeed equal to 0.
       QD_WARN_IF(max_size == 0, "Unused autodiff stack {} should have been eliminated.", stack->name());
       stack->max_size = max_size;
     }

--- a/quadrants/ir/control_flow_graph.cpp
+++ b/quadrants/ir/control_flow_graph.cpp
@@ -1354,26 +1354,71 @@ void ControlFlowGraph::determine_ad_stack_size() {
     }
   }
 
-  // BF scratch reused across stacks to avoid reallocating per iteration.
+  // Group stacks whose per-node (increased_size, max_increased_size) rows are bit-identical, so
+  // that BF runs once per equivalence class instead of once per stack. In practice many AD-stacks
+  // in the same kernel share their push/pop schedule (one alloca per autodiff variable in the
+  // same loop body), and BF on a large CFG dwarfs the dedup cost. We hash a sparse fingerprint
+  // (only nodes where the stack actually has push/pop activity) and group by it. Worst case (no
+  // duplicates): one BF run per stack, equivalent to running BF directly per stack.
+  using Fingerprint = std::vector<std::tuple<int, int, int>>;  // (node_id, is, mis), sorted by node_id
+  struct FingerprintHash {
+    std::size_t operator()(const Fingerprint &f) const noexcept {
+      std::size_t h = 1469598103934665603ULL;
+      for (auto &[n, i, m] : f) {
+        auto mix = [&](std::size_t x) {
+          h ^= x;
+          h *= 1099511628211ULL;
+        };
+        mix(static_cast<std::size_t>(n));
+        mix(static_cast<std::size_t>(static_cast<unsigned>(i)));
+        mix(static_cast<std::size_t>(static_cast<unsigned>(m)));
+      }
+      return h;
+    }
+  };
+  std::unordered_map<Fingerprint, int, FingerprintHash> fp_to_rep;  // fingerprint -> representative stack id
+  std::vector<int> stack_to_rep(num_stacks, -1);
+  std::vector<int> rep_stack_ids;  // stack ids that actually run BF
+  for (int sid = 0; sid < num_stacks; sid++) {
+    if (!stack_active[sid]) {
+      continue;
+    }
+    Fingerprint fp;
+    const auto &is_row = increased_size[sid];
+    const auto &mis_row = max_increased_size[sid];
+    for (int n = 0; n < num_nodes; n++) {
+      if (is_row[n] != 0 || mis_row[n] != 0) {
+        fp.emplace_back(n, is_row[n], mis_row[n]);
+      }
+    }
+    auto [it, inserted] = fp_to_rep.emplace(std::move(fp), sid);
+    stack_to_rep[sid] = it->second;
+    if (inserted) {
+      rep_stack_ids.push_back(sid);
+    }
+  }
+
+  // BF scratch reused across representatives to avoid reallocating per iteration.
   std::vector<int> max_size_at_node_begin(num_nodes);
   std::vector<char> in_queue(num_nodes);
   std::vector<int> times_pushed_in_queue(num_nodes);
   std::queue<int> to_visit;
 
-  // The maximum stack size determining algorithm -- run the Bellman-Ford algorithm on each
-  // AD-stack separately.
-  for (int sid = 0; sid < num_stacks; sid++) {
-    AdStackAllocaStmt *stack = stacks[sid];
-    if (!stack_active[sid]) {
-      // No push/pop in the CFG: BF would visit reachable nodes with all-zero edge weights and
-      // settle with `max_size = 0`, no positive loop. Reproduce the post-BF result directly.
-      QD_WARN("Unused autodiff stack {} should have been eliminated.", stack->name());
-      continue;
-    }
+  // BF results keyed by representative stack id, broadcast below to every stack that hashed to
+  // this representative.
+  struct BFResult {
+    int max_size;
+    bool has_positive_loop;
+  };
+  std::unordered_map<int, BFResult> rep_results;
+  rep_results.reserve(rep_stack_ids.size());
 
+  // The maximum stack size determining algorithm -- run the Bellman-Ford algorithm on each
+  // distinct (increased_size, max_increased_size) row pair.
+  for (int rep_sid : rep_stack_ids) {
     // Hoist references to the per-stack vectors out of the BF visit loop.
-    const std::vector<int> &mis_for_stack = max_increased_size[sid];
-    const std::vector<int> &is_for_stack = increased_size[sid];
+    const std::vector<int> &mis_for_stack = max_increased_size[rep_sid];
+    const std::vector<int> &is_for_stack = increased_size[rep_sid];
 
     // Reset BF scratch. `max_size_at_node_begin` starts at -1 to force the first relaxation to
     // overwrite, matching the original behaviour.
@@ -1426,7 +1471,20 @@ void ControlFlowGraph::determine_ad_stack_size() {
       }
     }
 
-    if (has_positive_loop) {
+    rep_results[rep_sid] = {max_size, has_positive_loop};
+  }
+
+  // Broadcast representative BF results to every active stack.
+  for (int sid = 0; sid < num_stacks; sid++) {
+    AdStackAllocaStmt *stack = stacks[sid];
+    if (!stack_active[sid]) {
+      // No push/pop in the CFG: BF would visit reachable nodes with all-zero edge weights and
+      // settle with `max_size = 0`, no positive loop. Reproduce the post-BF result directly.
+      QD_WARN("Unused autodiff stack {} should have been eliminated.", stack->name());
+      continue;
+    }
+    const BFResult &res = rep_results[stack_to_rep[sid]];
+    if (res.has_positive_loop) {
       // Leave `max_size = 0` so the structural bounded-loop pre-pass in
       // `irpass::determine_ad_stack_size` gets a chance to derive a symbolic bound (a
       // statically-bounded inner loop whose push-only body defeats Bellman-Ford, resolved from
@@ -1435,8 +1493,8 @@ void ControlFlowGraph::determine_ad_stack_size() {
     } else {
       // Since we use |max_size| == 0 for adaptive sizes, we do not want stacks with maximum
       // capacity indeed equal to 0.
-      QD_WARN_IF(max_size == 0, "Unused autodiff stack {} should have been eliminated.", stack->name());
-      stack->max_size = max_size;
+      QD_WARN_IF(res.max_size == 0, "Unused autodiff stack {} should have been eliminated.", stack->name());
+      stack->max_size = res.max_size;
     }
   }
 }


### PR DESCRIPTION
# \`determine_ad_stack_size\`: replace whole-CFG Bellman-Ford with SCC + DAG DP

> Four commits, no behavior change. Reduces the AD-stack sizing pass from a per-stack global Bellman-Ford on the full CFG to a Tarjan SCC condensation plus per-stack DAG dynamic programming. On a large reverse-mode kernel that previously hung the compiler indefinitely (V=9531, ~9514 nodes inside cyclic SCCs, 4241 AD-stacks), the pass now returns in 163 ms total.

## TL;DR

\`ControlFlowGraph::determine_ad_stack_size()\` runs once per kernel to size every adaptive \`AdStackAllocaStmt\`. The existing pass solves a max-prefix-sum longest-path problem with Bellman-Ford SPFA, run once per AD-stack against the full CFG. On large reverse-mode kernels with thousands of AD-stacks and multi-thousand-node loop bodies, the aggregate cost is K * V * E, and the autodiff push/pop pattern (paired in the same loop SCC, balanced cycle sums) puts each per-stack SPFA in its hard \`|V|+1\`-pushes-per-node ceiling.

This PR replaces the algorithm with:

- Tarjan SCC condensation of the CFG, computed once and shared across all AD-stacks
- Deduplication of AD-stacks with bit-identical \`(increased_size, max_increased_size)\` per-node row pairs
- Per representative: topological DP across the SCC DAG; inside each cyclic SCC, a single-pass DP on DFS-finish-time-ordered forward edges plus one back-edge relaxation check for positive-cycle detection
- Sign-based fast paths for the trivial cyclic-SCC cases

Output of the pass (every AD-stack's \`max_size\`, plus the positive-cycle flag that routes unresolvable shapes into the structural \`SizeExpr\` pre-pass) is byte-identical to the prior pass on the C++ unit test matrix and on a downstream end-to-end reverse-mode test that previously hung.

## Why

Adaptive AD-stacks (\`AdStackAllocaStmt\` with \`max_size = 0\`) need their static upper bound resolved per kernel. The semantic problem is: for each AD-stack, what is the maximum running net push count along any walk from the kernel entry? The existing pass uses a queue-based Bellman-Ford SPFA with \`|V|+1\`-pushes-per-node positive-cycle detection, run once per AD-stack against the entire CFG.

On large autodiff kernels:

- K (number of AD-stacks) is in the thousands -- one alloca per autodiff variable
- V and E (CFG nodes/edges) are also in the thousands -- autodiff transforms inflate the IR several-fold
- The body of the autodiff range-for forms a single huge cyclic SCC, and stacks have *paired* push/pop in that SCC. Sum of \`is\` over the SCC = 0 (balanced cycle), so the SPFA never trips its positive-cycle short-circuit but iterates to its hard ceiling
- The aggregate cost reaches K * V * E, which on the largest kernel observed was effectively non-terminating

## Mechanism

Four sequential commits, each a strict simplification on top of the prior version.

### 1. Drop hash overhead from the per-stack hot loop

\`AdStackAllocaStmt*\`-keyed \`unordered_map<AdStackAllocaStmt*, vector<int>>\` for the per-stack \`increased_size\` and \`max_increased_size\` arrays is replaced with \`vector<vector<int>>\` indexed by a contiguous int stack id (one hash insert at stack discovery, plain vector access in the hot loop). The per-stack vector references are hoisted out of the SPFA visit loop, and outgoing-edge node ids are precomputed once per source node so the inner loop walks an int vector instead of hashing \`node_ids[next_node]\` per edge traversal. AD-stacks with no push/pop in the CFG are skipped entirely (they were running a no-op SPFA before).

### 2. Deduplicate AD-stacks with identical push/pop rows

A sparse fingerprint of \`(node_id, increased_size[node], max_increased_size[node])\` triples per AD-stack groups stacks into equivalence classes. The longest-path computation runs once per representative; \`(max_size, has_positive_loop)\` is broadcast to every member of the class. Worst case (no duplicates) reduces to running SPFA once per stack -- strictly opportunistic.

### 3. Scope per-stack work to Tarjan SCCs

Tarjan SCC condensation of the CFG once, shared across all per-stack runs. Output: \`scc_id[n]\`, \`scc_nodes[s]\`, \`dfs_finish[n]\`. Per representative: walk the SCC DAG in topological order (sources first, since Tarjan emits SCCs in reverse-topological order); each non-cyclic SCC is processed in O(1) per node; bounded SPFA runs only inside cyclic SCCs, with cycle detection scoped to the SCC. Inter-SCC edges relax forward and are touched O(1) per stack since predecessor SCCs are already finalized.

### 4. Replace cyclic-SCC SPFA with DAG DP + back-edge check (the unlock)

The previous step still ran bounded SPFA inside each cyclic SCC. On autodiff kernels this is the band: paired push/pop in the same loop SCC means signs are mixed and SPFA iterates to its \`|S|+1\`-pushes-per-node ceiling on every stack.

Fix: during Tarjan, record DFS finish time per node. Split each cyclic SCC's intra-edges into a forward set (target finishes before source) and a back set (target finishes at or after source). Per representative:

\`\`\`
for each cyclic SCC S in topological order:
    if min_is(S) >= 0 and max_is(S) > 0:
        positive cycle
        // every node lies on some cycle (SCC property), and a cycle through a strictly-positive node
        // with all non-negative is along it sums positive
    elif min_is(S) == 0 == max_is(S):
        spread max entry-side begin to every node in S in O(|S|)
    else:
        // single-pass DAG DP on forward edges
        for each u in S in descending dfs_finish order:
            for each forward edge u -> v:
                relax max_size_at_node_begin[v]
        // one relaxation check on back edges
        for each u in S, each back edge u -> v:
            if begin[u] + is[u] > begin[v]:
                positive cycle
\`\`\`

**Correctness**: any walk inside an SCC decomposes into a forward path along non-back edges plus zero or more closed cycles formed by a back-edge plus a forward path. For SCCs with no positive cycle, traversing a cycle adds a non-positive amount to the running size and so cannot improve \`max_size\` beyond what the forward DP already computed. The back-edge relaxation check after the DP detects the only failure mode (some back-edge would still improve a forward predecessor's value, which can only happen if a positive cycle exists for this stack).

Per-cyclic-SCC cost drops from O(|S| * |E_S|) to O(|S| + |E_S|).

## Per-kernel measurements

Measured on a large reverse-mode autodiff test (full simulation step plus backward pass) on CPU. Same input on both columns:

| Kernel | V | active stacks | reps | cyclic SCCs / nodes | dp ms (before) | dp ms (after) |
|---|---|---|---|---|---|---|
| \`kernel_update_cartesian_space_c289_0\` | 567 | 456 | 226 | 1 / 564 | 178 | 0.5 |
| \`kernel_step_2_c501_0\` | 231 | 93 | 82 | 3 / 226 | 2.1 | 0.1 |
| \`kernel_compute_qacc_c303_0\` | 1520 | 584 | 584 | 2 / 1516 | 2700 | 4.2 |
| \`kernel_forward_dynamics_without_qacc_c305_0\` | 9531 | 4241 | 3959 | 15 / 9514 | (never finished) | 113 |

End-to-end test: previously hung indefinitely on the last kernel; now passes in 152 s (full simulation step plus backward pass plus correctness assertions).

## Tests

- \`tests/cpp/transforms/determine_ad_stack_size_test.cpp\`: 8 existing scenarios pass unchanged (Basic, Loop, LoopPushOnlyBoundByTripCount, EmptyNodes, plus a 4-way \`If\` parametrization). These exercise the algorithm's full input shape: push-only loops, push-then-pop-paired bodies, branches, unreachable-from-entry sub-CFGs.
- \`tests/python/test_ad_basics.py\`: 147 tests pass unchanged.
- A downstream end-to-end reverse-mode rigid-body simulation test that previously hung now passes.

The cpp tests cover all the algorithm shapes that were formerly handled by the bounded SPFA, so the DAG-DP-plus-back-edge-check version is exercised for all of them. No new tests are necessary; the existing matrix already pins down the algorithm's input/output behavior.

## Side-effect audit

| Concern | Where checked | Verdict |
|---|---|---|
| Output for stacks with no positive cycle | DAG DP on forward edges processed in descending DFS finish-time order | Exact max-walk-sum on the back-edge-removed DAG, equals SCC's max-walk-sum when no positive cycle exists |
| Output for stacks with positive cycle | back-edge relaxation check after forward DP | Same \`has_positive_loop\` flag as before; routed to the structural \`SizeExpr\` pre-pass identically |
| Self-loops (singleton-SCC cyclic case) | classified as back-edges via \`dfs_finish[u] == dfs_finish[v]\`; the singleton SCC's cyclic flag walks \`next_ids_intra_back\` | Self-loop with positive \`is\` correctly flags positive cycle via the back-edge relaxation step |
| Inter-SCC propagation order | \`next_ids_inter[u]\` is the dedicated set; relaxed only after the SCC has converged | Predecessor-SCC values are finalized when an SCC is entered -- single-pass topological order on the SCC DAG matches Tarjan's emission order |
| Per-kernel determinism | fingerprint over \`(node_id, is, mis)\` triples; node ids are deterministic per CFG | Same input -> same representative -> same output |
| Public API | \`ControlFlowGraph::determine_ad_stack_size()\` signature unchanged; behavior contract unchanged (positive cycle -> \`max_size = 0\`; no compile-time fallback) | Caller in \`irpass::determine_ad_stack_size\` (\`quadrants/transforms/determine_ad_stack_size.cpp\`) is unmodified |
| Downstream IR passes / clients | \`AdStackAllocaStmt::max_size\` is the only output; no new fields | All consumers that read \`max_size\` continue to see identical values |
