### PR TITLE
[CUDA] Honor offline_cache=False end-to-end so QD_OFFLINE_CACHE=0 actually gives a cold compile

### DIFF
--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -55,6 +55,7 @@ tile16
 
 graph
 perf_dispatch
+init_options
 ```
 
 ```{toctree}

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -10,16 +10,16 @@ Whether the compilation caches **persist on disk across Python invocations**. De
 
 Setting `offline_cache=False` is intended to emulate cold-start, i.e. a fresh Python process with no prior on-disk artifacts available. In-process caches operate independently of this flag: within a single Python session, identical kernels are never recompiled. The flag therefore controls only whether the next Python invocation observes a warm or a cold disk.
 
-When `offline_cache=True`, three persistent layers cooperate. The first two share the cache directory configured by `offline_cache_file_path` (default `~/.cache/quadrants`); the third is owned by libcuda and lives outside that path.
+When `offline_cache=True`, three persistent layers cooperate. The first two share the cache directory configured by `offline_cache_file_path` (default `~/.cache/quadrants/qdcache`); the third is owned by libcuda and lives outside that path.
 
 1. The cross-backend kernel-IR / compiled-kernel cache (driven by `KernelCompilationManager`). When the IR-and-config hash hits, the previously compiled kernel data is loaded from disk and the entire compile pipeline is skipped. Active for every backend (CPU, CUDA, AMDGPU, Metal, Vulkan).
-2. The CUDA per-arch PTX cache, written under `<offline_cache_file_path>/ptx_cache_sm_*` (driven by `PtxCache`). When the LLVM-IR hash hits, the previously emitted PTX is loaded from disk and `ptxas` is skipped.
-3. The NVIDIA driver compute cache at `~/.nv/ComputeCache`, keyed by PTX content hash. When this hits, even `ptxas` work that the per-arch PTX cache would have triggered is skipped because the SASS itself is reused. This cache is owned by libcuda and not by Quadrants.
+2. The CUDA per-arch PTX cache, written under `<offline_cache_file_path>/ptx_cache_sm_*` (driven by `PtxCache`). When the LLVM-IR hash hits, the previously emitted PTX is loaded from disk and the LLVM-to-PTX compilation pipeline (LLVM optimization passes plus the NVPTX backend's PTX emission) is skipped. `ptxas` itself runs later inside `cuModuleLoadDataEx` and is governed by Layer 3.
+3. The NVIDIA driver compute cache at `~/.nv/ComputeCache`, keyed by PTX content hash. When this hits, `ptxas` work is skipped because the SASS itself is reused. This cache is owned by libcuda and not by Quadrants.
 
 Setting `offline_cache=False` (or `QD_OFFLINE_CACHE=0`) disables every disk-persistent layer so a fresh Python session sees a true cold start:
 
-- Layer 1 falls back to memory-only. The kernel-IR cache is not consulted on construction and not written on shutdown, so kernels are compiled from source on every Python invocation.
-- Layer 2 falls back to memory-only. PTX is still cached within one process so kernels with identical LLVM IR share `ptxas` output, but nothing is read from or written to disk.
+- Layer 1 falls back to memory-only. The disk cache is not consulted for kernel data and new kernels are not persisted, so kernels are compiled from source on every Python invocation.
+- Layer 2 falls back to memory-only. PTX is still cached within one process so kernels with identical LLVM IR share PTX output, but nothing is read from or written to disk.
 - Layer 3 cannot be controlled by the libcuda environment variable `CUDA_CACHE_DISABLE` from inside Python because the variable is captured by libcuda at process start. Quadrants instead appends a per-process nonce comment to the PTX it submits to `cuModuleLoadDataEx`. The nonce is constant within one process - kernels with identical PTX still share a cubin in the same run - and changes between processes so cross-run hits cannot quietly serve stale SASS.
 
 When to set it to `False`:

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -8,7 +8,7 @@
 
 Whether the compilation caches **persist on disk across Python invocations**. Default `True`. The "offline" in the name refers to the fact that this cache outlives the process: it is what makes the *second* time you start a Python interpreter and run a kernel cheap, by reusing artifacts from the first run.
 
-Setting `offline_cache=False` is intended to emulate cold-start, where a "cold start" denotes a fresh Python process with no prior on-disk artifacts available. In-process caches operate independently of this flag: within a single Python session, identical kernels are never recompiled. The flag therefore controls only whether the next Python invocation observes a warm or a cold disk.
+Setting `offline_cache=False` is intended to emulate cold-start, i.e. a fresh Python process with no prior on-disk artifacts available. In-process caches operate independently of this flag: within a single Python session, identical kernels are never recompiled. The flag therefore controls only whether the next Python invocation observes a warm or a cold disk.
 
 When `offline_cache=True`, three persistent layers cooperate:
 

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -1,6 +1,6 @@
 # qd.init options
 
-`qd.init(...)` accepts every field of the underlying `CompileConfig` struct as a keyword argument; the same fields are also reachable as environment variables of the form `QD_<UPPERCASE_NAME>` (e.g. `QD_OFFLINE_CACHE=0`). This page covers some of the knobs that are commonly tuned in practice, with a focus on options whose behavior was changed or added recently. The underlying source of truth is `quadrants/program/compile_config.h`.
+`qd.init(...)` accepts every field of the underlying `CompileConfig` struct as a keyword argument; the same fields are also reachable as environment variables of the form `QD_<UPPERCASE_NAME>` (e.g. `QD_OFFLINE_CACHE=0`). This page covers some of the knobs that are commonly tuned in practice. The underlying source of truth is `quadrants/program/compile_config.h`.
 
 ## Caching
 

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -1,20 +1,28 @@
 # qd.init options
 
-`qd.init(...)` accepts every field of the underlying `CompileConfig` struct as a keyword argument; the same fields are also reachable as environment variables of the form `QD_<UPPERCASE_NAME>` (e.g. `QD_OFFLINE_CACHE=0`). This page collects the knobs Genesis or downstream users reach for in practice. The underlying source of truth is `quadrants/program/compile_config.h`.
+`qd.init(...)` accepts every field of the underlying `CompileConfig` struct as a keyword argument; the same fields are also reachable as environment variables of the form `QD_<UPPERCASE_NAME>` (e.g. `QD_OFFLINE_CACHE=0`). This page covers some of the knobs that are commonly tuned in practice, with a focus on options whose behavior was changed or added recently. The underlying source of truth is `quadrants/program/compile_config.h`.
 
 ## Caching
 
 ### `offline_cache`
 
-Whether to read and write the on-disk kernel cache. Default `True`.
+Whether to read and write the on-disk caches that let successive runs skip recompilation. Default `True`.
 
-`offline_cache=False` (or `QD_OFFLINE_CACHE=0`) takes effect at two layers on CUDA so successive runs really do recompile from scratch:
+When enabled, three layers cooperate to make the second run of the same kernel cheap:
 
-1. The Quadrants kernel-IR cache and the per-arch PTX cache under `~/.cache/quadrants/.../ptx_cache_sm_*` are not consulted and not written.
-2. The NVIDIA driver compute cache at `~/.nv/ComputeCache` is keyed by PTX content hash. Because `CUDA_CACHE_DISABLE` is captured by libcuda at process start (so toggling it from inside Python has no effect), Quadrants instead appends a per-process nonce comment to the PTX it submits to `cuModuleLoadDataEx`. The nonce is constant within one process - kernels with identical PTX still share a cubin in the same run - and changes between processes so cross-run hits cannot quietly serve stale SASS.
+1. The cross-backend kernel-IR / compiled-kernel cache under `~/.cache/quadrants` (driven by `KernelCompilationManager`). When the IR-and-config hash hits, the previously compiled kernel data is loaded and the entire compile pipeline is skipped. Active for every backend (CPU, CUDA, AMDGPU, Metal, Vulkan).
+2. The CUDA per-arch PTX cache under `~/.cache/quadrants/.../ptx_cache_sm_*` (driven by `PtxCache`). When the LLVM-IR hash hits, the previously emitted PTX is loaded and `ptxas` is skipped.
+3. The NVIDIA driver compute cache at `~/.nv/ComputeCache`, keyed by PTX content hash. When this hits, even `ptxas` work that the per-arch PTX cache would have triggered is skipped because the SASS itself is reused. This cache is owned by libcuda and not by Quadrants.
+
+When `offline_cache=False` (or `QD_OFFLINE_CACHE=0`):
+
+- Layer 1 falls back to memory-only. The kernel-IR cache is not consulted on construction and not written on shutdown, so kernels are compiled from source on every run.
+- Layer 2 falls back to memory-only. PTX is still cached within one process so kernels with identical LLVM IR share `ptxas` output, but nothing is read from or written to disk.
+- Layer 3 cannot be controlled by the libcuda environment variable `CUDA_CACHE_DISABLE` from inside Python because the variable is captured by libcuda at process start. Quadrants instead appends a per-process nonce comment to the PTX it submits to `cuModuleLoadDataEx`. The nonce is constant within one process - kernels with identical PTX still share a cubin in the same run - and changes between processes so cross-run hits cannot quietly serve stale SASS.
 
 When to use it:
 - Taking compile-time profiles where any cached SASS would mask the real cost.
 - Investigating a stale-cache bug or suspected cache corruption.
+- Reproducing first-run behavior in CI matrix runs that would otherwise warm the caches across iterations.
 
-For normal use, leave it at `True`; the cache is the dominant source of fast warm-up.
+For normal use, leave it at `True`; the cache layers are the dominant source of fast warm-up.

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -1,6 +1,6 @@
 # qd.init options
 
-`qd.init(...)` accepts every field of the underlying `CompileConfig` struct as a keyword argument; the same fields are also reachable as environment variables of the form `QD_<UPPERCASE_NAME>` (e.g. `QD_OFFLINE_CACHE=0`). This page covers some of the knobs that are commonly tuned in practice. The underlying source of truth is `quadrants/program/compile_config.h`.
+`qd.init(...)` accepts every field of the underlying `CompileConfig` struct as a keyword argument; the same fields are also reachable as environment variables of the form `QD_<UPPERCASE_NAME>` (e.g. `QD_OFFLINE_CACHE=0`). This page covers some of the knobs that are commonly tuned in practice. The underlying source of truth is [`quadrants/program/compile_config.h`](https://github.com/Genesis-Embodied-AI/quadrants/blob/main/quadrants/program/compile_config.h).
 
 ## Caching
 

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -10,10 +10,10 @@ Whether the compilation caches **persist on disk across Python invocations**. De
 
 Setting `offline_cache=False` is intended to emulate cold-start, i.e. a fresh Python process with no prior on-disk artifacts available. In-process caches operate independently of this flag: within a single Python session, identical kernels are never recompiled. The flag therefore controls only whether the next Python invocation observes a warm or a cold disk.
 
-When `offline_cache=True`, three persistent layers cooperate:
+When `offline_cache=True`, three persistent layers cooperate. The first two share the cache directory configured by `offline_cache_file_path` (default `~/.cache/quadrants`); the third is owned by libcuda and lives outside that path.
 
-1. The cross-backend kernel-IR / compiled-kernel cache under `~/.cache/quadrants` (driven by `KernelCompilationManager`). When the IR-and-config hash hits, the previously compiled kernel data is loaded from disk and the entire compile pipeline is skipped. Active for every backend (CPU, CUDA, AMDGPU, Metal, Vulkan).
-2. The CUDA per-arch PTX cache under `~/.cache/quadrants/.../ptx_cache_sm_*` (driven by `PtxCache`). When the LLVM-IR hash hits, the previously emitted PTX is loaded from disk and `ptxas` is skipped.
+1. The cross-backend kernel-IR / compiled-kernel cache (driven by `KernelCompilationManager`). When the IR-and-config hash hits, the previously compiled kernel data is loaded from disk and the entire compile pipeline is skipped. Active for every backend (CPU, CUDA, AMDGPU, Metal, Vulkan).
+2. The CUDA per-arch PTX cache, written under `<offline_cache_file_path>/ptx_cache_sm_*` (driven by `PtxCache`). When the LLVM-IR hash hits, the previously emitted PTX is loaded from disk and `ptxas` is skipped.
 3. The NVIDIA driver compute cache at `~/.nv/ComputeCache`, keyed by PTX content hash. When this hits, even `ptxas` work that the per-arch PTX cache would have triggered is skipped because the SASS itself is reused. This cache is owned by libcuda and not by Quadrants.
 
 Setting `offline_cache=False` (or `QD_OFFLINE_CACHE=0`) disables every disk-persistent layer so a fresh Python session sees a true cold start:

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -28,3 +28,27 @@ When to set it to `False`:
 - Reproducing first-run behavior in CI matrix runs that would otherwise warm the caches across iterations.
 
 For normal use, leave it at `True`; the cache layers are the dominant source of fast warm-up.
+
+## Compile-time tuning
+
+### `cfg_optimization`
+
+Whether to run the control-flow-graph optimization pass. Default `True`. Setting it to `False` makes compilation up to 6x faster while costing 1-5% of runtime speed; consider disabling it if compile time is the bottleneck and the runtime delta is acceptable.
+
+### `fast_math`
+
+Whether to enable IEEE-relaxed floating-point optimizations (FMA fusion, no NaN / infinity / signed-zero guarantees). Default `True`. Disable when investigating numerical anomalies or running deterministic-tolerance tests.
+
+### `num_compile_threads`
+
+Number of host threads used when compiling kernels. Default `4`. Raise on machines with many idle cores compiling many kernels back-to-back; lower (or set to `1`) on memory-pressure-bound systems where concurrent LLVM compilations thrash.
+
+## Debugging
+
+### `debug`
+
+Enables IR verification between every compiler pass plus additional runtime checks (integer-overflow guards on arithmetic, linear-index overflow guards on tensor indexing, adstack push-bounds at the runtime helper level). Default `False`. Compile time slows substantially because the verifier walks the IR after every transform and the extra runtime checks expand the emitted code; ~21s additional has been observed on adstack-heavy kernels. Turn this on while iterating on a kernel that is producing incorrect numerics or while developing a new compiler pass; turn it back off once the bug is found.
+
+### `check_out_of_bound`
+
+Enables runtime bounds-checking for tensor indexing. Default `False`. Costs runtime performance proportional to indexing density; leave off for benchmarks. Backends that do not expose the `assertion` extension (currently Metal and Vulkan) cannot honor this flag.

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -1,0 +1,20 @@
+# qd.init options
+
+`qd.init(...)` accepts every field of the underlying `CompileConfig` struct as a keyword argument; the same fields are also reachable as environment variables of the form `QD_<UPPERCASE_NAME>` (e.g. `QD_OFFLINE_CACHE=0`). This page collects the knobs Genesis or downstream users reach for in practice. The underlying source of truth is `quadrants/program/compile_config.h`.
+
+## Caching
+
+### `offline_cache`
+
+Whether to read and write the on-disk kernel cache. Default `True`.
+
+`offline_cache=False` (or `QD_OFFLINE_CACHE=0`) takes effect at two layers on CUDA so successive runs really do recompile from scratch:
+
+1. The Quadrants kernel-IR cache and the per-arch PTX cache under `~/.cache/quadrants/.../ptx_cache_sm_*` are not consulted and not written.
+2. The NVIDIA driver compute cache at `~/.nv/ComputeCache` is keyed by PTX content hash. Because `CUDA_CACHE_DISABLE` is captured by libcuda at process start (so toggling it from inside Python has no effect), Quadrants instead appends a per-process nonce comment to the PTX it submits to `cuModuleLoadDataEx`. The nonce is constant within one process - kernels with identical PTX still share a cubin in the same run - and changes between processes so cross-run hits cannot quietly serve stale SASS.
+
+When to use it:
+- Taking compile-time profiles where any cached SASS would mask the real cost.
+- Investigating a stale-cache bug or suspected cache corruption.
+
+For normal use, leave it at `True`; the cache is the dominant source of fast warm-up.

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -6,21 +6,23 @@
 
 ### `offline_cache`
 
-Whether to read and write the on-disk caches that let successive runs skip recompilation. Default `True`.
+Whether the compilation caches **persist on disk across Python invocations**. Default `True`. The "offline" in the name refers to the fact that this cache outlives the process: it is what makes the *second* time you start a Python interpreter and run a kernel cheap, by reusing artifacts from the first run.
 
-When enabled, three layers cooperate to make the second run of the same kernel cheap:
+Setting `offline_cache=False` is intended to emulate cold-start, where a "cold start" denotes a fresh Python process with no prior on-disk artifacts available. In-process caches operate independently of this flag: within a single Python session, identical kernels are never recompiled. The flag therefore controls only whether the next Python invocation observes a warm or a cold disk.
 
-1. The cross-backend kernel-IR / compiled-kernel cache under `~/.cache/quadrants` (driven by `KernelCompilationManager`). When the IR-and-config hash hits, the previously compiled kernel data is loaded and the entire compile pipeline is skipped. Active for every backend (CPU, CUDA, AMDGPU, Metal, Vulkan).
-2. The CUDA per-arch PTX cache under `~/.cache/quadrants/.../ptx_cache_sm_*` (driven by `PtxCache`). When the LLVM-IR hash hits, the previously emitted PTX is loaded and `ptxas` is skipped.
+When `offline_cache=True`, three persistent layers cooperate:
+
+1. The cross-backend kernel-IR / compiled-kernel cache under `~/.cache/quadrants` (driven by `KernelCompilationManager`). When the IR-and-config hash hits, the previously compiled kernel data is loaded from disk and the entire compile pipeline is skipped. Active for every backend (CPU, CUDA, AMDGPU, Metal, Vulkan).
+2. The CUDA per-arch PTX cache under `~/.cache/quadrants/.../ptx_cache_sm_*` (driven by `PtxCache`). When the LLVM-IR hash hits, the previously emitted PTX is loaded from disk and `ptxas` is skipped.
 3. The NVIDIA driver compute cache at `~/.nv/ComputeCache`, keyed by PTX content hash. When this hits, even `ptxas` work that the per-arch PTX cache would have triggered is skipped because the SASS itself is reused. This cache is owned by libcuda and not by Quadrants.
 
-When `offline_cache=False` (or `QD_OFFLINE_CACHE=0`):
+Setting `offline_cache=False` (or `QD_OFFLINE_CACHE=0`) disables every disk-persistent layer so a fresh Python session sees a true cold start:
 
-- Layer 1 falls back to memory-only. The kernel-IR cache is not consulted on construction and not written on shutdown, so kernels are compiled from source on every run.
+- Layer 1 falls back to memory-only. The kernel-IR cache is not consulted on construction and not written on shutdown, so kernels are compiled from source on every Python invocation.
 - Layer 2 falls back to memory-only. PTX is still cached within one process so kernels with identical LLVM IR share `ptxas` output, but nothing is read from or written to disk.
 - Layer 3 cannot be controlled by the libcuda environment variable `CUDA_CACHE_DISABLE` from inside Python because the variable is captured by libcuda at process start. Quadrants instead appends a per-process nonce comment to the PTX it submits to `cuModuleLoadDataEx`. The nonce is constant within one process - kernels with identical PTX still share a cubin in the same run - and changes between processes so cross-run hits cannot quietly serve stale SASS.
 
-When to use it:
+When to set it to `False`:
 - Taking compile-time profiles where any cached SASS would mask the real cost.
 - Investigating a stale-cache bug or suspected cache corruption.
 - Reproducing first-run behavior in CI matrix runs that would otherwise warm the caches across iterations.

--- a/docs/source/user_guide/troubleshooting.md
+++ b/docs/source/user_guide/troubleshooting.md
@@ -10,6 +10,13 @@ To run without cache:
 qd.init(offline_cache=False, ...)
 ```
 
+On CUDA, `offline_cache=False` (or `QD_OFFLINE_CACHE=0`) takes effect at two layers so successive runs really do recompile from scratch:
+
+1. The Quadrants kernel-IR cache and the per-arch PTX cache under `~/.cache/quadrants/.../ptx_cache_sm_*` are not consulted and not written.
+2. The NVIDIA driver compute cache at `~/.nv/ComputeCache` is keyed by PTX content hash. Because `CUDA_CACHE_DISABLE` is captured by libcuda at process start (so toggling it from inside Python has no effect), Quadrants instead appends a per-process nonce comment to the PTX it submits to `cuModuleLoadDataEx`. The nonce is constant within one process - kernels with identical PTX still share a cubin in the same run - and changes between processes so cross-run hits cannot quietly serve stale SASS.
+
+Use this when taking compile-time profiles to make sure the numbers reflect a real cold compile and not a warm cache.
+
 To clear cache:
 - the cache is located by default on linux and mac at `~/.cache/quadrants`
 - simply remove this entire folder:

--- a/docs/source/user_guide/troubleshooting.md
+++ b/docs/source/user_guide/troubleshooting.md
@@ -10,12 +10,7 @@ To run without cache:
 qd.init(offline_cache=False, ...)
 ```
 
-On CUDA, `offline_cache=False` (or `QD_OFFLINE_CACHE=0`) takes effect at two layers so successive runs really do recompile from scratch:
-
-1. The Quadrants kernel-IR cache and the per-arch PTX cache under `~/.cache/quadrants/.../ptx_cache_sm_*` are not consulted and not written.
-2. The NVIDIA driver compute cache at `~/.nv/ComputeCache` is keyed by PTX content hash. Because `CUDA_CACHE_DISABLE` is captured by libcuda at process start (so toggling it from inside Python has no effect), Quadrants instead appends a per-process nonce comment to the PTX it submits to `cuModuleLoadDataEx`. The nonce is constant within one process - kernels with identical PTX still share a cubin in the same run - and changes between processes so cross-run hits cannot quietly serve stale SASS.
-
-Use this when taking compile-time profiles to make sure the numbers reflect a real cold compile and not a warm cache.
+See [qd.init options](init_options.md) for what `offline_cache=False` actually does on CUDA (it bypasses both the Quadrants PtxCache and the NVIDIA driver compute cache).
 
 To clear cache:
 - the cache is located by default on linux and mac at `~/.cache/quadrants`

--- a/quadrants/runtime/cuda/jit_cuda.cpp
+++ b/quadrants/runtime/cuda/jit_cuda.cpp
@@ -348,11 +348,26 @@ std::string JITSessionCUDA::compile_module_to_ptx(std::unique_ptr<llvm::Module> 
   }
 
   std::string buffer(outstr.begin(), outstr.end());
+  append_compute_cache_bypass_nonce_if_disabled(buffer, this->config_);
 
   // Null-terminate the ptx source
   buffer.push_back(0);
   ptx_cache_->store_ptx(ptx_cache_key, buffer);
   return buffer;
+}
+
+void append_compute_cache_bypass_nonce_if_disabled(std::string &ptx, const CompileConfig &compile_config) {
+  // CUDA_CACHE_DISABLE is captured at libcuda init time so it cannot be toggled mid-process; appending a per-session
+  // comment shifts the PTX hash that the driver compute cache uses, forcing ptxas to re-run cold. The nonce is
+  // `static` so that within one process every call sees the same value: two kernels in the same run that produce
+  // identical PTX still hit the driver cache and skip a second ptxas invocation, while only cross-process reuse is
+  // broken - the property needed for clean cold-cache measurements when offline_cache=false.
+  if (compile_config.offline_cache) {
+    return;
+  }
+  static const std::string session_nonce =
+      fmt::format("\n// quadrants-session-nonce: {}\n", static_cast<int64_t>(std::time(nullptr)));
+  ptx.append(session_nonce);
 }
 
 std::unique_ptr<JITSession> create_llvm_jit_session_cuda(QuadrantsLLVMContext *tlctx,

--- a/quadrants/runtime/cuda/jit_cuda.cpp
+++ b/quadrants/runtime/cuda/jit_cuda.cpp
@@ -1,3 +1,6 @@
+#include <chrono>
+#include <random>
+
 #include "quadrants/runtime/cuda/jit_cuda.h"
 #include "quadrants/runtime/llvm/llvm_context.h"
 #include "quadrants/codegen/ir_dump.h"
@@ -361,12 +364,17 @@ void append_compute_cache_bypass_nonce_if_disabled(std::string &ptx, const Compi
   // comment shifts the PTX hash that the driver compute cache uses, forcing ptxas to re-run cold. The nonce is
   // `static` so that within one process every call sees the same value: two kernels in the same run that produce
   // identical PTX still hit the driver cache and skip a second ptxas invocation, while only cross-process reuse is
-  // broken - the property needed for clean cold-cache measurements when offline_cache=false.
+  // broken - the property needed for clean cold-cache measurements when offline_cache=false. We mix a high-resolution
+  // timestamp with a random_device draw so back-to-back processes (CI matrix runs, `for i in {1..N}; do ./bench`)
+  // cannot collide on the same wall-clock second the way std::time(nullptr) would.
   if (compile_config.offline_cache) {
     return;
   }
-  static const std::string session_nonce =
-      fmt::format("\n// quadrants-session-nonce: {}\n", static_cast<int64_t>(std::time(nullptr)));
+  static const std::string session_nonce = []() {
+    auto now = std::chrono::system_clock::now().time_since_epoch().count();
+    auto entropy = std::random_device{}();
+    return fmt::format("\n// quadrants-session-nonce: {}-{:08x}\n", static_cast<int64_t>(now), entropy);
+  }();
   ptx.append(session_nonce);
 }
 

--- a/quadrants/runtime/cuda/jit_cuda.h
+++ b/quadrants/runtime/cuda/jit_cuda.h
@@ -88,6 +88,12 @@ class JITSessionCUDA : public JITSession {
   const CompileConfig &config_;
 };
 
+// Append a per-process nonce comment to `ptx` when `compile_config.offline_cache` is disabled, so the NVIDIA driver
+// compute cache (~/.nv/ComputeCache) - keyed by PTX content hash - cannot serve stale SASS across runs. The nonce is
+// constant within a single process, which preserves intra-run cache hits between kernels with identical PTX while
+// busting cross-run hits. PTX comments do not affect SASS codegen. No-op when offline_cache is true.
+void append_compute_cache_bypass_nonce_if_disabled(std::string &ptx, const CompileConfig &compile_config);
+
 #endif
 
 std::unique_ptr<JITSession> create_llvm_jit_session_cuda(QuadrantsLLVMContext *tlctx,

--- a/quadrants/runtime/cuda/ptx_cache.cpp
+++ b/quadrants/runtime/cuda/ptx_cache.cpp
@@ -56,6 +56,9 @@ PtxCache::PtxCache(const Config config, const CompileConfig &compile_config, int
       compute_capability_(compute_capability),
       cache_dir_(join_path(config_.offline_cache_path, fmt::format("ptx_cache_sm_{}", compute_capability_))) {
   QD_DEBUG("Create ptxcache with offline_cache_file_path = {}", this->cache_dir_);
+  if (get_cache_mode(compile_config_) != CacheMode::MemAndDiskCache) {
+    return;
+  }
   auto filepath = join_path(this->cache_dir_, kMetadataFilename);
   auto lock_path = join_path(this->cache_dir_, kMetadataLockName);
   if (path_exists(filepath)) {
@@ -70,6 +73,10 @@ PtxCache::PtxCache(const Config config, const CompileConfig &compile_config, int
 
 void PtxCache::dump() {
   if (wrapped_by_key_.empty()) {
+    return;
+  }
+  if (get_cache_mode(compile_config_) != CacheMode::MemAndDiskCache) {
+    wrapped_by_key_.clear();
     return;
   }
 
@@ -216,7 +223,7 @@ void PtxCache::store_ptx(const std::string &cache_key, const std::string &ptx) {
   k.metadata.cache_key = cache_key;
   k.metadata.created_at = k.metadata.last_used_at = std::time(nullptr);
   k.metadata.size = 0;  // Populate `size` within the PtxCache::dump()
-  k.metadata.cache_mode = CacheMode::MemAndDiskCache;
+  k.metadata.cache_mode = get_cache_mode(compile_config_);
   wrapped_by_key_[cache_key] = std::move(k);
 }
 
@@ -226,7 +233,7 @@ std::optional<std::string> PtxCache::load_ptx(const std::string &cache_key) {
 }
 
 CacheMode PtxCache::get_cache_mode(const CompileConfig &compile_config) {
-  return CacheMode::MemAndDiskCache;
+  return compile_config.offline_cache ? CacheMode::MemAndDiskCache : CacheMode::MemCache;
 }
 
 }  // namespace quadrants::lang

--- a/tests/cpp/runtime/cuda/jit_cuda_test.cpp
+++ b/tests/cpp/runtime/cuda/jit_cuda_test.cpp
@@ -1,0 +1,40 @@
+#include "gtest/gtest.h"
+
+#include "quadrants/program/compile_config.h"
+#include "quadrants/runtime/cuda/jit_cuda.h"
+
+namespace quadrants::lang {
+
+TEST(JitCudaSessionNonce, OfflineCacheEnabledLeavesPtxUntouched) {
+  CompileConfig compile_config;
+  compile_config.arch = Arch::cuda;
+  compile_config.offline_cache = true;
+
+  std::string ptx = ".version 7.0\n.target sm_80\n";
+  const std::string original = ptx;
+  append_compute_cache_bypass_nonce_if_disabled(ptx, compile_config);
+  EXPECT_EQ(original, ptx);
+}
+
+TEST(JitCudaSessionNonce, OfflineCacheDisabledAppendsStableNonce) {
+  CompileConfig compile_config;
+  compile_config.arch = Arch::cuda;
+  compile_config.offline_cache = false;
+
+  std::string ptx_a = ".version 7.0\n";
+  std::string ptx_b = ".version 7.0\n";
+
+  append_compute_cache_bypass_nonce_if_disabled(ptx_a, compile_config);
+  append_compute_cache_bypass_nonce_if_disabled(ptx_b, compile_config);
+
+  // Nonce was appended.
+  EXPECT_GT(ptx_a.size(), std::string(".version 7.0\n").size());
+  EXPECT_NE(ptx_a.find("quadrants-session-nonce"), std::string::npos);
+
+  // Two calls within the same process must produce identical output: the nonce is process-stable so kernels with
+  // identical PTX still hit the driver compute cache within one run. Cross-process reuse is broken instead, by the
+  // nonce changing between processes.
+  EXPECT_EQ(ptx_a, ptx_b);
+}
+
+}  // namespace quadrants::lang

--- a/tests/cpp/runtime/cuda/ptx_cache_test.cpp
+++ b/tests/cpp/runtime/cuda/ptx_cache_test.cpp
@@ -26,6 +26,7 @@ TEST(PtxCache, TestBasic) {
 
   CompileConfig compile_config;
   compile_config.arch = Arch::cuda;
+  compile_config.offline_cache = true;  // Exercises the disk-persistence path; mem-only path is covered separately.
 
   // Use a test compute capability value
   int compute_capability = 80;  // SM 8.0 for testing
@@ -92,6 +93,7 @@ TEST(PtxCache, TestSmVersionPartitioning) {
 
   CompileConfig compile_config;
   compile_config.arch = Arch::cuda;
+  compile_config.offline_cache = true;  // Exercises the disk-persistence path; mem-only path is covered separately.
 
   // Test with SM 8.0
   int compute_capability_80 = 80;

--- a/tests/cpp/runtime/cuda/ptx_cache_test.cpp
+++ b/tests/cpp/runtime/cuda/ptx_cache_test.cpp
@@ -137,4 +137,42 @@ TEST(PtxCache, TestSmVersionPartitioning) {
   ASSERT_EQ(ptx_code_75, ptx_cache_75->load_ptx(key_75));
 }
 
+TEST(PtxCache, OfflineCacheDisabledSkipsDisk) {
+  auto temp_dir = std::filesystem::temp_directory_path() / "PtxCache.OfflineCacheDisabledSkipsDisk";
+  std::filesystem::remove_all(temp_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(temp_dir));
+  struct DirCleaner {
+    std::filesystem::path path;
+    ~DirCleaner() {
+      std::filesystem::remove_all(path);
+    }
+  } dir_cleaner{temp_dir};
+
+  PtxCache::Config config;
+  config.offline_cache_path = temp_dir.string();
+
+  CompileConfig compile_config;
+  compile_config.arch = Arch::cuda;
+  compile_config.offline_cache = false;
+
+  int compute_capability = 80;
+  auto sm_dir = temp_dir / ("ptx_cache_sm_" + std::to_string(compute_capability));
+
+  auto ptx_cache = std::make_unique<PtxCache>(config, compile_config, compute_capability);
+  std::string key = ptx_cache->make_cache_key("ir", false);
+
+  // In-memory caching still works within a single instance.
+  ptx_cache->store_ptx(key, "ptx-payload");
+  ASSERT_EQ("ptx-payload", ptx_cache->load_ptx(key));
+
+  // dump() must not write anything to disk when the offline cache is disabled.
+  ptx_cache->dump();
+  EXPECT_FALSE(std::filesystem::exists(sm_dir))
+      << "ptx_cache_sm_* directory must not be created when offline_cache=false";
+
+  // A fresh instance pointed at the same temp dir must not observe the previous payload.
+  ptx_cache = std::make_unique<PtxCache>(config, compile_config, compute_capability);
+  EXPECT_EQ(std::nullopt, ptx_cache->load_ptx(key));
+}
+
 }  // namespace quadrants::lang


### PR DESCRIPTION
# Honor offline_cache=False end-to-end on the CUDA backend (plus a `qd.init` user-guide page)

> `QD_OFFLINE_CACHE=0` is supposed to disable on-disk kernel caching so users can take cold-compile measurements. On CUDA today it does not: two layers of caching survive the flag and silently serve cached compilation across runs. This PR closes both leaks. It also adds a new `init_options.md` user-guide page documenting the commonly-tuned `qd.init(...)` knobs (offline_cache, cfg_optimization, fast_math, num_compile_threads, debug, check_out_of_bound) - subsumes #581 which was reduced to docs-only after `cuda_jit_opt_level` was dropped (no measurable benefit on the integration profile).

**TL;DR**

- `PtxCache::get_cache_mode` hard-coded `MemAndDiskCache` and never consulted `compile_config.offline_cache`. Fixed: with `offline_cache=False`, the constructor skips loading prior metadata, `dump()` returns without writing, and `store_ptx` tags entries `MemCache` so the dump filter excludes them. In-process memory caching still works.
- The NVIDIA driver compute cache at `~/.nv/ComputeCache` is keyed by PTX content hash. `CUDA_CACHE_DISABLE` is captured at libcuda init time so it cannot be toggled after the Python interpreter has started. Workaround: when `offline_cache=False`, append a process-stable nonce comment to the PTX so the driver's content hash misses across runs but stays identical for kernels with identical PTX within one run.
- New `docs/source/user_guide/init_options.md` user-guide page (hooked into the user-guide index under Performance). Documents `offline_cache` plus the other commonly-tuned `qd.init(...)` knobs (`cfg_optimization`, `fast_math`, `num_compile_threads`, `debug`, `check_out_of_bound`). No code change for those knobs - just consolidating prose that did not have a single home before.

## Why

Mixed cache hits across runs were producing apparent ~5min cold compiles that were actually <30s warm compiles, hiding the real cost we wanted to profile. `CUDA_CACHE_DISABLE` cannot help mid-process - the driver caches the env var at `cuInit` time. The only in-process way to bypass the driver compute cache is to perturb the PTX hash itself.

## Mechanism

### PtxCache gating

Before:

```cpp
CacheMode PtxCache::get_cache_mode(const CompileConfig &compile_config) {
  return CacheMode::MemAndDiskCache;
}
```

After:

```cpp
CacheMode PtxCache::get_cache_mode(const CompileConfig &compile_config) {
  return compile_config.offline_cache ? CacheMode::MemAndDiskCache : CacheMode::MemCache;
}
```

Three call paths now consult this:
1. Constructor (`ptx_cache.cpp`) - skip loading metadata.tcb when not MemAndDiskCache.
2. `dump()` - early-return when not MemAndDiskCache (the per-entry filter at the loop already drops `MemCache` tagged entries, but skipping the lock acquisition is cleaner).
3. `store_ptx` - tag new entries with the current mode rather than always `MemAndDiskCache`.

### Driver compute cache bypass via PTX nonce

`compile_module_to_ptx` calls `append_compute_cache_bypass_nonce_if_disabled(buffer, config)` after assembling the PTX. The helper:

```cpp
void append_compute_cache_bypass_nonce_if_disabled(std::string &ptx, const CompileConfig &compile_config) {
  if (compile_config.offline_cache) {
    return;
  }
  static const std::string session_nonce =
      fmt::format("\n// quadrants-session-nonce: {}\n", static_cast<int64_t>(std::time(nullptr)));
  ptx.append(session_nonce);
}
```

The nonce is `static` so it is computed once per process. Two kernels in the same run that produce identical PTX still hit the driver cache and skip a second ptxas invocation; only cross-process reuse is broken, which is exactly the property needed for clean cold-cache measurements. PTX comments do not affect SASS codegen.

## Per-flag matrix

| offline_cache | PtxCache disk reads | PtxCache disk writes | Driver compute cache hits across runs |
|--------------|---------------------|----------------------|---------------------------------------|
| True (default)  | yes | yes | yes (unchanged) |
| False           | no  | no  | no (PTX hash differs per process)     |

## Tests

`tests/cpp/runtime/cuda/ptx_cache_test.cpp`
- `PtxCache.OfflineCacheDisabledSkipsDisk` - pins the PtxCache fix. With `offline_cache=False`: in-memory load still works, `dump()` does not create the `ptx_cache_sm_<cc>` directory, and a fresh instance returns nullopt for the previously-stored key. Fails on the unfixed tree (the `sm_dir` is created and the second instance loads from disk).

`tests/cpp/runtime/cuda/jit_cuda_test.cpp` (new file)
- `JitCudaSessionNonce.OfflineCacheEnabledLeavesPtxUntouched` - smoke-tests the no-op branch.
- `JitCudaSessionNonce.OfflineCacheDisabledAppendsStableNonce` - asserts the nonce is appended and that two calls within the same process produce identical output, directly pinning the documented intra-run cache hit / cross-run cache miss invariant.

## Side-effect audit

- Default `qd.init()` (offline_cache=True): all caching paths unchanged.
- `qd.init(offline_cache=False)` / `QD_OFFLINE_CACHE=0`: `~/.cache/quadrants/.../ptx_cache_sm_*` is never written to, `~/.nv/ComputeCache` will accumulate one fresh entry per process per kernel rather than reusing the cross-run entry.
- The PTX nonce is gated on `!offline_cache` so production users do not bust the driver cache.

