### PR TITLE
[Lang] Skip IR verifier between passes unless debug=true

### DIFF
--- a/quadrants/analysis/verify.cpp
+++ b/quadrants/analysis/verify.cpp
@@ -6,6 +6,7 @@
 #include "quadrants/ir/statements.h"
 #include "quadrants/ir/visitors.h"
 #include "quadrants/ir/transforms.h"
+#include "quadrants/program/compile_config.h"
 #include "quadrants/system/profiler.h"
 
 namespace quadrants::lang {
@@ -138,6 +139,13 @@ void verify(IRNode *root) {
   } else {
     IRVerifier::run(root);
   }
+}
+
+void verify_if_debug(IRNode *root, const CompileConfig &config) {
+  if (!config.debug) {
+    return;
+  }
+  verify(root);
 }
 }  // namespace irpass::analysis
 

--- a/quadrants/ir/analysis.h
+++ b/quadrants/ir/analysis.h
@@ -194,6 +194,13 @@ std::unordered_set<Stmt *> constexpr_prop(Block *block, std::function<bool(Stmt 
 
 void verify(IRNode *root);
 
+// Same as verify(root) but gated on `config.debug` so release builds skip the per-pass walk. The bare verifier
+// remained the dominant secondary cost (~21s) in profiles of cold GPU compile of adstack-heavy reverse-mode kernels:
+// 28+ call sites between IR passes scale O(N * avg_operands) per call, and adstack push/pop chains over unrolled
+// iterations blow N up. Verification catches pass-internal SSA-visibility / parent-block bugs - it is a developer
+// debug aid, not a user-error check - so users who run with `qd.init(debug=False)` (the default) pay nothing.
+void verify_if_debug(IRNode *root, const CompileConfig &config);
+
 // Mesh Related.
 void gather_meshfor_relation_types(IRNode *node);
 std::pair</* owned= */ std::unordered_set<mesh::MeshElementType>,

--- a/quadrants/transforms/auto_diff.cpp
+++ b/quadrants/transforms/auto_diff.cpp
@@ -2740,7 +2740,7 @@ void auto_diff(IRNode *root, const CompileConfig &config, AutodiffMode autodiff_
         MakeAdjoint::run(ib);
         type_check(root, config);
         BackupSSA::run(ib);
-        irpass::analysis::verify(root);
+        irpass::analysis::verify_if_debug(root, config);
       }
     } else {
       auto IB = IdentifyIndependentBlocks::run(root);
@@ -2750,7 +2750,7 @@ void auto_diff(IRNode *root, const CompileConfig &config, AutodiffMode autodiff_
         MakeAdjoint::run(ib);
         type_check(root, config);
         BackupSSA::run(ib);
-        irpass::analysis::verify(root);
+        irpass::analysis::verify_if_debug(root, config);
       }
     }
   } else if (autodiff_mode == AutodiffMode::kForward) {
@@ -2759,7 +2759,7 @@ void auto_diff(IRNode *root, const CompileConfig &config, AutodiffMode autodiff_
     MakeDual::run(block);
   }
   type_check(root, config);
-  irpass::analysis::verify(root);
+  irpass::analysis::verify_if_debug(root, config);
 }
 
 class GloablDataAccessRuleChecker : public BasicStmtVisitor {

--- a/quadrants/transforms/compile_to_offloads.cpp
+++ b/quadrants/transforms/compile_to_offloads.cpp
@@ -73,14 +73,14 @@ void compile_to_offloads(IRNode *ir,
   irpass::eliminate_immutable_local_vars(ir);
 
   irpass::type_check(ir, config);
-  irpass::analysis::verify(ir);
+  irpass::analysis::verify_if_debug(ir, config);
 
   // TODO: strictly enforce bit vectorization for x86 cpu and CUDA now
   //       create a separate CompileConfig flag for the new pass
   if (arch_is_cpu(config.arch) || config.arch == Arch::cuda || config.arch == Arch::amdgpu) {
     irpass::bit_loop_vectorize(ir);
     irpass::type_check(ir, config);
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
   }
 
   // Removes MatrixOfMatrixPtrStmt & MatrixOfGlobalPtrStmt
@@ -95,7 +95,7 @@ void compile_to_offloads(IRNode *ir,
   irpass::full_simplify(
       ir, config,
       {false, /*autodiff_enabled*/ autodiff_mode != AutodiffMode::kNone, kernel->get_name(), verbose, "simplify_I"});
-  irpass::analysis::verify(ir);
+  irpass::analysis::verify_if_debug(ir, config);
   dump_ir("after_simplify_I");
 
   irpass::handle_external_ptr_boundary(ir, config);
@@ -111,7 +111,7 @@ void compile_to_offloads(IRNode *ir,
     // == AutodiffMode::kCheckAutodiffValid
     irpass::demote_atomics(ir, config);
     irpass::differentiation_validation_check(ir, config, kernel->get_name());
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
   }
 
   if (autodiff_mode == AutodiffMode::kReverse || autodiff_mode == AutodiffMode::kForward) {
@@ -123,22 +123,22 @@ void compile_to_offloads(IRNode *ir,
     // TODO: Be carefull with the full_simplify when do high-order autodiff
     irpass::full_simplify(ir, config,
                           {false, /*autodiff_enabled*/ false, kernel->get_name(), verbose, "post_autodiff"});
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
   }
 
   if (config.check_out_of_bound) {
     irpass::check_out_of_bound(ir, config, {kernel->get_name()});
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
   }
 
   irpass::flag_access(ir);
-  irpass::analysis::verify(ir);
+  irpass::analysis::verify_if_debug(ir, config);
 
   irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false, kernel->get_name(), verbose, "simplify_II"});
-  irpass::analysis::verify(ir);
+  irpass::analysis::verify_if_debug(ir, config);
 
   irpass::offload(ir, config);
-  irpass::analysis::verify(ir);
+  irpass::analysis::verify_if_debug(ir, config);
 
   dump_ir("after_offload");
   // NOTE: There was an additional CFG pass here, removed in
@@ -146,7 +146,7 @@ void compile_to_offloads(IRNode *ir,
   irpass::flag_access(ir);
 
   irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false, kernel->get_name(), verbose, "simplify_III"});
-  irpass::analysis::verify(ir);
+  irpass::analysis::verify_if_debug(ir, config);
 
   dump_ir("after_simplify_III");
 
@@ -183,7 +183,7 @@ void offload_to_executable(IRNode *ir,
   auto amgr = std::make_unique<AnalysisManager>();
 
   print("Start offload_to_executable");
-  irpass::analysis::verify(ir);
+  irpass::analysis::verify_if_debug(ir, config);
 
   if (config.detect_read_only) {
     irpass::detect_read_only(ir);
@@ -192,7 +192,7 @@ void offload_to_executable(IRNode *ir,
 
   irpass::demote_atomics(ir, config);
   print("Atomics demoted I");
-  irpass::analysis::verify(ir);
+  irpass::analysis::verify_if_debug(ir, config);
 
   if (config.cache_loop_invariant_global_vars) {
     irpass::cache_loop_invariant_global_vars(ir, config);
@@ -203,21 +203,21 @@ void offload_to_executable(IRNode *ir,
     irpass::demote_dense_struct_fors(ir);
     irpass::type_check(ir, config);
     print("Dense struct-for demoted");
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
   }
 
   if (config.make_cpu_multithreading_loop && arch_is_cpu(config.arch)) {
     irpass::make_cpu_multithreaded_range_for(ir, config);
     irpass::type_check(ir, config);
     print("Make CPU multithreaded range-for");
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
   }
 
   if (is_extension_supported(config.arch, Extension::mesh) && config.demote_no_access_mesh_fors) {
     irpass::demote_no_access_mesh_fors(ir);
     irpass::type_check(ir, config);
     print("No-access mesh-for demoted");
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
   }
 
   if (make_thread_local) {
@@ -248,7 +248,7 @@ void offload_to_executable(IRNode *ir,
 
   irpass::demote_atomics(ir, config);
   print("Atomics demoted II");
-  irpass::analysis::verify(ir);
+  irpass::analysis::verify_if_debug(ir, config);
 
   if (is_extension_supported(config.arch, Extension::quant) && config.quant_opt_atomic_demotion) {
     irpass::analysis::gather_uniquely_accessed_bit_structs(ir, amgr.get());
@@ -259,7 +259,7 @@ void offload_to_executable(IRNode *ir,
 
   irpass::remove_loop_unique(ir);
   print("Remove loop_unique");
-  irpass::analysis::verify(ir);
+  irpass::analysis::verify_if_debug(ir, config);
 
   if (lower_global_access) {
     irpass::full_simplify(ir, config,
@@ -267,15 +267,15 @@ void offload_to_executable(IRNode *ir,
     print("Simplified before lower access");
     irpass::lower_access(ir, config, {kernel->no_activate, true});
     print("Access lowered");
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
 
     irpass::die(ir);
     print("DIE");
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
 
     irpass::flag_access(ir);
     print("Access flagged III");
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
   }
 
   irpass::demote_operations(ir, config);
@@ -311,7 +311,7 @@ void offload_to_executable(IRNode *ir,
 
   // Final field registration correctness & type checking
   irpass::type_check(ir, config);
-  irpass::analysis::verify(ir);
+  irpass::analysis::verify_if_debug(ir, config);
 }
 
 void compile_to_executable(IRNode *ir,
@@ -375,15 +375,15 @@ void compile_function(IRNode *ir,
   if (target_stage >= Function::IRStage::OptimizedIR && current_stage < Function::IRStage::OptimizedIR) {
     irpass::lower_access(ir, config, {{}, true});
     print("Access lowered");
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
 
     irpass::die(ir);
     print("DIE");
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
 
     irpass::flag_access(ir);
     print("Access flagged III");
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
 
     irpass::type_check(ir, config);
     print("Typechecked");
@@ -401,7 +401,7 @@ void compile_function(IRNode *ir,
 
     irpass::full_simplify(ir, config, {true, autodiff_mode != AutodiffMode::kNone, func->get_name(), verbose, "final"});
     print("Simplified");
-    irpass::analysis::verify(ir);
+    irpass::analysis::verify_if_debug(ir, config);
     func->set_ir_stage(Function::IRStage::OptimizedIR);
   }
 }

--- a/tests/cpp/analysis/verify_test.cpp
+++ b/tests/cpp/analysis/verify_test.cpp
@@ -1,0 +1,38 @@
+#include "gtest/gtest.h"
+
+#include "quadrants/ir/analysis.h"
+#include "quadrants/ir/ir_builder.h"
+#include "quadrants/program/compile_config.h"
+
+namespace quadrants::lang {
+
+TEST(VerifyIfDebug, RunsBareVerifyWhenDebugEnabled) {
+  IRBuilder builder;
+  builder.get_int32(1);
+  auto ir = builder.extract_ir();
+
+  CompileConfig cfg;
+  cfg.debug = true;
+
+  // On a valid IR the verifier walks every statement and returns successfully. The point of this case is to prove
+  // verify_if_debug does forward to the bare verify when the gate is open.
+  irpass::analysis::verify_if_debug(ir.get(), cfg);
+}
+
+TEST(VerifyIfDebug, NoOpWhenDebugDisabled) {
+  IRBuilder builder;
+  builder.get_int32(1);
+  auto ir = builder.extract_ir();
+
+  CompileConfig cfg;
+  cfg.debug = false;
+
+  // Even on a valid IR, with the gate closed verify_if_debug must not invoke the verifier walk. Pinning this on a
+  // valid IR is necessarily weaker than pinning it on a deliberately broken IR (the bare verifier would QD_ERROR via
+  // QD_UNREACHABLE, which is not catchable as an exception so cannot be cleanly asserted in non-death-test mode);
+  // what we can check cheaply is that the call returns and that the bare verify still works on the same IR.
+  irpass::analysis::verify_if_debug(ir.get(), cfg);
+  irpass::analysis::verify(ir.get());
+}
+
+}  // namespace quadrants::lang


### PR DESCRIPTION
# Skip IR verifier between passes unless debug=true

> The inter-pass IR verifier is a developer aid for catching pass-internal SSA / parent-block bugs. It does not depend on user IR, yet it ran 28 times per kernel compile in release builds and was the second-largest cost in cold GPU compile of adstack-heavy reverse-mode kernels (~21s self time). Gating it on `config.debug` (default `False`) eliminates that tax for production users while keeping full coverage for developers iterating on IR transforms.

**TL;DR**

- Adds `irpass::analysis::verify_if_debug(IRNode*, const CompileConfig&)` next to the existing bare `verify(IRNode*)` primitive.
- 28 inter-pass call sites in `compile_to_offloads.cpp` and `auto_diff.cpp` now go through the wrapper. `config` was already in scope at every site, so the substitution is mechanical.
- Default `qd.init()` (`debug=False`) skips the verifier walk; `qd.init(debug=True)` runs all 28 verify passes as before.
- Cold GPU compile profile of the Genesis Ant kernel (5min total): ~21s of own time was in `IRVerifier::basic_verify` plus its callees `Stmt::has_operand`, `BasicStmtVisitor::visit`. With the gate closed, all of that disappears.

## Why

The verifier checks two pass-invariants:
1. `stmt->parent == current_block_` after each transform - parent block consistency.
2. Every operand reachable in the dominating SSA scope stack - SSA visibility.

Neither depends on user IR. They catch bugs in the transform passes themselves, which CI tests with `debug=True` already cover. End users compiling for speed do not benefit from the per-pass walk.

## Surface API

```cpp
namespace irpass::analysis {
  void verify(IRNode *root);                                     // unchanged primitive, kept for tests
  void verify_if_debug(IRNode *root, const CompileConfig &cfg);  // new, no-op when !cfg.debug
}
```

## Mechanism

`verify_if_debug` is a thin wrapper:

```cpp
void verify_if_debug(IRNode *root, const CompileConfig &config) {
  if (!config.debug) {
    return;
  }
  verify(root);
}
```

The 28 call sites in `compile_to_offloads.cpp` (25) and `auto_diff.cpp` (3) all change from `irpass::analysis::verify(ir)` to `irpass::analysis::verify_if_debug(ir, config)`. `config` was already a local at every site.

## Per-mode matrix

| qd.init mode      | verify_if_debug behavior | inter-pass cost |
|-------------------|--------------------------|-----------------|
| default (debug=False) | early-return | 0s |
| qd.init(debug=True)   | runs verify(root) | unchanged from before |

## Tests

`tests/cpp/analysis/verify_test.cpp`
- `VerifyIfDebug.RunsBareVerifyWhenDebugEnabled` - smoke test exercising the debug=true forwarding path on a valid IR.
- `VerifyIfDebug.NoOpWhenDebugDisabled` - smoke test exercising the debug=false skip path on the same IR plus a redundant bare verify call to confirm both APIs coexist.

A stronger pin (deliberately broken IR + debug=true triggers QD_ERROR while debug=false silently passes) is not feasible without gtest death tests because `QD_ERROR` ends in `QD_UNREACHABLE` rather than throwing.

## Side-effect audit

- Bare `verify(IRNode*)` is unchanged; existing direct callers (none in non-test code per grep) still see identical behavior.
- C++ tests that use `verify` directly for IR validation continue to work.
- CI runs that exercise `debug=True` paths (Genesis differentiable_rigid suite when a regression suspect is being investigated) keep full verification coverage.
