### PR TITLE
[Lang] whole_kernel_cse: 2.5x compile time speedup on large kernels

### DIFF
--- a/quadrants/transforms/whole_kernel_cse.cpp
+++ b/quadrants/transforms/whole_kernel_cse.cpp
@@ -37,8 +37,26 @@ class MarkUndone : public BasicStmtVisitor {
   }
 
   static void run(std::unordered_set<int> *visited, Stmt *modified_operand) {
+    // Walk the same scope as `replace_all_usages_with(nullptr, modified_operand, ...)` does -- the eliminated
+    // statement's parent block (and its descendant subtrees) plus the top-level statements of every ancestor block.
+    // The previous version walked the entire `get_ir_root()`, which on large autodiff kernels gave an O(N) sweep
+    // per elimination and produced an O(N^2) outer pass when many statements were CSE-eliminated. SSA dominance
+    // guarantees every user of `modified_operand` lives in this scope, so we cannot miss a stale `visited_` entry.
     MarkUndone marker(visited, modified_operand);
-    modified_operand->get_ir_root()->accept(&marker);
+    if (modified_operand->parent == nullptr) {
+      modified_operand->get_ir_root()->accept(&marker);
+      return;
+    }
+    modified_operand->parent->accept(&marker);
+    auto current_block = modified_operand->parent->parent_block();
+    while (current_block != nullptr) {
+      for (auto &stmt : current_block->statements) {
+        if (stmt->has_operand(modified_operand)) {
+          visited->erase(stmt->instance_id);
+        }
+      }
+      current_block = current_block->parent_block();
+    }
   }
 };
 
@@ -46,8 +64,13 @@ class MarkUndone : public BasicStmtVisitor {
 class WholeKernelCSE : public BasicStmtVisitor {
  private:
   std::unordered_set<int> visited_;
-  // each scope corresponds to an unordered_set
-  std::vector<std::unordered_map<std::size_t, std::unordered_set<Stmt *> > > visible_stmts_;
+  // Single hash-bucketed visibility table covering every active scope, keyed by `operand_hash`. Each `visit(Block*)`
+  // pushes a fresh entry on `scope_inserts_` recording what it added so the corresponding entries can be removed
+  // from `visible_stmts_` on scope exit. Equivalent in semantics to the prior per-scope `unordered_map` stack but
+  // collapses the per-stmt visibility lookup from O(nesting depth) to O(1) hash + O(bucket size) bucket walk -- the
+  // scope-chain walk was the bottleneck on deeply-nested autodiff IR.
+  std::unordered_map<std::size_t, std::vector<Stmt *>> visible_stmts_;
+  std::vector<std::vector<std::pair<std::size_t, Stmt *>>> scope_inserts_;
   DelayedIRModifier modifier_;
 
  public:
@@ -68,7 +91,9 @@ class WholeKernelCSE : public BasicStmtVisitor {
 
   static std::size_t operand_hash(const Stmt *stmt) {
     std::size_t hash_code{0};
-    auto hash_type = std::hash<std::type_index>{}(std::type_index(typeid(stmt)));
+    // Use the dynamic type via `typeid(*stmt)` -- `typeid(stmt)` operates on the pointer expression and returns the
+    // `Stmt*` static type for every input, collapsing every statement class into the same hash component.
+    auto hash_type = std::hash<std::type_index>{}(std::type_index(typeid(*stmt)));
     if (stmt->is<GlobalPtrStmt>() || stmt->is<LoopUniqueStmt>()) {
       // special cases in common_statement_eliminable()
       return hash_type;
@@ -84,9 +109,11 @@ class WholeKernelCSE : public BasicStmtVisitor {
   }
 
   static bool common_statement_eliminable(Stmt *this_stmt, Stmt *prev_stmt) {
-    // Is this_stmt eliminable given that prev_stmt appears before it and has
-    // the same type with it?
-    if (this_stmt->type() != prev_stmt->type())
+    // Is this_stmt eliminable given that prev_stmt appears before it and has the same type with it? Use RTTI here
+    // instead of `Stmt::type()` -- the latter constructs a `StatementTypeNameVisitor`, dispatches `accept()`, and
+    // returns a freshly-allocated `std::string`, which dominated this pass on large autodiff kernels because it ran
+    // for every (this_stmt, prev_stmt) pair that shared a hash bucket.
+    if (typeid(*this_stmt) != typeid(*prev_stmt))
       return false;
     if (this_stmt->is<GlobalPtrStmt>()) {
       auto this_ptr = this_stmt->as<GlobalPtrStmt>();
@@ -113,6 +140,11 @@ class WholeKernelCSE : public BasicStmtVisitor {
     return irpass::analysis::same_statements(this_stmt, prev_stmt);
   }
 
+  void register_visible(std::size_t hash_value, Stmt *stmt) {
+    visible_stmts_[hash_value].push_back(stmt);
+    scope_inserts_.back().emplace_back(hash_value, stmt);
+  }
+
   void visit(Stmt *stmt) override {
     if (!stmt->common_statement_eliminable())
       return;
@@ -122,11 +154,12 @@ class WholeKernelCSE : public BasicStmtVisitor {
     // Generic visitor for all CSE-able statements.
     std::size_t hash_value = operand_hash(stmt);
     if (is_done(stmt)) {
-      visible_stmts_.back()[hash_value].insert(stmt);
+      register_visible(hash_value, stmt);
       return;
     }
-    for (auto &scope : visible_stmts_) {
-      for (auto &prev_stmt : scope[hash_value]) {
+    auto it = visible_stmts_.find(hash_value);
+    if (it != visible_stmts_.end()) {
+      for (auto *prev_stmt : it->second) {
         if (common_statement_eliminable(stmt, prev_stmt)) {
           MarkUndone::run(&visited_, stmt);
           stmt->replace_usages_with(prev_stmt);
@@ -135,16 +168,32 @@ class WholeKernelCSE : public BasicStmtVisitor {
         }
       }
     }
-    visible_stmts_.back()[hash_value].insert(stmt);
+    register_visible(hash_value, stmt);
     set_done(stmt);
   }
 
   void visit(Block *stmt_list) override {
-    visible_stmts_.emplace_back();
+    scope_inserts_.emplace_back();
     for (auto &stmt : stmt_list->statements) {
       stmt->accept(this);
     }
-    visible_stmts_.pop_back();
+    // On scope exit drop every entry inserted at this depth from the global visibility table; entries from outer
+    // scopes (recorded in earlier `scope_inserts_` frames) survive so they remain visible to sibling subtrees.
+    for (auto &[hash_value, stmt] : scope_inserts_.back()) {
+      auto it = visible_stmts_.find(hash_value);
+      if (it == visible_stmts_.end()) {
+        continue;
+      }
+      auto &bucket = it->second;
+      auto pos = std::find(bucket.begin(), bucket.end(), stmt);
+      if (pos != bucket.end()) {
+        bucket.erase(pos);
+      }
+      if (bucket.empty()) {
+        visible_stmts_.erase(it);
+      }
+    }
+    scope_inserts_.pop_back();
   }
 
   void visit(IfStmt *if_stmt) override {

--- a/quadrants/transforms/whole_kernel_cse.cpp
+++ b/quadrants/transforms/whole_kernel_cse.cpp
@@ -9,50 +9,55 @@
 
 namespace quadrants::lang {
 
-// A helper class to maintain WholeKernelCSE::visited
-class MarkUndone : public BasicStmtVisitor {
+// Walks the same scope as `replace_all_usages_with(nullptr, old_stmt, ...)` - `old_stmt`'s parent block subtree
+// plus the top-level statements of every ancestor block, which SSA dominance guarantees contains every user of
+// `old_stmt`. Per visited statement: if it has `old_stmt` as an operand, erase it from `visited_` (so the next
+// outer iteration of the CSE fixpoint loop re-evaluates it under the new operand pointer) and replace the operand
+// with `new_stmt`. Combining the previous separate `MarkUndone::run` and `replace_all_usages_with` walks halves the
+// IR-walking cost per CSE elimination.
+class ReplaceAndMarkUndone : public BasicStmtVisitor {
  private:
   std::unordered_set<int> *const visited_;
-  Stmt *const modified_operand_;
+  Stmt *const old_stmt_;
+  Stmt *const new_stmt_;
+
+  void mark_and_replace(Stmt *stmt) {
+    if (stmt->has_operand(old_stmt_)) {
+      visited_->erase(stmt->instance_id);
+      stmt->replace_operand_with(old_stmt_, new_stmt_);
+    }
+  }
 
  public:
   using BasicStmtVisitor::visit;
 
-  MarkUndone(std::unordered_set<int> *visited, Stmt *modified_operand)
-      : visited_(visited), modified_operand_(modified_operand) {
+  ReplaceAndMarkUndone(std::unordered_set<int> *visited, Stmt *old_stmt, Stmt *new_stmt)
+      : visited_(visited), old_stmt_(old_stmt), new_stmt_(new_stmt) {
     allow_undefined_visitor = true;
     invoke_default_visitor = true;
   }
 
   void visit(Stmt *stmt) override {
-    if (stmt->has_operand(modified_operand_)) {
-      visited_->erase(stmt->instance_id);
-    }
+    mark_and_replace(stmt);
   }
 
   void preprocess_container_stmt(Stmt *stmt) override {
-    if (stmt->has_operand(modified_operand_)) {
-      visited_->erase(stmt->instance_id);
-    }
+    mark_and_replace(stmt);
   }
 
-  static void run(std::unordered_set<int> *visited, Stmt *modified_operand) {
-    // Walk the same scope as `replace_all_usages_with(nullptr, modified_operand, ...)` does -- the eliminated
-    // statement's parent block (and its descendant subtrees) plus the top-level statements of every ancestor block.
-    // The previous version walked the entire `get_ir_root()`, which on large autodiff kernels gave an O(N) sweep
-    // per elimination and produced an O(N^2) outer pass when many statements were CSE-eliminated. SSA dominance
-    // guarantees every user of `modified_operand` lives in this scope, so we cannot miss a stale `visited_` entry.
-    MarkUndone marker(visited, modified_operand);
-    if (modified_operand->parent == nullptr) {
-      modified_operand->get_ir_root()->accept(&marker);
+  static void run(std::unordered_set<int> *visited, Stmt *old_stmt, Stmt *new_stmt) {
+    ReplaceAndMarkUndone walker(visited, old_stmt, new_stmt);
+    if (old_stmt->parent == nullptr) {
+      old_stmt->get_ir_root()->accept(&walker);
       return;
     }
-    modified_operand->parent->accept(&marker);
-    auto current_block = modified_operand->parent->parent_block();
+    old_stmt->parent->accept(&walker);
+    auto current_block = old_stmt->parent->parent_block();
     while (current_block != nullptr) {
       for (auto &stmt : current_block->statements) {
-        if (stmt->has_operand(modified_operand)) {
+        if (stmt->has_operand(old_stmt)) {
           visited->erase(stmt->instance_id);
+          stmt->replace_operand_with(old_stmt, new_stmt);
         }
       }
       current_block = current_block->parent_block();
@@ -67,7 +72,7 @@ class WholeKernelCSE : public BasicStmtVisitor {
   // Single hash-bucketed visibility table covering every active scope, keyed by `operand_hash`. Each `visit(Block*)`
   // pushes a fresh entry on `scope_inserts_` recording what it added so the corresponding entries can be removed
   // from `visible_stmts_` on scope exit. Equivalent in semantics to the prior per-scope `unordered_map` stack but
-  // collapses the per-stmt visibility lookup from O(nesting depth) to O(1) hash + O(bucket size) bucket walk -- the
+  // collapses the per-stmt visibility lookup from O(nesting depth) to O(1) hash + O(bucket size) bucket walk - the
   // scope-chain walk was the bottleneck on deeply-nested autodiff IR.
   std::unordered_map<std::size_t, std::vector<Stmt *>> visible_stmts_;
   std::vector<std::vector<std::pair<std::size_t, Stmt *>>> scope_inserts_;
@@ -91,7 +96,7 @@ class WholeKernelCSE : public BasicStmtVisitor {
 
   static std::size_t operand_hash(const Stmt *stmt) {
     std::size_t hash_code{0};
-    // Use the dynamic type via `typeid(*stmt)` -- `typeid(stmt)` operates on the pointer expression and returns the
+    // Use the dynamic type via `typeid(*stmt)` - `typeid(stmt)` operates on the pointer expression and returns the
     // `Stmt*` static type for every input, collapsing every statement class into the same hash component.
     auto hash_type = std::hash<std::type_index>{}(std::type_index(typeid(*stmt)));
     if (stmt->is<GlobalPtrStmt>() || stmt->is<LoopUniqueStmt>()) {
@@ -109,10 +114,14 @@ class WholeKernelCSE : public BasicStmtVisitor {
   }
 
   static bool common_statement_eliminable(Stmt *this_stmt, Stmt *prev_stmt) {
-    // Is this_stmt eliminable given that prev_stmt appears before it and has the same type with it? Use RTTI here
-    // instead of `Stmt::type()` -- the latter constructs a `StatementTypeNameVisitor`, dispatches `accept()`, and
-    // returns a freshly-allocated `std::string`, which dominated this pass on large autodiff kernels because it ran
-    // for every (this_stmt, prev_stmt) pair that shared a hash bucket.
+    // Is this_stmt eliminable given that prev_stmt appears before it and has the same type with it? `operand_hash`
+    // mixes `typeid(*stmt)` into the bucket key, so any prev_stmt reaching here almost always already matches the
+    // type and this check is effectively a no-op for correctly-bucketed candidates. It is still load-bearing
+    // because the `as<...>` casts below are unchecked static-cast convenience wrappers - if a hash collision ever
+    // lets a different-type prev_stmt through, those casts reinterpret memory and the downstream
+    // `definitely_same_address` / `same_value` calls hit UB. The previous implementation called `Stmt::type()`
+    // (which constructs a `StatementTypeNameVisitor`, dispatches `accept()`, and allocates a `std::string` per
+    // call) inside this same hot path, which dominated the pass on large autodiff kernels; RTTI here is cheap.
     if (typeid(*this_stmt) != typeid(*prev_stmt))
       return false;
     if (this_stmt->is<GlobalPtrStmt>()) {
@@ -161,8 +170,7 @@ class WholeKernelCSE : public BasicStmtVisitor {
     if (it != visible_stmts_.end()) {
       for (auto *prev_stmt : it->second) {
         if (common_statement_eliminable(stmt, prev_stmt)) {
-          MarkUndone::run(&visited_, stmt);
-          stmt->replace_usages_with(prev_stmt);
+          ReplaceAndMarkUndone::run(&visited_, stmt, prev_stmt);
           modifier_.erase(stmt);
           return;
         }


### PR DESCRIPTION
# \`whole_kernel_cse\`: scoped MarkUndone, flat hash bucket, combined walk

> Two commits, no behaviour change. Reduces the per-elimination IR-walking cost in WholeKernelCSE from O(N) full-IR sweeps to O(scope) walks (where \`scope\` is the SSA dominance frontier of the eliminated statement), replaces the per-scope hash-map stack with a flat hash table, swaps a string-allocating type comparison for an RTTI compare, and folds the MarkUndone walk into the replace-usages walk. Affects every kernel that runs through \`irpass::full_simplify\`; absolute savings are largest on large reverse-mode kernels where autodiff inflates the IR.

## TL;DR

\`irpass::whole_kernel_cse\` runs three to four times per kernel inside \`irpass::full_simplify\`, with an outer fixpoint loop until no more eliminations are possible. The pass walks the kernel IR, hashes each statement by operand pointers, and replaces a statement with a previously-seen equivalent. Profiling shows it is the dominant compile-time cost on large autodiff kernels:

- \`MarkUndone::run\` walked \`get_ir_root()\` per elimination: O(M * V) total. SSA dominance bounds the user set to the eliminated stmt's parent block subtree plus ancestor top-level stmts (the same scope \`replace_all_usages_with(nullptr, ...)\` already covers).
- The visibility table was a stack of per-scope \`unordered_map<size_t, unordered_set<Stmt*>>\` requiring an O(D) map lookup per stmt visit, where D is nesting depth.
- Each elimination ran two scope sweeps - one for MarkUndone, one for \`replace_all_usages_with\` - both checking \`has_operand\`.
- \`Stmt::type()\` (used for the type-mismatch fast path in \`common_statement_eliminable\`) constructs a \`StatementTypeNameVisitor\`, dispatches \`accept()\`, and allocates a \`std::string\` per call.

### Per-kernel measurements

Genesis Ant-scale reverse-mode test (\`tests/test_grad.py::test_differentiable_rigid[gpu]\`, macOS Metal, fresh compile cache via \`QD_OFFLINE_CACHE=0\`).

\`kernel_forward_dynamics_without_qacc_c305_0\` (V=9535, E=14331, 14 cyclic SCCs, 4241 AD-stacks):

| Stage | \`forward_dynamics\` compile |
|---|---|
| Baseline | 91 s |
| Scoped MarkUndone + flat bucket + RTTI | 48 s |
| + Combined \`ReplaceAndMarkUndone\` walker | **36 s** |

Smaller kernels in the same test (forward velocity, update_cartesian_space, step_2, compute_qacc) see proportional improvements that are absolute-time invisible because their original CSE cost was already in the few-millisecond range.

## Why

Sampling \`pytest\` during \`kernel_forward_dynamics_without_qacc\` compilation on macOS Metal showed 100% CPU in the \`WholeKernelCSE::visit(Stmt*) -> MarkUndone::run -> BasicStmtVisitor::visit(Block*) -> IfStmt -> ...\` recursion chain. The compile cost on this kernel scales with two compounding factors: many CSE candidates per pass, each triggering a full-IR sweep, and a deeply-nested \`IfStmt\` structure generated by the autodiff transform that inflates the visibility-stack lookup cost.

This pass runs on every kernel through \`full_simplify\`, so the optimisations apply equally to forward (\`AutodiffMode::NONE\` / \`FORWARD\`) and reverse compilations; reverse kernels were where the wallclock cost made the bottleneck visible because their IR is roughly two to three times the size of the forward equivalent.

## Mechanism

### 1. Scope \`MarkUndone\` to the SSA dominance frontier

\`MarkUndone::run\` previously walked \`modified_operand->get_ir_root()\`. Replaced with the same scope \`replace_all_usages_with(nullptr, ...)\` already uses: walk \`modified_operand->parent\` (its containing block's full subtree) and then iterate ancestor blocks' top-level statements. Per SSA dominance every user of \`modified_operand\` lives in this scope, so we cannot miss a stale \`visited_\` entry. Cost per elimination drops from O(V) to O(scope size); on deeply-nested kernels the eliminated stmt usually lives well below the offloaded body, so the relevant subtree is much smaller than the whole IR.

### 2. Flat hash bucket plus per-scope insertion log

The visibility table was a \`vector<unordered_map<size_t, unordered_set<Stmt*>>>\` keyed by scope (one entry per active block). On each \`visit(Stmt*)\` we walked every scope's map. Replaced with:

- one global \`unordered_map<size_t, vector<Stmt*>>\` keyed by \`operand_hash\`;
- a \`vector<vector<pair<size_t, Stmt*>>>\` recording what was inserted at each scope depth.

\`visit(Block*)\` pushes a fresh insertion log entry, recurses, then on scope exit replays the entry to remove the corresponding stmts from the global table. Sibling subtrees see only ancestor inserts, identical to the per-scope-map semantics. Per-stmt visibility lookup is now O(1) hash plus an O(bucket) bucket walk instead of O(D) hash maps.

### 3. Combine MarkUndone and replace-usages into \`ReplaceAndMarkUndone\`

The MarkUndone walk and the \`replace_all_usages_with\` walk cover the same scope (parent block subtree plus ancestor top-level) and both check \`has_operand(modified_operand)\` per visited stmt. Folded into a single \`ReplaceAndMarkUndone\` pass that does both side-effects per visit. Halves the IR-walking cost per elimination.

### 4. RTTI type compare instead of \`Stmt::type()\`

\`Stmt::type()\` constructs a \`StatementTypeNameVisitor\`, dispatches \`accept()\` (virtual), and returns a freshly-allocated \`std::string\`. Called inside \`common_statement_eliminable\` for every (this_stmt, prev_stmt) pair that shares a hash bucket - which on large kernels was thousands of comparisons per pass.

Replaced with \`typeid(*this_stmt) != typeid(*prev_stmt)\`. Same correctness contract: the unchecked \`prev_stmt->as<...>()\` casts immediately below the early-return need this guard, otherwise a hash-bucket collision would reinterpret memory in \`definitely_same_address\`. After this PR the typeid compare is almost always true at runtime because \`operand_hash\` now also routes by \`typeid(*stmt)\` (see below); the guard is kept as the load-bearing safety net.

### 5. Bonus: \`typeid(*stmt)\` in \`operand_hash\`

\`operand_hash\` previously used \`std::hash<std::type_index>{}(std::type_index(typeid(stmt)))\`. \`typeid(stmt)\` operates on the \`Stmt*\` static type for every input, collapsing every concrete statement class into the same hash component - bucket separation came only from operand pointer hashes. Switched to \`typeid(*stmt)\`, so different statement classes now land in different buckets when their operand sets happen to alias.

## Side-effect audit

| Concern | Where checked | Verdict |
|---|---|---|
| Visibility-table scope semantics | \`visit(Block*)\` pushes \`scope_inserts_\`; on exit, replay drops only this-scope entries from \`visible_stmts_\` | Sibling subtrees see only ancestor inserts; identical to the previous per-scope \`unordered_map\` stack |
| MarkUndone correctness on dominated users | New scope = \`modified_operand->parent\` subtree plus ancestor top-level stmts | SSA dominance guarantees every user of \`modified_operand\` lives in this scope; no stale \`visited_\` entry can survive |
| MarkUndone for stmts with \`parent == nullptr\` | Falls back to \`get_ir_root()\` walk | Defensive only; should not happen for IR built through normal compile paths |
| \`ReplaceAndMarkUndone\` matches \`replace_all_usages_with\` semantics | Inherits \`BasicStmtVisitor\` like the existing \`StatementUsageReplace\`; same scope traversal, same \`has_operand\` check, same call site \`replace_operand_with\` | Equivalent traversal; both side-effects fire on the same set of stmts |
| Type-mismatch guard after \`operand_hash\` typeid mix | \`typeid(*this_stmt) != typeid(*prev_stmt)\` early-return retained in \`common_statement_eliminable\` | Almost always true at runtime now (hash bucket already keyed by typeid) but load-bearing - the \`prev_stmt->as<...>()\` casts immediately below are unchecked static-cast wrappers; a hash collision without this guard would reinterpret memory |
| \`typeid(*stmt)\` on polymorphic Stmt | Stmt has virtual member functions (\`quadrants/ir/ir.h\`) | RTTI returns the dynamic type as required |
| Public API of \`irpass::whole_kernel_cse\` | Unchanged signature; same one-shot driver \`WholeKernelCSE::run(IRNode*)\`; same outer fixpoint loop | Callers unmodified |
