### PR TITLE
[Docs] Add init_options.md user-guide page documenting commonly-tuned qd.init knobs

### DIFF
--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -55,6 +55,7 @@ tile16
 
 graph
 perf_dispatch
+init_options
 ```
 
 ```{toctree}

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -1,0 +1,27 @@
+# qd.init options
+
+`qd.init(...)` accepts every field of the underlying `CompileConfig` struct as a keyword argument; the same fields are also reachable as environment variables of the form `QD_<UPPERCASE_NAME>` (e.g. `QD_OFFLINE_CACHE=0`). This page covers some of the knobs that are commonly tuned in practice. The underlying source of truth is `quadrants/program/compile_config.h`.
+
+## Compile-time tuning
+
+### `cfg_optimization`
+
+Whether to run the control-flow-graph optimization pass. Default `True`. Setting it to `False` makes compilation up to 6x faster while costing 1-5% of runtime speed; consider disabling it if compile time is the bottleneck and the runtime delta is acceptable.
+
+### `fast_math`
+
+Whether to enable IEEE-relaxed floating-point optimizations (FMA fusion, no NaN / infinity / signed-zero guarantees). Default `True`. Disable when investigating numerical anomalies or running deterministic-tolerance tests.
+
+### `num_compile_threads`
+
+Number of host threads used when compiling kernels. Default `4`. Raise on machines with many idle cores compiling many kernels back-to-back; lower (or set to `1`) on memory-pressure-bound systems where concurrent LLVM compilations thrash.
+
+## Debugging
+
+### `debug`
+
+Enables IR verification between every compiler pass and a number of additional runtime checks. Default `False`. Compile time slows substantially (~21s additional on adstack-heavy kernels) because the verifier walks the IR after every transform. Turn this on while iterating on a kernel that is producing incorrect numerics or while developing a new compiler pass; turn it back off once the bug is found.
+
+### `check_out_of_bound`
+
+Enables runtime bounds-checking for tensor indexing. Default `False`. Costs runtime performance proportional to indexing density; leave off for benchmarks. Not supported on the Metal backend.

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -20,8 +20,8 @@ Number of host threads used when compiling kernels. Default `4`. Raise on machin
 
 ### `debug`
 
-Enables IR verification between every compiler pass and a number of additional runtime checks. Default `False`. Compile time slows substantially (~21s additional on adstack-heavy kernels) because the verifier walks the IR after every transform. Turn this on while iterating on a kernel that is producing incorrect numerics or while developing a new compiler pass; turn it back off once the bug is found.
+Enables IR verification between every compiler pass plus additional runtime checks (integer-overflow guards on arithmetic, linear-index overflow guards on tensor indexing, adstack push-bounds at the runtime helper level). Default `False`. Compile time slows substantially because the verifier walks the IR after every transform and the extra runtime checks expand the emitted code; ~21s additional has been observed on adstack-heavy kernels. Turn this on while iterating on a kernel that is producing incorrect numerics or while developing a new compiler pass; turn it back off once the bug is found.
 
 ### `check_out_of_bound`
 
-Enables runtime bounds-checking for tensor indexing. Default `False`. Costs runtime performance proportional to indexing density; leave off for benchmarks. Not supported on the Metal backend.
+Enables runtime bounds-checking for tensor indexing. Default `False`. Costs runtime performance proportional to indexing density; leave off for benchmarks. Backends that do not expose the `assertion` extension (currently Metal and Vulkan) cannot honor this flag.


### PR DESCRIPTION
> `qd.init(...)` accepts every field of `CompileConfig` plus the corresponding `QD_<UPPERCASE_NAME>` environment variables, but no user-facing page lists which of those knobs people actually tune in practice or what each does. This PR adds a short reference page and links it under Performance in the user guide.

**TL;DR**

- New page: `docs/source/user_guide/init_options.md`. Documents `cfg_optimization`, `fast_math`, `num_compile_threads`, `debug`, `check_out_of_bound`. Each section explains what the knob does and the context in which a user should consider setting it (compile-time vs runtime trade-off, profiling, debugging).
- Hooked into the user-guide index under the existing Performance toctree.
- No code change, no public API surface change.

## Why

`CompileConfig` has dozens of fields and the page documents only the ones that come up regularly. The cuda-specific `cuda_jit_opt_level` knob from the original revision of this PR was dropped because the cold-compile A/B against the integration branch found no measurable benefit from setting it, so exposing it would add a public API knob with no payoff.

## Tests

Doc-only change. No tests touched.