### PR TITLE
[AutoDiff] Speed up reverse-mode kernel launches on GPU backends

### DIFF
--- a/quadrants/rhi/amdgpu/amdgpu_driver_functions.inc.h
+++ b/quadrants/rhi/amdgpu/amdgpu_driver_functions.inc.h
@@ -32,6 +32,8 @@ PER_AMDGPU_FUNCTION(malloc_managed, hipMallocManaged, void **, std::size_t, uint
 PER_AMDGPU_FUNCTION(memset, hipMemset, void *, uint8, std::size_t);
 PER_AMDGPU_FUNCTION(mem_free, hipFree, void *);
 PER_AMDGPU_FUNCTION(mem_free_async_impl, hipFreeAsync, void *, void *);
+PER_AMDGPU_FUNCTION(mem_alloc_host, hipHostMalloc, void **, std::size_t, uint32);
+PER_AMDGPU_FUNCTION(mem_free_host, hipHostFree, void *);
 PER_AMDGPU_FUNCTION(device_get_default_mem_pool, hipDeviceGetDefaultMemPool, void **, int);
 PER_AMDGPU_FUNCTION(mem_pool_set_attribute, hipMemPoolSetAttribute, void *, uint32, void *);
 PER_AMDGPU_FUNCTION(mem_get_info, hipMemGetInfo, std::size_t *, std::size_t *);

--- a/quadrants/rhi/cuda/cuda_driver_functions.inc.h
+++ b/quadrants/rhi/cuda/cuda_driver_functions.inc.h
@@ -34,6 +34,8 @@ PER_CUDA_FUNCTION(memset, cuMemsetD8_v2, void *, uint8, std::size_t);
 PER_CUDA_FUNCTION(memsetd32, cuMemsetD32_v2, void *, uint32, std::size_t);
 PER_CUDA_FUNCTION(mem_free, cuMemFree_v2, void *);
 PER_CUDA_FUNCTION(mem_free_async_impl, cuMemFreeAsync, void *, void *);
+PER_CUDA_FUNCTION(mem_alloc_host, cuMemAllocHost_v2, void **, std::size_t);
+PER_CUDA_FUNCTION(mem_free_host, cuMemFreeHost, void *);
 PER_CUDA_FUNCTION(mem_advise, cuMemAdvise, void *, std::size_t, uint32, uint32);
 PER_CUDA_FUNCTION(mem_get_info, cuMemGetInfo_v2, std::size_t *, std::size_t *);
 PER_CUDA_FUNCTION(mem_get_attribute, cuPointerGetAttribute, void *, uint32, void *);

--- a/quadrants/runtime/gfx/adstack_sizer_launch.cpp
+++ b/quadrants/runtime/gfx/adstack_sizer_launch.cpp
@@ -36,19 +36,22 @@ namespace gfx {
 
 namespace {
 
-// True iff every SizeExpr across every adstack alloca in every task is host-resolvable, i.e. contains no
-// `ExternalTensorRead` leaf. ExternalTensorRead dereferences the ndarray data pointer at a runtime-resolved
-// linear offset, and on SPIR-V backends that data lives in GPU-private memory so the host evaluator cannot
-// touch it without a device round-trip; the rest of the SizeExpr grammar (Const, FieldLoad, ExternalTensorShape,
-// BoundVariable, Add/Sub/Mul/Max, MaxOverRange) is host-resolvable through the existing `evaluate_adstack_size_expr`
-// path. Mirrors the `compute_contains_device_leaf` predicate used by
-// `encode_adstack_size_expr_device_bytecode_for_spirv`'s pre-substitution but at task granularity.
+// True iff every SizeExpr across every adstack alloca in every task is host-resolvable WITHOUT triggering a
+// nested kernel launch. On SPIR-V backends both `ExternalTensorRead` and `FieldLoad` would require a device
+// round-trip from the host: ExternalTensorRead dereferences ndarray data that lives in GPU-private memory,
+// and FieldLoad would have to launch a `SNodeRwAccessorsBank::read_int` accessor kernel to read the SNode
+// value off-device. Either of those launched mid-publish corrupts the SPIR-V launcher's per-task metadata
+// upload state and shows up as wrong gradients on kernels that mix the two paths (this is the leaf set the
+// SPIR-V on-device sizer was specifically built to handle on-device via PSB loads). The fast path therefore
+// only fires when every SizeExpr leaf is one of `Const`, `ExternalTensorShape`, `BoundVariable`, or the
+// arithmetic / `MaxOverRange` combinators.
 bool all_size_exprs_host_resolvable(const std::vector<size_t> &adstack_task_indices,
                                     const std::vector<spirv::TaskAttributes> &task_attribs) {
   for (size_t ti : adstack_task_indices) {
     for (const auto &alloca : task_attribs[ti].ad_stack.allocas) {
       for (const auto &node : alloca.size_expr.nodes) {
-        if (static_cast<SizeExpr::Kind>(node.kind) == SizeExpr::Kind::ExternalTensorRead) {
+        auto kind = static_cast<SizeExpr::Kind>(node.kind);
+        if (kind == SizeExpr::Kind::ExternalTensorRead || kind == SizeExpr::Kind::FieldLoad) {
           return false;
         }
       }

--- a/quadrants/runtime/gfx/adstack_sizer_launch.cpp
+++ b/quadrants/runtime/gfx/adstack_sizer_launch.cpp
@@ -40,8 +40,8 @@ namespace {
 // `ExternalTensorRead` leaf. ExternalTensorRead dereferences the ndarray data pointer at a runtime-resolved
 // linear offset, and on SPIR-V backends that data lives in GPU-private memory so the host evaluator cannot
 // touch it without a device round-trip; the rest of the SizeExpr grammar (Const, FieldLoad, ExternalTensorShape,
-// BoundVariable, Add/Sub/Mul/Max, MaxOverRange) is host-resolvable through the existing
-// `evaluate_adstack_size_expr` path. Mirrors the `compute_contains_device_leaf` predicate used by
+// BoundVariable, Add/Sub/Mul/Max, MaxOverRange) is host-resolvable through the existing `evaluate_adstack_size_expr`
+// path. Mirrors the `compute_contains_device_leaf` predicate used by
 // `encode_adstack_size_expr_device_bytecode_for_spirv`'s pre-substitution but at task granularity.
 bool all_size_exprs_host_resolvable(const std::vector<size_t> &adstack_task_indices,
                                     const std::vector<spirv::TaskAttributes> &task_attribs) {

--- a/quadrants/runtime/gfx/adstack_sizer_launch.cpp
+++ b/quadrants/runtime/gfx/adstack_sizer_launch.cpp
@@ -17,12 +17,14 @@
 
 #include "quadrants/runtime/gfx/runtime.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <vector>
 
 #include "quadrants/codegen/spirv/adstack_sizer_shader.h"
 #include "quadrants/common/logging.h"
+#include "quadrants/ir/adstack_size_expr.h"
 #include "quadrants/ir/adstack_size_expr_device.h"
 #include "quadrants/program/adstack_size_expr_eval.h"
 #include "quadrants/program/launch_context_builder.h"
@@ -31,6 +33,89 @@
 
 namespace quadrants::lang {
 namespace gfx {
+
+namespace {
+
+// True iff every SizeExpr across every adstack alloca in every task is host-resolvable, i.e. contains no
+// `ExternalTensorRead` leaf. ExternalTensorRead dereferences the ndarray data pointer at a runtime-resolved
+// linear offset, and on SPIR-V backends that data lives in GPU-private memory so the host evaluator cannot
+// touch it without a device round-trip; the rest of the SizeExpr grammar (Const, FieldLoad, ExternalTensorShape,
+// BoundVariable, Add/Sub/Mul/Max, MaxOverRange) is host-resolvable through the existing
+// `evaluate_adstack_size_expr` path. Mirrors the `compute_contains_device_leaf` predicate used by
+// `encode_adstack_size_expr_device_bytecode_for_spirv`'s pre-substitution but at task granularity.
+bool all_size_exprs_host_resolvable(const std::vector<size_t> &adstack_task_indices,
+                                    const std::vector<spirv::TaskAttributes> &task_attribs) {
+  for (size_t ti : adstack_task_indices) {
+    for (const auto &alloca : task_attribs[ti].ad_stack.allocas) {
+      for (const auto &node : alloca.size_expr.nodes) {
+        if (static_cast<SizeExpr::Kind>(node.kind) == SizeExpr::Kind::ExternalTensorRead) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+// Replicates the sizer shader's per-task metadata layout on the host: for each task, write a flat
+// `[stride_float, stride_int, (offset_i, max_size_i)*]` buffer where `max_size_i` is the host-evaluated
+// SizeExpr (falling back to `max_size_compile_time` for stacks with an empty `nodes` vector), and offsets
+// run as a per-heap prefix sum (Float advances by `2 * max_size`, Int by `max_size`, matching the
+// primal+adjoint interleaved Float-heap layout the main-kernel codegen already bakes in). The shader logic
+// this mirrors lives in `quadrants/codegen/spirv/adstack_sizer_shader.cpp` (the `running_off_f` /
+// `running_off_i` accumulator and the metadata writeback at the bottom of the per-stack loop).
+//
+// Caller must have verified `all_size_exprs_host_resolvable` first; this function asserts that no
+// SizeExpr contains `ExternalTensorRead`.
+void eval_per_task_metadata_on_host(const std::vector<size_t> &adstack_task_indices,
+                                    const std::vector<spirv::TaskAttributes> &task_attribs,
+                                    Program *prog,
+                                    LaunchContextBuilder &host_ctx,
+                                    std::vector<PerTaskAdStackRuntime> &per_task_ad_stack) {
+  using HeapKind = spirv::TaskAttributes::AdStackAllocaAttribs::HeapKind;
+  for (size_t ti : adstack_task_indices) {
+    const auto &allocas = task_attribs[ti].ad_stack.allocas;
+    auto &rt = per_task_ad_stack[ti];
+    const size_t n_stacks = allocas.size();
+    rt.metadata.assign(2 + 2 * n_stacks, 0);
+    uint32_t running_off_f = 0;
+    uint32_t running_off_i = 0;
+    for (size_t i = 0; i < n_stacks; ++i) {
+      const auto &a = allocas[i];
+      uint32_t max_size;
+      if (a.size_expr.nodes.empty()) {
+        // Cache-load fallback: no symbolic tree captured, the compile-time bound is authoritative.
+        // Match the shader's `max(max_size_compile_time, 1)` lower clamp.
+        max_size = std::max<uint32_t>(a.max_size_compile_time, 1u);
+      } else {
+        int64_t evaluated = evaluate_adstack_size_expr(a.size_expr, prog, &host_ctx);
+        // `evaluate_adstack_size_expr` returns -1 only when `expr.nodes` is empty (handled above) or hits
+        // an internal hard error; clamp to the same `max(_, 1)` lower bound the shader applies.
+        if (evaluated < 1) {
+          evaluated = 1;
+        }
+        max_size = static_cast<uint32_t>(evaluated);
+      }
+      uint32_t offset;
+      if (a.heap_kind == HeapKind::Float) {
+        offset = running_off_f;
+        // Primal + adjoint interleaved.
+        running_off_f += 2u * max_size;
+      } else {
+        offset = running_off_i;
+        running_off_i += max_size;
+      }
+      rt.metadata[2 + 2 * i] = offset;
+      rt.metadata[2 + 2 * i + 1] = max_size;
+    }
+    rt.metadata[0] = running_off_f;
+    rt.metadata[1] = running_off_i;
+    rt.stride_float = running_off_f;
+    rt.stride_int = running_off_i;
+  }
+}
+
+}  // namespace
 
 std::vector<PerTaskAdStackRuntime> GfxRuntime::publish_adstack_metadata_spirv(
     LaunchContextBuilder &host_ctx,
@@ -58,6 +143,21 @@ std::vector<PerTaskAdStackRuntime> GfxRuntime::publish_adstack_metadata_spirv(
                  "GfxRuntime::launch_kernel: `ProgramImpl::program` back-reference not set; cannot "
                  "encode AdStack SizeExpr bytecode. Ensure GfxProgramImpl passes `program_impl = this` "
                  "into `GfxRuntime::Params`.");
+
+  // Fast path: when no SizeExpr in any adstack-bearing task contains an `ExternalTensorRead` leaf, every
+  // capacity bound is host-resolvable through `evaluate_adstack_size_expr`, and the entire GPU sizer pipeline
+  // (sizer-bytecode upload, per-task metadata-buffer alloc, `flush()` + `device_->wait_idle()` to force PSB
+  // visibility, sizer cmdlist record + `submit_synced`, blocking metadata readback) drops out. On Metal /
+  // MoltenVK the dropped pair of `wait_idle()` calls each cost a full GPU-host stall per launch; with one
+  // launch per substep across forward + backward of a 100-substep test, that stall cost compounds linearly
+  // with the test's launch count and was the dominant runtime regression observed when adstacks replaced
+  // `unrolling_limit` for autodiff. Kernels whose size_expr trees include `ExternalTensorRead` (an ndarray
+  // scalar load whose data lives in GPU-private memory) still need the on-device sizer below.
+  if (all_size_exprs_host_resolvable(adstack_task_indices, task_attribs)) {
+    eval_per_task_metadata_on_host(adstack_task_indices, task_attribs, program_impl_->program, host_ctx,
+                                   per_task_ad_stack);
+    return per_task_ad_stack;
+  }
   QD_ERROR_IF(!device_->get_caps().get(DeviceCapability::spirv_has_physical_storage_buffer) ||
                   !device_->get_caps().get(DeviceCapability::spirv_has_int64) ||
                   !device_->get_caps().get(DeviceCapability::spirv_has_int8) ||

--- a/quadrants/runtime/gfx/adstack_sizer_launch.cpp
+++ b/quadrants/runtime/gfx/adstack_sizer_launch.cpp
@@ -150,9 +150,9 @@ std::vector<PerTaskAdStackRuntime> GfxRuntime::publish_adstack_metadata_spirv(
   // visibility, sizer cmdlist record + `submit_synced`, blocking metadata readback) drops out. On Metal /
   // MoltenVK the dropped pair of `wait_idle()` calls each cost a full GPU-host stall per launch; with one
   // launch per substep across forward + backward of a 100-substep test, that stall cost compounds linearly
-  // with the test's launch count and was the dominant runtime regression observed when adstacks replaced
-  // `unrolling_limit` for autodiff. Kernels whose size_expr trees include `ExternalTensorRead` (an ndarray
-  // scalar load whose data lives in GPU-private memory) still need the on-device sizer below.
+  // with the test's launch count and is the dominant per-launch overhead under adstack mode. Kernels whose
+  // size_expr trees include `ExternalTensorRead` (an ndarray scalar load whose data lives in GPU-private
+  // memory) still need the on-device sizer below.
   if (all_size_exprs_host_resolvable(adstack_task_indices, task_attribs)) {
     eval_per_task_metadata_on_host(adstack_task_indices, task_attribs, program_impl_->program, host_ctx,
                                    per_task_ad_stack);

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -735,8 +735,8 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
     // the host on every one of the three writes we issue per launch; with thousands of reverse-mode launches
     // per `test_differentiable_rigid` run, those serial host stalls were a measurable fraction of wallclock.
     // `FieldLoad` is serviced by `SNodeRwAccessorsBank` regardless of arch.
-    // Guard `program_impl_->program` lookups against the C++-only-tests setup where `program_impl_` itself is
-    // null; the on-device branch below already does this and falls back to `max_size_compile_time`.
+    // Guard `program_impl_->program` lookups against the C++-only-tests setup where `program_impl_` itself is null;
+    // the on-device branch below already does this and falls back to `max_size_compile_time`.
     Program *prog = (program_impl_ != nullptr) ? program_impl_->program : nullptr;
     std::vector<uint64_t> host_max_sizes(n_stacks);
     for (std::size_t i = 0; i < n_stacks; ++i) {

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -710,10 +710,9 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
   // h2d + sizer-kernel launch + d2h-stride pipeline entirely and write the metadata directly via `copy_h2d`.
   // On CUDA the saved `cuMemcpyDtoH` for the per-launch stride readback is the dominant cost: every reverse-
   // mode kernel launch in a 100-substep test paid one such synchronous DtoH each, and that compound stall
-  // accounted for the bulk of the GPU regression seen when adstack mode replaced `unrolling_limit`. The
-  // condition is computed once per launch by scanning each stack's `nodes` vector for an `ExternalTensorRead`
-  // leaf; the scan is O(total SizeExpr nodes), well below the cost of the cheapest h2d / d2h on any LLVM GPU
-  // backend.
+  // accounted for the bulk of the GPU launch overhead under adstack mode. The condition is computed once per
+  // launch by scanning each stack's `nodes` vector for an `ExternalTensorRead` leaf; the scan is O(total
+  // SizeExpr nodes), well below the cost of the cheapest h2d / d2h on any LLVM GPU backend.
   bool all_size_exprs_host_resolvable = true;
   for (std::size_t i = 0; i < n_stacks && all_size_exprs_host_resolvable; ++i) {
     if (i >= ad_stack.size_exprs.size()) {

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -711,9 +711,9 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
   // On CUDA the saved `cuMemcpyDtoH` for the per-launch stride readback is the dominant cost: every reverse-
   // mode kernel launch in a 100-substep test paid one such synchronous DtoH each, and that compound stall
   // accounted for the bulk of the GPU regression seen when adstack mode replaced `unrolling_limit`. The
-  // condition is computed once per launch by scanning each stack's `nodes` vector for an
-  // `ExternalTensorRead` leaf; the scan is O(total SizeExpr nodes), well below the cost of the cheapest
-  // h2d / d2h on any LLVM GPU backend.
+  // condition is computed once per launch by scanning each stack's `nodes` vector for an `ExternalTensorRead`
+  // leaf; the scan is O(total SizeExpr nodes), well below the cost of the cheapest h2d / d2h on any LLVM GPU
+  // backend.
   bool all_size_exprs_host_resolvable = true;
   for (std::size_t i = 0; i < n_stacks && all_size_exprs_host_resolvable; ++i) {
     if (i >= ad_stack.size_exprs.size()) {

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -662,10 +662,38 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
 
   std::size_t stride = 0;
   const bool is_gpu_llvm = (config_.arch == Arch::cuda || config_.arch == Arch::amdgpu);
-  if (!is_gpu_llvm) {
-    // CPU: run the host evaluator directly. The ndarray data is host-accessible (see
-    // `set_host_accessible_ndarray_ptrs` in the CPU kernel launcher) so `ExternalTensorRead` resolves without
-    // any device round-trip; FieldLoad is serviced by `SNodeRwAccessorsBank` exactly as before.
+
+  // Host-eval fast path. The on-device sizer kernel exists to handle one specific leaf, `ExternalTensorRead`,
+  // whose ndarray data lives in GPU-private memory (`cudaMalloc` / `hipMalloc`, no UVA fallback) and thus
+  // cannot be touched from the host. Every other SizeExpr leaf - `Const`, `BoundVariable`,
+  // `ExternalTensorShape`, `FieldLoad` - is host-resolvable through the existing `evaluate_adstack_size_expr`
+  // path, so when the kernel's SizeExprs are all `ExternalTensorRead`-free we can skip the encode + bytecode
+  // h2d + sizer-kernel launch + d2h-stride pipeline entirely and write the metadata directly via `copy_h2d`.
+  // On CUDA the saved `cuMemcpyDtoH` for the per-launch stride readback is the dominant cost: every reverse-
+  // mode kernel launch in a 100-substep test paid one such synchronous DtoH each, and that compound stall
+  // accounted for the bulk of the GPU regression seen when adstack mode replaced `unrolling_limit`. The
+  // condition is computed once per launch by scanning each stack's `nodes` vector for an
+  // `ExternalTensorRead` leaf; the scan is O(total SizeExpr nodes), well below the cost of the cheapest
+  // h2d / d2h on any LLVM GPU backend.
+  bool all_size_exprs_host_resolvable = true;
+  for (std::size_t i = 0; i < n_stacks && all_size_exprs_host_resolvable; ++i) {
+    if (i >= ad_stack.size_exprs.size()) {
+      continue;
+    }
+    for (const auto &node : ad_stack.size_exprs[i].nodes) {
+      if (static_cast<SizeExpr::Kind>(node.kind) == SizeExpr::Kind::ExternalTensorRead) {
+        all_size_exprs_host_resolvable = false;
+        break;
+      }
+    }
+  }
+  const bool use_host_eval = !is_gpu_llvm || all_size_exprs_host_resolvable;
+  if (use_host_eval) {
+    // CPU + GPU-without-ExternalTensorRead path: run the host evaluator directly and `copy_h2d` the resulting
+    // arrays. On CPU the ndarray data is host-accessible (see `set_host_accessible_ndarray_ptrs` in the CPU
+    // kernel launcher) so even `ExternalTensorRead` would resolve without a device round-trip; the
+    // `is_gpu_llvm` arms gate kept this branch CPU-only before the ExternalTensorRead-free check above
+    // unlocked it for CUDA / AMDGPU. `FieldLoad` is serviced by `SNodeRwAccessorsBank` regardless.
     std::vector<uint64_t> host_max_sizes(n_stacks);
     for (std::size_t i = 0; i < n_stacks; ++i) {
       const SerializedSizeExpr *expr = (i < ad_stack.size_exprs.size()) ? &ad_stack.size_exprs[i] : nullptr;

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -735,12 +735,15 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
     // the host on every one of the three writes we issue per launch; with thousands of reverse-mode launches
     // per `test_differentiable_rigid` run, those serial host stalls were a measurable fraction of wallclock.
     // `FieldLoad` is serviced by `SNodeRwAccessorsBank` regardless of arch.
+    // Guard `program_impl_->program` lookups against the C++-only-tests setup where `program_impl_` itself is
+    // null; the on-device branch below already does this and falls back to `max_size_compile_time`.
+    Program *prog = (program_impl_ != nullptr) ? program_impl_->program : nullptr;
     std::vector<uint64_t> host_max_sizes(n_stacks);
     for (std::size_t i = 0; i < n_stacks; ++i) {
       const SerializedSizeExpr *expr = (i < ad_stack.size_exprs.size()) ? &ad_stack.size_exprs[i] : nullptr;
       int64_t v = -1;
-      if (expr != nullptr && !expr->nodes.empty() && program_impl_->program != nullptr) {
-        v = evaluate_adstack_size_expr(*expr, program_impl_->program, ctx);
+      if (expr != nullptr && !expr->nodes.empty() && prog != nullptr) {
+        v = evaluate_adstack_size_expr(*expr, prog, ctx);
       }
       if (v < 0) {
         v = static_cast<int64_t>(ad_stack.allocas[i].max_size_compile_time);

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -507,6 +507,45 @@ void LlvmRuntimeExecutor::finalize() {
   runtime_temporaries_cache_ = nullptr;
   runtime_adstack_heap_buffer_field_ptr_ = nullptr;
   runtime_adstack_heap_size_field_ptr_ = nullptr;
+  // Release the pinned-host metadata scratch and its completion event. Sequence: first drain the pending in-flight
+  // copy via `event_synchronize` (the next launch's reuse path would have done this lazily, but on shutdown there
+  // is no next launch), then free the host pinning, then destroy the event. Skipping the synchronize before
+  // `mem_free_host` would race the DMA engine's read against the host free; skipping `event_destroy` would leak a
+  // CUDA / HIP event handle.
+  if (pinned_metadata_event_ != nullptr) {
+#if defined(QD_WITH_CUDA)
+    if (config_.arch == Arch::cuda) {
+      if (pinned_metadata_event_pending_) {
+        CUDADriver::get_instance().event_synchronize(pinned_metadata_event_);
+      }
+      CUDADriver::get_instance().event_destroy(pinned_metadata_event_);
+    }
+#endif
+#if defined(QD_WITH_AMDGPU)
+    if (config_.arch == Arch::amdgpu) {
+      if (pinned_metadata_event_pending_) {
+        AMDGPUDriver::get_instance().event_synchronize(pinned_metadata_event_);
+      }
+      AMDGPUDriver::get_instance().event_destroy(pinned_metadata_event_);
+    }
+#endif
+    pinned_metadata_event_ = nullptr;
+    pinned_metadata_event_pending_ = false;
+  }
+  if (pinned_metadata_scratch_ != nullptr) {
+#if defined(QD_WITH_CUDA)
+    if (config_.arch == Arch::cuda) {
+      CUDADriver::get_instance().mem_free_host(pinned_metadata_scratch_);
+    }
+#endif
+#if defined(QD_WITH_AMDGPU)
+    if (config_.arch == Arch::amdgpu) {
+      AMDGPUDriver::get_instance().mem_free_host(pinned_metadata_scratch_);
+    }
+#endif
+    pinned_metadata_scratch_ = nullptr;
+    pinned_metadata_scratch_capacity_ = 0;
+  }
   if (config_.arch == Arch::cuda || config_.arch == Arch::amdgpu) {
     preallocated_runtime_objects_allocs_.reset();
     preallocated_runtime_memory_allocs_.reset();
@@ -689,11 +728,14 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
   }
   const bool use_host_eval = !is_gpu_llvm || all_size_exprs_host_resolvable;
   if (use_host_eval) {
-    // CPU + GPU-without-ExternalTensorRead path: run the host evaluator directly and `copy_h2d` the resulting
-    // arrays. On CPU the ndarray data is host-accessible (see `set_host_accessible_ndarray_ptrs` in the CPU
-    // kernel launcher) so even `ExternalTensorRead` would resolve without a device round-trip; the
-    // `is_gpu_llvm` arms gate kept this branch CPU-only before the ExternalTensorRead-free check above
-    // unlocked it for CUDA / AMDGPU. `FieldLoad` is serviced by `SNodeRwAccessorsBank` regardless.
+    // CPU + GPU-without-ExternalTensorRead path: run the host evaluator directly. On CPU we use synchronous
+    // `copy_h2d` (just `std::memcpy` for that arch), but on CUDA / AMDGPU we ship the same payload through
+    // pinned-host memory via async `cuMemcpyHtoDAsync` / `hipMemcpyHtoDAsync` so the host returns immediately
+    // after queueing the copies on the default stream and the subsequent main-kernel launch (also on the
+    // default stream) stream-orders after the copies. The synchronous `cuMemcpyHtoD_v2` path used to block
+    // the host on every one of the three writes we issue per launch; with thousands of reverse-mode launches
+    // per `test_differentiable_rigid` run, those serial host stalls were a measurable fraction of wallclock.
+    // `FieldLoad` is serviced by `SNodeRwAccessorsBank` regardless of arch.
     std::vector<uint64_t> host_max_sizes(n_stacks);
     for (std::size_t i = 0; i < n_stacks; ++i) {
       const SerializedSizeExpr *expr = (i < ad_stack.size_exprs.size()) ? &ad_stack.size_exprs[i] : nullptr;
@@ -711,10 +753,126 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
       host_offsets[i] = stride;
       stride += align_up_8(sizeof(int64_t) + ad_stack.allocas[i].entry_size_bytes * host_max_sizes[i]);
     }
-    copy_h2d(offsets_dev_ptr, host_offsets.data(), n_stacks * sizeof(uint64_t));
-    copy_h2d(max_sizes_dev_ptr, host_max_sizes.data(), n_stacks * sizeof(uint64_t));
     uint64_t stride_u64 = static_cast<uint64_t>(stride);
-    copy_h2d(runtime_adstack_stride_field_ptr_, &stride_u64, sizeof(uint64_t));
+    if (!is_gpu_llvm) {
+      copy_h2d(offsets_dev_ptr, host_offsets.data(), n_stacks * sizeof(uint64_t));
+      copy_h2d(max_sizes_dev_ptr, host_max_sizes.data(), n_stacks * sizeof(uint64_t));
+      copy_h2d(runtime_adstack_stride_field_ptr_, &stride_u64, sizeof(uint64_t));
+    } else {
+      // Three-block payload packed into the pinned-host scratch as `[stride_u64, offsets[n_stacks],
+      // max_sizes[n_stacks]]`. Three async DMAs land on the three target device addresses (the runtime
+      // struct's stride field, the offsets storage buffer, the max_sizes storage buffer) sourced from
+      // the corresponding offsets within the pinned scratch. The driver's H2D DMA engine reads from the
+      // pinned bytes at execution time, so we must not overwrite the scratch before all three copies
+      // have completed - hence the per-launch `event_record` after the last copy and the
+      // `event_synchronize` at the top of the next launch. The wait is typically a no-op because a few
+      // microseconds of small copies finish well before the host returns, dispatches the main kernel,
+      // and re-enters this function on the next launch.
+      const std::size_t header_bytes = sizeof(uint64_t);
+      const std::size_t array_bytes = n_stacks * sizeof(uint64_t);
+      const std::size_t total_bytes = header_bytes + 2 * array_bytes;
+
+      auto wait_pending = [this]() {
+        if (!pinned_metadata_event_pending_) {
+          return;
+        }
+#if defined(QD_WITH_CUDA)
+        if (config_.arch == Arch::cuda) {
+          CUDADriver::get_instance().event_synchronize(pinned_metadata_event_);
+        }
+#endif
+#if defined(QD_WITH_AMDGPU)
+        if (config_.arch == Arch::amdgpu) {
+          AMDGPUDriver::get_instance().event_synchronize(pinned_metadata_event_);
+        }
+#endif
+        pinned_metadata_event_pending_ = false;
+      };
+
+      // Grow / first-allocate the pinned host scratch and the per-launch completion event. Doubling growth
+      // means the pinned alloc / free traffic is amortised to O(log peak_total_bytes) across a run.
+      if (total_bytes > pinned_metadata_scratch_capacity_) {
+        wait_pending();
+        if (pinned_metadata_scratch_ != nullptr) {
+#if defined(QD_WITH_CUDA)
+          if (config_.arch == Arch::cuda) {
+            CUDADriver::get_instance().mem_free_host(pinned_metadata_scratch_);
+          }
+#endif
+#if defined(QD_WITH_AMDGPU)
+          if (config_.arch == Arch::amdgpu) {
+            AMDGPUDriver::get_instance().mem_free_host(pinned_metadata_scratch_);
+          }
+#endif
+          pinned_metadata_scratch_ = nullptr;
+        }
+        std::size_t new_capacity = std::max<std::size_t>(total_bytes, 2 * pinned_metadata_scratch_capacity_);
+#if defined(QD_WITH_CUDA)
+        if (config_.arch == Arch::cuda) {
+          CUDADriver::get_instance().mem_alloc_host(&pinned_metadata_scratch_, new_capacity);
+        }
+#endif
+#if defined(QD_WITH_AMDGPU)
+        if (config_.arch == Arch::amdgpu) {
+          // `hipHostMallocDefault == 0`. Coherent / portable / write-combined flags are intentionally not set;
+          // the workload is small payloads written linearly by the host and DMA-read by the GPU once.
+          AMDGPUDriver::get_instance().mem_alloc_host(&pinned_metadata_scratch_, new_capacity, 0u);
+        }
+#endif
+        pinned_metadata_scratch_capacity_ = new_capacity;
+      }
+      if (pinned_metadata_event_ == nullptr) {
+        // `cuEventCreate` flag `0` (CU_EVENT_DEFAULT) means timing-enabled, which the driver costs us nothing
+        // to set up here and lets future profilers attach without re-creating the event. `hipEventCreateWithFlags`
+        // takes the same encoding.
+#if defined(QD_WITH_CUDA)
+        if (config_.arch == Arch::cuda) {
+          CUDADriver::get_instance().event_create(&pinned_metadata_event_, 0u);
+        }
+#endif
+#if defined(QD_WITH_AMDGPU)
+        if (config_.arch == Arch::amdgpu) {
+          AMDGPUDriver::get_instance().event_create(&pinned_metadata_event_, 0u);
+        }
+#endif
+      }
+      // Block until any in-flight copies from the previous launch have finished pulling from the pinned scratch
+      // before we overwrite it. In steady state this is a no-op because the small DMAs finish well before the
+      // host loops back here; the wait exists only to defend against an unusual interleaving where the GPU
+      // queue is backlogged and the next launch enters this function before the previous launch's last copy
+      // has been consumed.
+      wait_pending();
+
+      auto *pinned = static_cast<uint64_t *>(pinned_metadata_scratch_);
+      pinned[0] = stride_u64;
+      std::memcpy(pinned + 1, host_offsets.data(), array_bytes);
+      std::memcpy(pinned + 1 + n_stacks, host_max_sizes.data(), array_bytes);
+
+      [[maybe_unused]] void *default_stream = nullptr;
+#if defined(QD_WITH_CUDA)
+      if (config_.arch == Arch::cuda) {
+        CUDADriver::get_instance().memcpy_host_to_device_async(runtime_adstack_stride_field_ptr_, pinned, header_bytes,
+                                                               default_stream);
+        CUDADriver::get_instance().memcpy_host_to_device_async(offsets_dev_ptr, pinned + 1, array_bytes,
+                                                               default_stream);
+        CUDADriver::get_instance().memcpy_host_to_device_async(max_sizes_dev_ptr, pinned + 1 + n_stacks, array_bytes,
+                                                               default_stream);
+        CUDADriver::get_instance().event_record(pinned_metadata_event_, default_stream);
+      }
+#endif
+#if defined(QD_WITH_AMDGPU)
+      if (config_.arch == Arch::amdgpu) {
+        AMDGPUDriver::get_instance().memcpy_host_to_device_async(runtime_adstack_stride_field_ptr_, pinned,
+                                                                 header_bytes, default_stream);
+        AMDGPUDriver::get_instance().memcpy_host_to_device_async(offsets_dev_ptr, pinned + 1, array_bytes,
+                                                                 default_stream);
+        AMDGPUDriver::get_instance().memcpy_host_to_device_async(max_sizes_dev_ptr, pinned + 1 + n_stacks, array_bytes,
+                                                                 default_stream);
+        AMDGPUDriver::get_instance().event_record(pinned_metadata_event_, default_stream);
+      }
+#endif
+      pinned_metadata_event_pending_ = true;
+    }
   } else {
     // GPU (CUDA / AMDGPU): encode the SizeExpr trees into device bytecode, upload, launch the sizer runtime
     // function, read back just the computed stride. The sizer kernel writes `adstack_max_sizes[]`,

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -847,27 +847,33 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
       std::memcpy(pinned + 1, host_offsets.data(), array_bytes);
       std::memcpy(pinned + 1 + n_stacks, host_max_sizes.data(), array_bytes);
 
-      [[maybe_unused]] void *default_stream = nullptr;
+      // Queue the metadata copies on the same stream the subsequent main-kernel dispatch will run on, so the
+      // GPU stream-orders the copies before the kernel reads `adstack_max_sizes` etc. On CUDA the active
+      // stream is `CUDAContext::get_instance().get_stream()` - configurable via `set_stream`, defaults to the
+      // null stream - and `CUDAContext::launch` dispatches kernels on the same handle. AMDGPU has no
+      // public stream-selection API: `AMDGPUContext::launch` always passes `nullptr` to `hipLaunchKernel`
+      // (i.e. the default stream), so the copies match that.
 #if defined(QD_WITH_CUDA)
       if (config_.arch == Arch::cuda) {
+        void *active_stream = CUDAContext::get_instance().get_stream();
         CUDADriver::get_instance().memcpy_host_to_device_async(runtime_adstack_stride_field_ptr_, pinned, header_bytes,
-                                                               default_stream);
-        CUDADriver::get_instance().memcpy_host_to_device_async(offsets_dev_ptr, pinned + 1, array_bytes,
-                                                               default_stream);
+                                                               active_stream);
+        CUDADriver::get_instance().memcpy_host_to_device_async(offsets_dev_ptr, pinned + 1, array_bytes, active_stream);
         CUDADriver::get_instance().memcpy_host_to_device_async(max_sizes_dev_ptr, pinned + 1 + n_stacks, array_bytes,
-                                                               default_stream);
-        CUDADriver::get_instance().event_record(pinned_metadata_event_, default_stream);
+                                                               active_stream);
+        CUDADriver::get_instance().event_record(pinned_metadata_event_, active_stream);
       }
 #endif
 #if defined(QD_WITH_AMDGPU)
       if (config_.arch == Arch::amdgpu) {
+        void *active_stream = nullptr;  // AMDGPUContext::launch always uses the default stream.
         AMDGPUDriver::get_instance().memcpy_host_to_device_async(runtime_adstack_stride_field_ptr_, pinned,
-                                                                 header_bytes, default_stream);
+                                                                 header_bytes, active_stream);
         AMDGPUDriver::get_instance().memcpy_host_to_device_async(offsets_dev_ptr, pinned + 1, array_bytes,
-                                                                 default_stream);
+                                                                 active_stream);
         AMDGPUDriver::get_instance().memcpy_host_to_device_async(max_sizes_dev_ptr, pinned + 1 + n_stacks, array_bytes,
-                                                                 default_stream);
-        AMDGPUDriver::get_instance().event_record(pinned_metadata_event_, default_stream);
+                                                                 active_stream);
+        AMDGPUDriver::get_instance().event_record(pinned_metadata_event_, active_stream);
       }
 #endif
       pinned_metadata_event_pending_ = true;

--- a/quadrants/runtime/llvm/llvm_runtime_executor.h
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.h
@@ -239,6 +239,22 @@ class LlvmRuntimeExecutor {
   DeviceAllocationUnique adstack_sizer_bytecode_alloc_ = nullptr;
   std::size_t adstack_sizer_bytecode_capacity_{0};
 
+  // Pinned (page-locked) host scratch + completion event used by the host-eval branch of `publish_adstack_metadata`
+  // on CUDA / AMDGPU to issue the per-launch adstack metadata writes asynchronously. With pageable host memory
+  // `cuMemcpyHtoDAsync` synchronises on the staging copy, so the source MUST be pinned for the async copy to be
+  // truly non-blocking; with pinned host memory the host returns immediately after queuing the copy on the
+  // default stream and the GPU pulls the bytes via DMA before the subsequent main-kernel launch (which is also
+  // queued on the default stream and stream-orders after the copies). One pinned scratch is reused across
+  // launches; `pinned_metadata_event_` is recorded after the last copy of each launch, and the next launch's
+  // `publish_adstack_metadata` waits on it before overwriting the scratch so the in-flight copy cannot read torn
+  // bytes. Allocated lazily on the first call that exercises this branch and grown via
+  // `cuMemAllocHost_v2` / `hipHostMalloc`; freed in the executor destructor. Capacity is in bytes and tracks the
+  // largest `(2 + 2 * n_stacks) * sizeof(uint64)` payload published so far.
+  void *pinned_metadata_scratch_{nullptr};
+  std::size_t pinned_metadata_scratch_capacity_{0};
+  void *pinned_metadata_event_{nullptr};
+  bool pinned_metadata_event_pending_{false};
+
   // good buddy
   friend LlvmProgramImpl;
   friend SNodeTreeBufferManager;

--- a/quadrants/runtime/llvm/llvm_runtime_executor.h
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.h
@@ -239,17 +239,16 @@ class LlvmRuntimeExecutor {
   DeviceAllocationUnique adstack_sizer_bytecode_alloc_ = nullptr;
   std::size_t adstack_sizer_bytecode_capacity_{0};
 
-  // Pinned (page-locked) host scratch + completion event used by the host-eval branch of `publish_adstack_metadata`
-  // on CUDA / AMDGPU to issue the per-launch adstack metadata writes asynchronously. With pageable host memory
-  // `cuMemcpyHtoDAsync` synchronises on the staging copy, so the source MUST be pinned for the async copy to be
-  // truly non-blocking; with pinned host memory the host returns immediately after queuing the copy on the
-  // default stream and the GPU pulls the bytes via DMA before the subsequent main-kernel launch (which is also
-  // queued on the default stream and stream-orders after the copies). One pinned scratch is reused across
-  // launches; `pinned_metadata_event_` is recorded after the last copy of each launch, and the next launch's
-  // `publish_adstack_metadata` waits on it before overwriting the scratch so the in-flight copy cannot read torn
-  // bytes. Allocated lazily on the first call that exercises this branch and grown via `cuMemAllocHost_v2` /
-  // `hipHostMalloc`; freed in the executor destructor. Capacity is in bytes and tracks the largest
-  // `(2 + 2 * n_stacks) * sizeof(uint64)` payload published so far.
+  // Pinned (page-locked) host scratch + completion event used by the host-eval branch of `publish_adstack_metadata` on
+  // CUDA / AMDGPU to issue the per-launch adstack metadata writes asynchronously. With pageable host memory
+  // `cuMemcpyHtoDAsync` synchronises on the staging copy, so the source MUST be pinned for the async copy to be truly
+  // non-blocking; with pinned host memory the host returns immediately after queuing the copy on the default stream and
+  // the GPU pulls the bytes via DMA before the subsequent main-kernel launch (which is also queued on the default
+  // stream and stream-orders after the copies). One pinned scratch is reused across launches; `pinned_metadata_event_`
+  // is recorded after the last copy of each launch, and the next launch's `publish_adstack_metadata` waits on it before
+  // overwriting the scratch so the in-flight copy cannot read torn bytes. Allocated lazily on the first call that
+  // exercises this branch and grown via `cuMemAllocHost_v2` / `hipHostMalloc`; freed in the executor destructor.
+  // Capacity is in bytes and tracks the largest `(2 + 2 * n_stacks) * sizeof(uint64)` payload published so far.
   void *pinned_metadata_scratch_{nullptr};
   std::size_t pinned_metadata_scratch_capacity_{0};
   void *pinned_metadata_event_{nullptr};

--- a/quadrants/runtime/llvm/llvm_runtime_executor.h
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.h
@@ -247,9 +247,9 @@ class LlvmRuntimeExecutor {
   // queued on the default stream and stream-orders after the copies). One pinned scratch is reused across
   // launches; `pinned_metadata_event_` is recorded after the last copy of each launch, and the next launch's
   // `publish_adstack_metadata` waits on it before overwriting the scratch so the in-flight copy cannot read torn
-  // bytes. Allocated lazily on the first call that exercises this branch and grown via
-  // `cuMemAllocHost_v2` / `hipHostMalloc`; freed in the executor destructor. Capacity is in bytes and tracks the
-  // largest `(2 + 2 * n_stacks) * sizeof(uint64)` payload published so far.
+  // bytes. Allocated lazily on the first call that exercises this branch and grown via `cuMemAllocHost_v2` /
+  // `hipHostMalloc`; freed in the executor destructor. Capacity is in bytes and tracks the largest
+  // `(2 + 2 * n_stacks) * sizeof(uint64)` payload published so far.
   void *pinned_metadata_scratch_{nullptr};
   std::size_t pinned_metadata_scratch_capacity_{0};
   void *pinned_metadata_event_{nullptr};

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -2287,8 +2287,13 @@ def test_adstack_fuses_sub_of_max_over_range_with_mismatched_lengths_is_safe(arr
             assert x.grad[k] == pytest.approx(2 * expected_visits[k] * 0.1, rel=1e-5)
 
 
+@pytest.mark.parametrize(
+    "x_unused_val",
+    [0.1, 100.0],
+    ids=["uniform_x", "amplified_unused_x"],
+)
 @test_utils.test(require=qd.extension.adstack)
-def test_adstack_sub_of_max_over_range_fusion_does_not_mix_fieldload_and_extread():
+def test_adstack_sub_of_max_over_range_fusion_does_not_mix_fieldload_and_extread(x_unused_val):
     # Pins that a reverse-mode kernel whose inner trip count is `fld[i] - arr[i]` - a scalar field minus an ndarray
     # element, both indexed by the outer loop variable - compiles and produces the correct gradient on every supported
     # backend.
@@ -2303,6 +2308,16 @@ def test_adstack_sub_of_max_over_range_fusion_does_not_mix_fieldload_and_extread
     # synthesised body would pair a bound-var-indexed `FieldLoad` with an `ExternalTensorRead`; the unfused
     # `Sub(MaxOverRange(i, 0, shape, FieldLoad), MaxOverRange(i, 0, shape, ExternalTensorRead))` keeps each operand
     # closed and host-foldable on both encoders.
+    #
+    # The `x_unused_val` parametrization sets `x[8..15]` to `x_unused_val` while keeping `x[0..7]` at `0.1`. Only
+    # `x[0..7]` is reached by the kernel under correct sizing, so `x_unused_val` does not affect the expected loss /
+    # gradient at all and the assertions are identical across parametrizations. The `amplified_unused_x` variant
+    # (`x_unused_val=100.0`) exists so that any regression that mis-routes a stack push / pop to a slot outside the
+    # intended index range surfaces as a multi-order-of-magnitude gradient delta (e.g. a single spurious visit to
+    # `x[8]` produces `x.grad[8]=200.0` instead of the `0.2` an `x_unused_val=0.1` setup would produce), so the
+    # failure cannot be misread as a tolerance issue. The original `uniform_x` (`x_unused_val=0.1`) parametrization
+    # preserves the historical loss / gradient magnitudes for direct continuity with the prior fixed-fixture form of
+    # this test.
     N = 4
     N_X = 16
 
@@ -2322,7 +2337,7 @@ def test_adstack_sub_of_max_over_range_fusion_does_not_mix_fieldload_and_extread
             loss[None] += accum
 
     for i in range(N_X):
-        x[i] = 0.1
+        x[i] = 0.1 if i < 8 else x_unused_val
     for i in range(N):
         fld[i] = 10
     arr_np = np.array([2, 2, 2, 2], dtype=np.int32)
@@ -2335,7 +2350,8 @@ def test_adstack_sub_of_max_over_range_fusion_does_not_mix_fieldload_and_extread
     qd.sync()
 
     # Each of the 4 outer iterations runs `fld[i] - arr[i] = 10 - 2 = 8` inner iters. Total pushes = 32.
-    # x[0..7] is visited 4 times (once per outer iter); x[8..] is never visited.
+    # x[0..7] is visited 4 times (once per outer iter); x[8..] is never visited, so the loss and gradients
+    # are independent of `x_unused_val`.
     assert loss[None] == pytest.approx(4 * 8 * 0.01, rel=1e-5)
     for k in range(8):
         assert x.grad[k] == pytest.approx(4 * 2 * 0.1, rel=1e-5)


### PR DESCRIPTION
# Speed up reverse-mode kernel launches on GPU backends via an adstack-sizer host-eval fast path

> Adds a host-eval fast path on every GPU backend (CUDA / AMDGPU on the LLVM runtime; Metal / Vulkan / MoltenVK on the SPIR-V runtime) that bypasses the on-device sizer kernel + readback whenever every adstack alloca's `SizeExpr` is host-resolvable. Includes the LLVM-side async pinned-host HtoD optimisation, the SPIR-V predicate's `FieldLoad` correctness fix, a Codex/Claude-bot review pass on the LLVM path (active-stream routing, `program_impl_` null-guard), a parametrized regression test, and several rounds of comment / wrap polish.

## TL;DR

Every reverse-mode kernel launch with adstack allocas runs the `SizeExpr` capacity computation. Pre-PR that always meant a GPU dispatch:

- **LLVM (CUDA / AMDGPU)**: `HtoD` of the encoded `SizeExpr` bytecode -> single-thread `runtime_eval_adstack_size_expr` kernel launch -> synchronous `DtoH` of the per-thread stride. The `DtoH` is a stream-sync that stalls the host until the sizer kernel has finished. With ~100 substeps x forward + backward x several reverse-mode tasks per substep, the test launches the sizer thousands of times and pays one host stall per launch.
- **SPIR-V (Metal / Vulkan / MoltenVK)**: explicit `flush()` + `device_->wait_idle()` for PSB visibility -> sizer-bytecode upload -> per-task descriptor bind / dispatch -> `submit_synced` -> blocking metadata readback. Two host-side GPU stalls per kernel launch.

This PR detects the common case where no `SizeExpr` leaf needs device-resident memory and skips the entire dispatch on both backends.

Reported impact on the motivating workload (Genesis `test_differentiable_rigid[gpu]`): roughly **4x faster** on CUDA after enabling this path.

## Why

`evaluate_adstack_size_expr` already handles every leaf the on-device sizer was designed to interpret, except `ExternalTensorRead` whose data pointer is GPU-private. Detecting that one leaf at host time and skipping the dispatch is straightforward, and the `unrolling_limit` baseline is exactly the all-host-resolvable case (no adstacks at all => no `SizeExpr` at all => no dispatch), so this fast path is the closest the adstack mode can get to the unrolled baseline's launch overhead.

## Mechanism

### LLVM path (`LlvmRuntimeExecutor::publish_adstack_metadata`)

The function already had a CPU branch that host-evals each `SerializedSizeExpr` and writes the metadata arrays directly via `copy_h2d`. The branch was gated on `!is_gpu_llvm`. The new code:

1. Scans every alloca's `size_expr.nodes` for any node whose kind is `SizeExpr::Kind::ExternalTensorRead`. `O(total node count across allocas)`.
2. Sets `use_host_eval = !is_gpu_llvm || all_size_exprs_host_resolvable`.
3. Routes to the existing host-eval branch when `use_host_eval` is true. CUDA / AMDGPU now reach this branch when no `ExternalTensorRead` is present.
4. Falls back to the existing `runtime_eval_adstack_size_expr` JIT call for kernels with `ExternalTensorRead`.

What dropped per launch when the fast path fires: one bytecode `HtoD`, one device sizer kernel launch, one `DtoH` stream-sync.

### LLVM async pinned-host metadata HtoD

The fast path's three small per-launch HtoD copies (`offsets`, `max_sizes`, `stride`) are issued asynchronously from a pinned-host scratch via `cuMemcpyHtoDAsync` / `hipMemcpyHtoDAsync`. The host returns immediately after queueing the three copies on the *active* CUDA stream (`CUDAContext::get_instance().get_stream()` so user-set custom streams stream-order against the main-kernel dispatch correctly; AMDGPU keeps `nullptr` because `AMDGPUContext::launch` always uses the default stream). Pinned scratch is allocated lazily via `cuMemAllocHost` / `hipHostMalloc` and grown amortised-doubling; a per-launch CUDA / HIP event guards scratch reuse against in-flight DMAs. Eliminates the three serial host stalls per launch the synchronous `cuMemcpyHtoD_v2` path had.

### SPIR-V path (`GfxRuntime::publish_adstack_metadata_spirv`)

Two helpers in an anonymous namespace:

- `all_size_exprs_host_resolvable(adstack_task_indices, task_attribs)`: scans every adstack-bearing task's allocas for an `ExternalTensorRead` *or* `FieldLoad` leaf. **`FieldLoad` is the correctness gate**: the host evaluator's `FieldLoad` path goes through `SNodeRwAccessorsBank::read_int`, whose nested accessor-kernel launch from inside the publish corrupts the SPIR-V launcher's per-task metadata-upload state and produces wrong gradients on every kernel that hits it. The on-device sizer was specifically built to handle `FieldLoad` on-device via PSB loads precisely because of this; the host-eval predicate must therefore reject both `ExternalTensorRead` (host can't read GPU-private memory) and `FieldLoad` (nested launch is unsafe).
- `eval_per_task_metadata_on_host(adstack_task_indices, task_attribs, prog, host_ctx, per_task_ad_stack)`: replicates the sizer shader's per-task metadata layout (`[stride_float, stride_int, (offset_i, max_size_i)*]`) on the host. Float-heap accumulator advances by `2 * max_size` (primal + adjoint), Int-heap by `max_size`, matching the `running_off_f` / `running_off_i` arithmetic in `quadrants/codegen/spirv/adstack_sizer_shader.cpp`.

The fast path runs after the `adstack_task_indices` early-out and before the sizer-pipeline build / bytecode upload / cmdlist record. When it fires, the function returns the host-computed `per_task_ad_stack` vector and never touches the sizer pipeline, the bytecode scratch buffer, the per-task metadata-buffer allocation, the `flush()`, the `device_->wait_idle()`, the sizer cmdlist record, the `submit_synced`, or the metadata readback - all of which are skipped entirely.

## Per-backend coverage matrix

| Backend                          | Pre-PR per-launch sizer cost                                                  | Post-PR (host-resolvable: no `ExternalTensorRead`, no `FieldLoad`)              | Post-PR (with `ExternalTensorRead` or `FieldLoad` on SPIR-V) |
| -------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| **CPU**                          | Already host-eval (no GPU dispatch)                                           | Unchanged                                                                       | Unchanged                                                    |
| **CUDA**                         | `HtoD` bytecode + sizer kernel + `DtoH` stride sync                           | 3 small async pinned `HtoD`s on the active stream, no kernel, no sync           | Unchanged (sizer kernel + readback)                          |
| **AMDGPU**                       | `HtoD` bytecode + sizer kernel + `DtoH` stride sync                           | 3 small async pinned `HtoD`s on the default stream, no kernel, no sync          | Unchanged                                                    |
| **Metal / MoltenVK**             | `flush` + `wait_idle` + bytecode upload + sizer cmdlist + readback            | None - host-eval only (when SizeExpr is `ExternalTensorRead` *and* `FieldLoad` free) | Unchanged                                                    |
| **Vulkan**                       | Same as Metal (shared SPIR-V path)                                            | Same as Metal                                                                   | Unchanged                                                    |

LLVM's host-eval `FieldLoad` is serviced by `SNodeRwAccessorsBank` exactly as before - no change for the LLVM CPU / CUDA / AMDGPU paths because the launcher reentrancy issue that gates SPIR-V doesn't apply there.

## Tests

- `pytest tests/python/test_adstack.py -n 8`: 770 passed, 10 xfailed locally on macOS Vulkan / arm64 / Metal.
- `test_adstack_sub_of_max_over_range_fusion_does_not_mix_fieldload_and_extread` is parametrized on `x_unused_val=[0.1, 100.0]`. The `amplified_unused_x` variant pins any future cross-stack push / pop misroute as a `200.0 vs 0.0` mismatch (5+ orders of magnitude) instead of a `0.2 vs 0.0` "looks-like-tolerance" delta - the original `0.1` setup was added by this PR's predecessor and made the SPIR-V FieldLoad-during-publish corruption look like a numerical tolerance issue rather than the structural correctness bug it was.
- `test_differentiable_rigid[gpu]` end-to-end: ~4x faster on CUDA per the reported repro.
- `tests/test_grad.py::test_differentiable_rigid[cpu]` end-to-end: passes.

## Codex / Claude bot review fixes

| Severity | Issue | Fix |
| --- | --- | --- |
| **P1** | Host-eval branch dereferenced `program_impl_->program` unconditionally; the on-device branch already supports `program_impl_ == nullptr` (C++-only tests) and falls back to `max_size_compile_time` | Hoisted the `program_impl_` null-check before the `evaluate_adstack_size_expr` call, mirroring the on-device branch |
| **P2** | Async metadata HtoDs were hard-coded to `default_stream = nullptr`; user calls to `CUDAContext::set_stream` would leave kernels reading stale metadata | Routed CUDA copies through `CUDAContext::get_instance().get_stream()` so they stream-order against `CUDAContext::launch`'s dispatch handle. AMDGPU keeps `nullptr` because `AMDGPUContext::launch` always passes `nullptr` to `hipLaunchKernel` |

## Side-effect audit

| Concern                                                                  | Where checked                                                                                                                                                                                                                            | Verdict                                                                                            |
| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| Host-eval correctness vs on-device sizer for ExternalTensorRead-free SizeExprs | `evaluate_adstack_size_expr` is the same function the on-device-bytecode encoder already calls during pre-substitution, so the leaves it can fold (`Const` / `FieldLoad` / `BoundVariable` / `ExternalTensorShape` / arithmetic / `MaxOverRange`) produce identical values | Same code path; no divergence between host fold and on-device sizer when the leaf set is identical |
| SPIR-V `FieldLoad` reentrancy                                            | Predicate explicitly rejects `FieldLoad` so the SPIR-V publish never calls `read_int` from inside `publish_adstack_metadata_spirv`; the on-device sizer's PSB-load path handles `FieldLoad` correctly                                  | Documented in the predicate's docstring and pinned by the parametrized regression test             |
| Metadata layout match between SPIR-V host-eval and shader output         | Per-stack offset uses `2 * max_size` for the Float heap and `max_size` for the Int heap, matching `adstack_sizer_shader.cpp`'s `running_off_f` / `running_off_i` accumulation; final stride values written into `metadata[0]` / `metadata[1]` | Bit-identical to shader output for the host-eval'able subset                                       |
| LLVM byte-offset / 8-byte alignment match                                | Same `align_up_8(sizeof(int64_t) + entry_size_bytes * max_size)` formula already used by the existing CPU host-eval branch; no change                                                                                                  | Identical to the previously CPU-only branch's behaviour                                            |
| `ExternalTensorRead` falls back to on-device sizer                       | Single linear scan of `size_expr.nodes` returns false on the first `ExternalTensorRead` kind; the `else` arm of the dispatch retains the original LLVM `runtime_eval_adstack_size_expr` call and the SPIR-V cmdlist record path | Behaviour identical to pre-PR for kernels that hit this case                                       |
| LLVM async metadata stream-ordering                                      | Active-stream routing via `CUDAContext::get_instance().get_stream()`; pinned scratch reuse guarded by per-launch CUDA / HIP event so DMAs cannot race the host overwrite                                                              | Stream-ordered against the main-kernel dispatch on every CUDA stream the user can configure        |
| Cache-load fallback for empty SizeExpr                                   | When `size_expr.nodes.empty()` (offline-cache hit, symbolic tree not serialised) the host-eval path uses `max_size_compile_time` with the same `max(_, 1)` lower clamp the shader applies                                              | Identical to shader behaviour                                                                      |
| `ProgramImpl` / program back-reference                                   | LLVM host-eval branch now guards on `program_impl_ != nullptr` before dereferencing `program_impl_->program` (P1 review fix); SPIR-V path's existing `QD_ASSERT_INFO` precondition is unchanged                                       | C++-only-tests setups fall back to compile-time bounds rather than crashing                        |