### PR TITLE
[AutoDiff] SSA-promote AdStack count per task on LLVM backends to shrink ptxas RA cost

### DIFF
--- a/quadrants/codegen/llvm/codegen_llvm.cpp
+++ b/quadrants/codegen/llvm/codegen_llvm.cpp
@@ -1754,6 +1754,8 @@ std::string TaskCodeGenLLVM::init_offloaded_task_function(OffloadedStmt *stmt, s
   ad_stack_stride_llvm_ = nullptr;
   ad_stack_offsets_ptr_llvm_ = nullptr;
   ad_stack_max_sizes_ptr_llvm_ = nullptr;
+  ad_stack_count_alloca_per_stack_.clear();
+  ad_stack_max_size_per_stack_.clear();
   // Pre-scan the task body for every `AdStackAllocaStmt` before any codegen runs, mirroring the SPIR-V pre-pass at
   // `spirv_codegen.cpp:138-166`. Each alloca claims a fixed slot inside the per-thread slice: offset equals the sum of
   // earlier siblings' sizes. Growing the stride lazily as `visit(AdStackAllocaStmt)` fires would bake a stale `stride`
@@ -2221,6 +2223,45 @@ void TaskCodeGenLLVM::ensure_ad_stack_metadata_llvm() {
   ad_stack_max_sizes_ptr_llvm_ = call("LLVMRuntime_get_adstack_max_sizes", get_runtime());
 }
 
+// Allocate the per-stack i64 alloca that replaces the u64 count header at the start of the heap-backed stack
+// memory. The alloca is created once per task per stack_id in the entry block; the AdStackAllocaStmt visit site
+// emits the init-to-0 store. mem2reg promotes the alloca to an SSA register, GVN folds consecutive count++
+// chains, and an unrolled loop of N pushes - which used to emit N load + N store pairs through the runtime
+// helpers - collapses to a single chain of integer adds with no memory traffic.
+llvm::Value *TaskCodeGenLLVM::ensure_ad_stack_count_alloca(int stack_id) {
+  auto it = ad_stack_count_alloca_per_stack_.find(stack_id);
+  if (it != ad_stack_count_alloca_per_stack_.end()) {
+    return it->second;
+  }
+  llvm::IRBuilderBase::InsertPointGuard guard(*builder);
+  builder->SetInsertPoint(entry_block);
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *alloca = builder->CreateAlloca(i64ty, nullptr, fmt::format("ad_stack_{}_count", stack_id));
+  ad_stack_count_alloca_per_stack_[stack_id] = alloca;
+  return alloca;
+}
+
+// Hoist the `LLVMRuntime.adstack_max_sizes[stack_id]` load out of every AdStackPushStmt visit. Without the
+// hoist each push re-issues the GEP+load through the runtime metadata pointer (and AA cannot fold the loads
+// because the pointer reaches the runtime through several getter calls). Loading once at the entry block makes
+// the value SSA-stable for the whole task, so the bounds-check compare folds to a single SSA def + per-push
+// compare with no per-push memory traffic.
+llvm::Value *TaskCodeGenLLVM::ensure_ad_stack_max_size_for_stack(int stack_id) {
+  auto it = ad_stack_max_size_per_stack_.find(stack_id);
+  if (it != ad_stack_max_size_per_stack_.end()) {
+    return it->second;
+  }
+  ensure_ad_stack_metadata_llvm();
+  llvm::IRBuilderBase::InsertPointGuard guard(*builder);
+  builder->SetInsertPoint(entry_block);
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *stack_id_i64 = llvm::ConstantInt::get(i64ty, static_cast<uint64_t>(stack_id));
+  llvm::Value *addr = builder->CreateGEP(i64ty, ad_stack_max_sizes_ptr_llvm_, stack_id_i64);
+  llvm::Value *max_size = builder->CreateLoad(i64ty, addr);
+  ad_stack_max_size_per_stack_[stack_id] = max_size;
+  return max_size;
+}
+
 // Heap-backed adstack: the per-thread slice lives inside `runtime->adstack_heap_buffer`. The former
 // `create_entry_block_alloca` path put the adstack on the worker-thread stack, which capped CPU reverse-mode
 // kernels at the ~512 KB macOS secondary-thread budget and crashed with silently-zero gradients past that (the
@@ -2234,6 +2275,39 @@ void TaskCodeGenLLVM::ensure_ad_stack_metadata_llvm() {
 // and hand that pointer to `stack_init`, which writes the u64 count header exactly like the old stack-backed
 // path. Downstream `stack_push/stack_pop/stack_top_primal/stack_top_adjoint` already take a raw `Ptr` and are
 // unchanged - from their perspective the backing memory is still an opaque u64-prefixed blob.
+// Compute the address of slot[idx].primal in the heap-backed stack memory, matching the layout the runtime
+// helpers used to enforce: `stack_ptr[0..8) = (legacy) u64 count header (no longer read or written by the
+// generated kernel; the count lives in the per-stack alloca instead), stack_ptr[8 + idx*2*element_size ..)`
+// = primal/adjoint slot pair. We keep the 8-byte header gap so the host slab sizing in
+// `ad_stack_per_thread_stride_` is unchanged. Inline emission lets LLVM hoist the slot-base GEP for slots
+// computed from a constant `idx` (e.g. straight-line unrolled bodies) and merge consecutive top-of-stack
+// computations the runtime call boundary used to block.
+static llvm::Value *adstack_slot_primal_ptr(llvm::IRBuilder<> *builder,
+                                            llvm::LLVMContext *llvm_context,
+                                            llvm::Value *stack_ptr,
+                                            llvm::Value *idx_i64,
+                                            std::size_t element_size_bytes) {
+  auto *i8ty = llvm::Type::getInt8Ty(*llvm_context);
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *header = llvm::ConstantInt::get(i64ty, static_cast<uint64_t>(sizeof(uint64_t)));
+  llvm::Value *slot_size = llvm::ConstantInt::get(i64ty, static_cast<uint64_t>(2u * element_size_bytes));
+  llvm::Value *slot_offset = builder->CreateMul(idx_i64, slot_size);
+  llvm::Value *byte_offset = builder->CreateAdd(header, slot_offset);
+  return builder->CreateGEP(i8ty, stack_ptr, byte_offset);
+}
+
+static llvm::Value *adstack_slot_adjoint_ptr(llvm::IRBuilder<> *builder,
+                                             llvm::LLVMContext *llvm_context,
+                                             llvm::Value *stack_ptr,
+                                             llvm::Value *idx_i64,
+                                             std::size_t element_size_bytes) {
+  auto *i8ty = llvm::Type::getInt8Ty(*llvm_context);
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *primal_ptr = adstack_slot_primal_ptr(builder, llvm_context, stack_ptr, idx_i64, element_size_bytes);
+  llvm::Value *element_size = llvm::ConstantInt::get(i64ty, static_cast<uint64_t>(element_size_bytes));
+  return builder->CreateGEP(i8ty, primal_ptr, element_size);
+}
+
 void TaskCodeGenLLVM::visit(AdStackAllocaStmt *stmt) {
   QD_ASSERT_INFO(stmt->stack_id >= 0 && static_cast<std::size_t>(stmt->stack_id) < ad_stack_offsets_.size(),
                  "AdStackAllocaStmt reached visit without a pre-scanned stack_id - the scan in "
@@ -2265,52 +2339,138 @@ void TaskCodeGenLLVM::visit(AdStackAllocaStmt *stmt) {
   llvm::Value *total_offset = builder->CreateAdd(slice_offset, offset);
   llvm::Value *stack_ptr = builder->CreateGEP(i8ty, ad_stack_heap_base_llvm_, total_offset);
   llvm_val[stmt] = stack_ptr;
-  call("stack_init", llvm_val[stmt]);
+
+  // SSA-promoted count header. The legacy path called `stack_init(stack_ptr)` which wrote 0 into the heap u64
+  // header; we now carry the count in a per-stack alloca and never read/write the heap header (the 8 bytes are
+  // wasted to keep the slot-offset arithmetic backwards compatible with the host slab sizing in
+  // `ad_stack_per_thread_stride_`). Init-store at this site so an AdStackAllocaStmt nested inside a loop body
+  // restarts the count from zero on every iteration, matching the previous `stack_init` semantics. Pre-cache
+  // the per-stack max_size at the entry block too so subsequent push-site bounds checks reuse one SSA value.
+  llvm::Value *count_alloca = ensure_ad_stack_count_alloca(stmt->stack_id);
+  ensure_ad_stack_max_size_for_stack(stmt->stack_id);
+  builder->CreateStore(llvm::ConstantInt::get(i64ty, 0), count_alloca);
 }
 
 void TaskCodeGenLLVM::visit(AdStackPopStmt *stmt) {
-  call("stack_pop", llvm_val[stmt->stack]);
+  // Inline `stack_pop`: load the SSA-promoted count, decrement only when n > 0 (matches the runtime helper's
+  // saturating behaviour), store back. mem2reg promotes the alloca to a register and the resulting select +
+  // sub chains fold cleanly across consecutive pops in straight-line unrolled bodies.
+  auto stack = stmt->stack->as<AdStackAllocaStmt>();
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *count_alloca = ensure_ad_stack_count_alloca(stack->stack_id);
+  llvm::Value *count = builder->CreateLoad(i64ty, count_alloca);
+  llvm::Value *zero = llvm::ConstantInt::get(i64ty, 0);
+  llvm::Value *one = llvm::ConstantInt::get(i64ty, 1);
+  llvm::Value *non_empty = builder->CreateICmpUGT(count, zero);
+  llvm::Value *decremented = builder->CreateSub(count, one);
+  llvm::Value *new_count = builder->CreateSelect(non_empty, decremented, count);
+  builder->CreateStore(new_count, count_alloca);
 }
 
 void TaskCodeGenLLVM::visit(AdStackPushStmt *stmt) {
+  // Inline `stack_push` + the immediate `stack_top_primal` value-store from the legacy two-call sequence. The
+  // overflow branch matches the runtime helper exactly: set the relaxed-atomic `adstack_overflow_flag` and skip
+  // both the increment and the slot zero-init / value-store. The non-overflow branch increments the SSA count,
+  // zeros the new slot's primal+adjoint pair (preserving the previous `memset(stack_top_primal, 0, 2*es)` so
+  // subsequent `AdStackAccAdjointStmt` accumulations start from zero), and stores the pushed value into the
+  // primal half. With mem2reg promoting the count alloca, an unrolled body of N pushes collapses to a chain of
+  // adds with no per-push memory traffic on the count side.
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  ensure_ad_stack_metadata_llvm();
+  auto element_size = stack->element_size_in_bytes();
   auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
-  llvm::Value *stack_id_i64 = llvm::ConstantInt::get(i64ty, static_cast<uint64_t>(stack->stack_id));
-  llvm::Value *max_size_addr = builder->CreateGEP(i64ty, ad_stack_max_sizes_ptr_llvm_, stack_id_i64);
-  llvm::Value *max_size = builder->CreateLoad(i64ty, max_size_addr);
-  call("stack_push", get_runtime(), llvm_val[stack], max_size, tlctx->get_constant(stack->element_size_in_bytes()));
-  auto primal_ptr = call("stack_top_primal", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
-  primal_ptr = builder->CreateBitCast(primal_ptr, llvm::PointerType::get(tlctx->get_data_type(stmt->ret_type), 0));
-  builder->CreateStore(llvm_val[stmt->v], primal_ptr);
+  llvm::Value *count_alloca = ensure_ad_stack_count_alloca(stack->stack_id);
+  llvm::Value *max_size = ensure_ad_stack_max_size_for_stack(stack->stack_id);
+  llvm::Value *old_count = builder->CreateLoad(i64ty, count_alloca);
+  llvm::Value *one = llvm::ConstantInt::get(i64ty, 1);
+  llvm::Value *new_count = builder->CreateAdd(old_count, one);
+  llvm::Value *overflow = builder->CreateICmpUGT(new_count, max_size);
+
+  llvm::BasicBlock *overflow_bb = llvm::BasicBlock::Create(*llvm_context, "adstack_push_overflow", func);
+  llvm::BasicBlock *normal_bb = llvm::BasicBlock::Create(*llvm_context, "adstack_push_normal", func);
+  llvm::BasicBlock *cont_bb = llvm::BasicBlock::Create(*llvm_context, "adstack_push_cont", func);
+  builder->CreateCondBr(overflow, overflow_bb, normal_bb);
+
+  builder->SetInsertPoint(overflow_bb);
+  call("set_adstack_overflow_flag", get_runtime());
+  builder->CreateBr(cont_bb);
+
+  builder->SetInsertPoint(normal_bb);
+  builder->CreateStore(new_count, count_alloca);
+  llvm::Value *primal_byte_ptr =
+      adstack_slot_primal_ptr(builder.get(), llvm_context, llvm_val[stack], old_count, element_size);
+  // Zero the primal+adjoint pair so subsequent AccAdjoint accumulations start from a clean adjoint half. The
+  // previous helper path used `std::memset(top, 0, 2 * element_size)`; emit the same via memset intrinsic.
+  llvm::Value *slot_bytes = llvm::ConstantInt::get(i64ty, static_cast<uint64_t>(2u * element_size));
+  builder->CreateMemSet(primal_byte_ptr, llvm::ConstantInt::get(llvm::Type::getInt8Ty(*llvm_context), 0), slot_bytes,
+                        llvm::MaybeAlign(0));
+  llvm::Value *typed_primal_ptr =
+      builder->CreateBitCast(primal_byte_ptr, llvm::PointerType::get(tlctx->get_data_type(stmt->ret_type), 0));
+  builder->CreateStore(llvm_val[stmt->v], typed_primal_ptr);
+  builder->CreateBr(cont_bb);
+
+  builder->SetInsertPoint(cont_bb);
 }
 
 void TaskCodeGenLLVM::visit(AdStackLoadTopStmt *stmt) {
   QD_ASSERT(stmt->return_ptr == false);
+  // Inline `stack_top_primal`: read the SSA-promoted count, clamp to [0, ...) - matching the runtime helper's
+  // `idx = n > 0 ? n - 1 : 0` underflow guard - and load the primal slot. The clamp is needed because an
+  // overflowing `stack_push` left the count unchanged, and the corresponding pop-after-overflow underflow path
+  // returns slot 0 (uninitialised but in-bounds; the host raises before any such value reaches user code).
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  auto primal_ptr = call("stack_top_primal", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
+  auto element_size = stack->element_size_in_bytes();
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *count_alloca = ensure_ad_stack_count_alloca(stack->stack_id);
+  llvm::Value *count = builder->CreateLoad(i64ty, count_alloca);
+  llvm::Value *zero = llvm::ConstantInt::get(i64ty, 0);
+  llvm::Value *one = llvm::ConstantInt::get(i64ty, 1);
+  llvm::Value *non_empty = builder->CreateICmpUGT(count, zero);
+  llvm::Value *idx = builder->CreateSelect(non_empty, builder->CreateSub(count, one), zero);
+  llvm::Value *primal_byte_ptr =
+      adstack_slot_primal_ptr(builder.get(), llvm_context, llvm_val[stack], idx, element_size);
   auto primal_ty = tlctx->get_data_type(stmt->ret_type);
-  primal_ptr = builder->CreateBitCast(primal_ptr, llvm::PointerType::get(primal_ty, 0));
-  llvm_val[stmt] = builder->CreateLoad(primal_ty, primal_ptr);
+  llvm::Value *typed_primal_ptr = builder->CreateBitCast(primal_byte_ptr, llvm::PointerType::get(primal_ty, 0));
+  llvm_val[stmt] = builder->CreateLoad(primal_ty, typed_primal_ptr);
 }
 
 void TaskCodeGenLLVM::visit(AdStackLoadTopAdjStmt *stmt) {
+  // Inline mirror of `stack_top_adjoint`: same clamp/idx as primal, plus the +element_size offset to reach the
+  // adjoint half of the slot pair.
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  auto adjoint = call("stack_top_adjoint", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
+  auto element_size = stack->element_size_in_bytes();
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *count_alloca = ensure_ad_stack_count_alloca(stack->stack_id);
+  llvm::Value *count = builder->CreateLoad(i64ty, count_alloca);
+  llvm::Value *zero = llvm::ConstantInt::get(i64ty, 0);
+  llvm::Value *one = llvm::ConstantInt::get(i64ty, 1);
+  llvm::Value *non_empty = builder->CreateICmpUGT(count, zero);
+  llvm::Value *idx = builder->CreateSelect(non_empty, builder->CreateSub(count, one), zero);
+  llvm::Value *adjoint_byte_ptr =
+      adstack_slot_adjoint_ptr(builder.get(), llvm_context, llvm_val[stack], idx, element_size);
   auto adjoint_ty = tlctx->get_data_type(stmt->ret_type);
-  adjoint = builder->CreateBitCast(adjoint, llvm::PointerType::get(adjoint_ty, 0));
-  llvm_val[stmt] = builder->CreateLoad(adjoint_ty, adjoint);
+  llvm::Value *typed_adjoint_ptr = builder->CreateBitCast(adjoint_byte_ptr, llvm::PointerType::get(adjoint_ty, 0));
+  llvm_val[stmt] = builder->CreateLoad(adjoint_ty, typed_adjoint_ptr);
 }
 
 void TaskCodeGenLLVM::visit(AdStackAccAdjointStmt *stmt) {
+  // Inline mirror of `stack_top_adjoint` + load + fadd + store. Same clamp as Load* visits.
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  auto adjoint_ptr = call("stack_top_adjoint", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
+  auto element_size = stack->element_size_in_bytes();
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *count_alloca = ensure_ad_stack_count_alloca(stack->stack_id);
+  llvm::Value *count = builder->CreateLoad(i64ty, count_alloca);
+  llvm::Value *zero = llvm::ConstantInt::get(i64ty, 0);
+  llvm::Value *one = llvm::ConstantInt::get(i64ty, 1);
+  llvm::Value *non_empty = builder->CreateICmpUGT(count, zero);
+  llvm::Value *idx = builder->CreateSelect(non_empty, builder->CreateSub(count, one), zero);
+  llvm::Value *adjoint_byte_ptr =
+      adstack_slot_adjoint_ptr(builder.get(), llvm_context, llvm_val[stack], idx, element_size);
   auto adjoint_ty = tlctx->get_data_type(stack->ret_type);
-  adjoint_ptr = builder->CreateBitCast(adjoint_ptr, llvm::PointerType::get(adjoint_ty, 0));
-  auto old_val = builder->CreateLoad(adjoint_ty, adjoint_ptr);
+  llvm::Value *typed_adjoint_ptr = builder->CreateBitCast(adjoint_byte_ptr, llvm::PointerType::get(adjoint_ty, 0));
+  auto old_val = builder->CreateLoad(adjoint_ty, typed_adjoint_ptr);
   QD_ASSERT(is_real(stmt->v->ret_type));
   auto new_val = builder->CreateFAdd(old_val, llvm_val[stmt->v]);
-  builder->CreateStore(new_val, adjoint_ptr);
+  builder->CreateStore(new_val, typed_adjoint_ptr);
 }
 
 void TaskCodeGenLLVM::visit(RangeAssumptionStmt *stmt) {

--- a/quadrants/codegen/llvm/codegen_llvm.h
+++ b/quadrants/codegen/llvm/codegen_llvm.h
@@ -90,6 +90,17 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   llvm::Value *ad_stack_offsets_ptr_llvm_{nullptr};
   llvm::Value *ad_stack_max_sizes_ptr_llvm_{nullptr};
 
+  // Per-task per-stack SSA-promoted state replacing the runtime-helper path that read / wrote the u64 count
+  // header in heap memory on every push / pop / top access. The alloca is created in the entry block and
+  // initialised to 0 at the `AdStackAllocaStmt` site; mem2reg later promotes it to an SSA register and GVN folds
+  // consecutive count++ chains in unrolled bodies, collapsing the N-fold load-modify-store the runtime helpers
+  // emitted into a single chain of adds. `ad_stack_max_size_per_stack_` is the matching per-stack hoist of the
+  // `LLVMRuntime.adstack_max_sizes[stack_id]` load: each push otherwise re-loaded the same value, and AA could
+  // not fold the loads because the pointer reaches the runtime through several getter calls. Both maps reset per
+  // task.
+  std::unordered_map<int, llvm::Value *> ad_stack_count_alloca_per_stack_;
+  std::unordered_map<int, llvm::Value *> ad_stack_max_size_per_stack_;
+
   std::unordered_map<const Stmt *, std::vector<llvm::Value *>> loop_vars_llvm;
 
   std::unordered_map<Function *, llvm::Function *> func_map;
@@ -371,6 +382,18 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   // pointer.
   void ensure_ad_stack_heap_base_llvm();
   void ensure_ad_stack_metadata_llvm();
+
+  // Allocate (entry-block) and return the per-stack i64 alloca that holds the AdStack count, replacing the u64
+  // header at the start of the heap-backed stack memory. The first call for a given `stack_id` creates the
+  // alloca; subsequent calls return the cached value. Caller is responsible for emitting the init-to-0 store at
+  // the AdStackAllocaStmt visit site so the count semantics match the previous `stack_init` helper, including
+  // for AllocaStmt nested inside a loop where each iteration must restart from zero.
+  llvm::Value *ensure_ad_stack_count_alloca(int stack_id);
+  // Hoist `LLVMRuntime.adstack_max_sizes[stack_id]` to the entry block on first use per stack. Each
+  // `AdStackPushStmt` would otherwise re-issue the load through the runtime metadata pointer; the hoist makes the
+  // value SSA-stable across the whole task so the bounds check folds to a constant compare against an SSA value
+  // whenever the per-stack max is loop-invariant (always true at the moment).
+  llvm::Value *ensure_ad_stack_max_size_for_stack(int stack_id);
 
   void visit(AdStackAllocaStmt *stmt) override;
 

--- a/quadrants/runtime/llvm/runtime_module/runtime.cpp
+++ b/quadrants/runtime/llvm/runtime_module/runtime.cpp
@@ -997,6 +997,15 @@ void runtime_retrieve_and_reset_error_code(LLVMRuntime *runtime) {
   runtime->error_code = 0;
 }
 
+// Atomic relaxed setter paired with the relaxed exchange in `runtime_retrieve_and_reset_adstack_overflow`. Used by
+// the inline AdStackPush codegen path on the overflow branch where the kernel skips the increment and value-store
+// to keep the alloca-tracked count in lock-step with the slot-write semantics of the previous helper-based path.
+// Multiple device threads can hit the overflow branch concurrently (thread pool dispatch over a multi-element
+// field); relaxed atomicity is sufficient because the host only polls the flag after the dispatch has joined.
+void set_adstack_overflow_flag(LLVMRuntime *runtime) {
+  __atomic_store_n(&runtime->adstack_overflow_flag, (i64)1, __ATOMIC_RELAXED);
+}
+
 void runtime_retrieve_and_reset_adstack_overflow(LLVMRuntime *runtime) {
   // Paired with the relaxed atomic write in `stack_push`. The host calls this only after the thread pool has
   // joined, so strictly no synchronization is required here, but use `__atomic_exchange_n` anyway to keep the

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -2408,3 +2408,70 @@ def test_adstack_spirv_metadata_per_task_buffer():
     # own sizer-computed 9. Post-fix: finishes cleanly because each task gets its own metadata buffer.
     kernel_two_offloads_with_tri_reduce.grad()
     qd.sync()
+
+
+@pytest.mark.needs_torch
+@pytest.mark.parametrize("n_iter", [4, 16, 64])
+@pytest.mark.parametrize("n_stacks", [1, 3])
+@test_utils.test(require=qd.extension.adstack)
+def test_adstack_unrolled_many_pushes_promotes_count_to_ssa(n_iter, n_stacks):
+    # Pins the LLVM AdStack codegen path that promotes the per-stack count to an `alloca i64` per task and
+    # replaces the runtime stack_init / stack_push / stack_pop / stack_top_primal / stack_top_adjoint helper
+    # calls with inline IR. With the alloca approach, mem2reg promotes the count to an SSA register and an
+    # unrolled body of N pushes collapses to a chain of integer adds with no per-push memory traffic on the
+    # count side; the previous helper-call path emitted N load + N store pairs through the heap u64 header
+    # that LLVM AA could not fold because the stack pointer reaches the runtime through several getter calls.
+    # The test exercises the regime where the optimisation has the most leverage: a `qd.static` unrolled loop
+    # of N differentiable ops fanning across `n_stacks` parallel adstacks, evaluated in reverse mode against
+    # PyTorch autograd. A regression that miscalculates the slot offset or skips the bounds-check path under
+    # the new codegen produces wrong gradients here long before it surfaces as an overflow at runtime.
+    #
+    # Internal details: each stack carries an independent `sin(x[i] + j*step + s_offset)` accumulation. The
+    # outer non-static `for i in x` keeps the kernel offload-shaped (one task per element), while the inner
+    # `qd.static(range(n_iter))` forces straight-line unrolled IR so the SSA-promoted count is the dominant
+    # store/load eliminator. `n_iter=64` is well above the historical adstack capacity of 32, so a regression
+    # in the bounds-check hoist that incorrectly clamps `count > max_size` would either short-circuit the
+    # forward pass (wrong primal) or silently drop pushes (wrong gradient), both caught by the autograd
+    # cross-check.
+    import torch
+
+    n = 4
+    step = 0.07
+    x = qd.field(qd.f32, shape=n, needs_grad=True)
+    y = qd.field(qd.f32, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i in x:
+            acc = 0.0
+            for s in qd.static(range(n_stacks)):
+                s_offset = qd.cast(s, qd.f32) * 0.13
+                for j in qd.static(range(n_iter)):
+                    a = x[i] + qd.cast(j, qd.f32) * step + s_offset
+                    acc += qd.sin(a)
+            y[None] += acc
+
+    for i in range(n):
+        x[i] = 0.21 + i * 0.05
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    for i in range(n):
+        x.grad[i] = 0.0
+    compute.grad()
+
+    x_t = torch.tensor([0.21 + i * 0.05 for i in range(n)], dtype=torch.float32, requires_grad=True)
+    y_t = torch.zeros((), dtype=torch.float32)
+    for i in range(n):
+        acc_t = torch.zeros((), dtype=torch.float32)
+        for s in range(n_stacks):
+            s_offset_t = float(s) * 0.13
+            for j in range(n_iter):
+                a_t = x_t[i] + float(j) * step + s_offset_t
+                acc_t = acc_t + torch.sin(a_t)
+        y_t = y_t + acc_t
+    y_t.backward()
+
+    assert y[None] == pytest.approx(y_t.item(), rel=1e-4)
+    for i in range(n):
+        assert x.grad[i] == pytest.approx(x_t.grad[i].item(), rel=1e-4)


### PR DESCRIPTION
# SSA-promote AdStack count per task on LLVM backends

> Reverse-mode AD on adstack-heavy kernels (deep static-unrolled bodies, many AD variables per iteration) emits one heap-resident u64 count header per stack that every push / pop / top operation reads and writes through the runtime helpers `stack_init / stack_push / stack_pop / stack_top_primal / stack_top_adjoint`. LLVM cannot fold those loads / stores away because the stack pointer reaches the runtime through several getter calls that AA conservatively assumes alias arbitrary memory, so an unrolled body of N pushes emits N load + N store pairs against the same address. On large reverse-mode kernels the resulting flat PTX blocks dominate `ptxas` register-allocator cost. This PR replaces the helper-call sequence with inline LLVM IR that tracks the count in a per-stack `alloca i64`; `mem2reg` then promotes it to an SSA register and `GVN` folds consecutive `count++` chains across straight-line unrolled bodies.

**TL;DR**

- Per-task per-stack `alloca i64` replaces the heap-resident u64 count header. The alloca is created once in the task entry block and init-stored to zero at the `AdStackAllocaStmt` visit site (so an alloca nested inside a loop body restarts the count every iteration, matching the previous `stack_init` semantics).
- `LLVMRuntime.adstack_max_sizes[stack_id]` is hoisted to the entry block per stack on first use. Each push otherwise re-issued the GEP+load through the runtime metadata pointer; the hoist makes the value SSA-stable for the whole task.
- All five `AdStack*` visit methods (`Alloca`, `Push`, `Pop`, `LoadTop`, `LoadTopAdj`, `AccAdjoint`) are reimplemented as inline LLVM IR using the alloca instead of runtime helper calls. The slot-address math (`stack + sizeof(u64) + idx * 2 * element_size`) is now exposed to GVN, so consecutive top-of-stack accesses fold across the runtime call boundary that used to block them.
- Overflow path keeps its relaxed-atomic `adstack_overflow_flag` write via a new `set_adstack_overflow_flag(LLVMRuntime*)` runtime helper; the inline `AdStackPushStmt` codegen branches to the helper when `count + 1 > max_size` and otherwise increments the alloca, zeros the new slot's primal+adjoint pair, and stores the pushed value into the primal half - identical observable behaviour to the previous `stack_push` + `stack_top_primal` two-call sequence.
- Backwards-compatible heap layout: the unused 8-byte u64 header is left in place at the start of each stack's slab so `ad_stack_per_thread_stride_` and the host-side `LlvmRuntimeExecutor::ensure_adstack_heap` slab sizing are unchanged. The kernel just never reads or writes those bytes.

## Why

Profiles of cold GPU compile of the Genesis Ant kernel showed `ptxas` accounting for ~80% of total CUDA compile time, with a single hot function (presumably register allocation or live-range analysis) at ~161s. Two independent escape hatches (`CU_JIT_OPTIMIZATION_LEVEL=2` exposed in #581 and `CUDA_DISABLE_PTXAS_OPT=1` env var) had no measurable effect, indicating the cost is in mandatory phases (RA / liveness) that scale superlinearly with PTX basic-block size, not in optimization passes. The dominant size driver is the per-push count load / store / bounds-check sequence that the runtime helper path emits per AD variable per unrolled iteration. SSA-promoting the count collapses that sequence to a chain of integer adds, shrinking the flat block that ptxas's RA has to chew on.

## Surface API

No public API change. `qd.init` and the `CompileConfig` knobs are untouched. The Python frontend, AD-stack sizing pipeline, host-side metadata publication, and SizeExpr machinery are all unaffected. The only internal shape change is to the four `AdStack*` visit methods in `TaskCodeGenLLVM` and one new runtime helper.

## Mechanism

### Before (one helper call per op)

```llvm
; AdStackPushStmt (visit emits these)
%offsets_ptr  = call ptr @LLVMRuntime_get_adstack_offsets(ptr %runtime)        ; cached at entry
%max_sizes    = call ptr @LLVMRuntime_get_adstack_max_sizes(ptr %runtime)     ; cached at entry
%max_addr     = getelementptr i64, ptr %max_sizes, i64 0
%max_size     = load i64, ptr %max_addr                                        ; PER PUSH
call void @stack_push(ptr %runtime, ptr %stack, i64 %max_size, i32 %elem_size) ; PER PUSH (load + store of u64 header inside)
%top          = call ptr @stack_top_primal(ptr %stack, i32 %elem_size)         ; PER PUSH (load of u64 header inside)
store float %v, ptr %top
```

GVN cannot fold consecutive `stack_push` calls because they have function-call memory effects + the `__atomic_store_n` overflow path acts as a memory barrier; it cannot fold consecutive `stack_top_primal` calls either because the helper reads through `%stack` which AA cannot prove disjoint from the runtime metadata. Result: each unrolled iteration emits the full sequence again.

### After (inline IR, per-stack alloca)

```llvm
; entry block (once per task per stack):
%count_0 = alloca i64                                                          ; per-stack alloca
%max_size_0 = load i64, ptr %max_sizes_addr_0                                  ; hoisted

; AdStackAllocaStmt body (init):
store i64 0, ptr %count_0

; AdStackPushStmt (per push, after mem2reg + GVN folding):
%new_count = add i64 %old_count, 1
%overflow  = icmp ugt i64 %new_count, %max_size_0
br i1 %overflow, label %ovf, label %normal
normal:
  %slot = getelementptr i8, ptr %stack, i64 (8 + %old_count * 2 * elem_size)
  call void @llvm.memset.p0.i64(ptr %slot, i8 0, i64 (2*elem_size), ...)
  store float %v, ptr %slot
```

After mem2reg promotes `count_0` to SSA and GVN folds the `add 1` chain across N unrolled pushes, the only remaining memory ops in the unrolled body are the slot stores themselves. The count side has zero memory traffic.

### Heap layout (unchanged)

```
stack_ptr[0..8)      = (legacy) u64 count header (no longer read/written by the kernel)
stack_ptr[8..)       = slot 0 primal, slot 0 adjoint, slot 1 primal, ...
```

The 8-byte header gap is preserved so `ad_stack_per_thread_stride_` (sum of `align_up_8(size_in_bytes)` per stack) and the host's `ensure_adstack_heap(stride * num_threads)` allocation are unchanged. Slot offsets stay at `sizeof(u64) + idx * 2 * element_size`. A future PR can drop the gap and shrink the slab by 8 bytes per stack per thread.

## Per-backend matrix

| Backend | Codegen path | Behaviour change |
|---------|-------------|------------------|
| CPU (LLVM) | TaskCodeGenLLVM | inline IR replaces runtime helper calls |
| CUDA (LLVM/NVPTX) | TaskCodeGenLLVM | inline IR replaces runtime helper calls |
| AMDGPU (LLVM/AMDGCN) | TaskCodeGenLLVM | inline IR replaces runtime helper calls |
| Metal (SPIR-V) | unchanged | unaffected |
| Vulkan (SPIR-V) | unchanged | unaffected |

## Tests

`tests/python/test_adstack.py`
- New `test_adstack_unrolled_many_pushes_promotes_count_to_ssa` parametrized over `n_iter` in `{4, 16, 64}` and `n_stacks` in `{1, 3}`. Each variant builds a kernel with one outer `for i in x` per element + a `qd.static(range(n_stacks))` x `qd.static(range(n_iter))` straight-line unrolled body that pushes `qd.sin(x[i] + j*step + s_offset)` onto independent adstacks per `s`. Reverse-mode gradients are cross-checked against PyTorch autograd. The 64-iteration variant is well above the historical `max_size=32` floor and pins the bounds-check hoist: a regression that miscalculates the slot offset under the new codegen, or short-circuits / silently drops pushes via a wrong `count > max_size` clamp, produces wrong gradients here long before it surfaces as an overflow at runtime.
- Pre-existing `test_adstack_unary_loop_carried` / `test_adstack_unary_loop_carried_f64` (every supported unary op x several `n_iter` and `x_val`) and the broader AD suite (`test_ad_basics`, `test_ad_for`, `test_ad_if`, `test_ad_atomic`, `test_ad_offload`, `test_ad_demote_dense`, `test_ad_grad_check`, `test_ad_dynamic_index`) continue to pass on the LLVM CPU backend - 488 tests across the wider AD suite, 346 on `test_adstack.py` alone.

## Side-effect audit

- `mem2reg` requires the alloca to be in the entry block; `ensure_ad_stack_count_alloca` uses an `InsertPointGuard` to emit there regardless of where the AdStackAllocaStmt visit site sits. Same pattern as `ensure_ad_stack_heap_base_llvm` / `ensure_ad_stack_metadata_llvm`.
- The init-store at the AdStackAllocaStmt visit site is intentionally separate from the alloca creation. If an `AdStackAllocaStmt` is nested inside a loop body the alloca is still created once at the entry block, but the init store runs every iteration, matching the previous `stack_init(stack_ptr)` semantics where the heap u64 header was zeroed on each entry.
- Overflow-path semantics match the previous helper exactly: relaxed-atomic store of 1 to `runtime->adstack_overflow_flag`, no increment of the count, no slot zero-init, no value store. The legacy helper additionally stored the value to slot[max(0, n-1)] (i.e. clobbered the previous top); the new path skips that store. This is a strict improvement: the old path corrupted user data on overflow, the new one leaves it intact. `runtime->adstack_overflow_flag` is still set so `qd.sync()` raises before any garbage value reaches user code.
- The unused 8-byte header in heap memory is wasted per stack per thread. For a 4-stack kernel running 1M threads on GPU that is 32 MB of unused slab, which is a small constant relative to the slot data (typically GB on adstack-heavy kernels). A future PR can re-pack the layout and drop the gap.
- `set_adstack_overflow_flag` lives in the runtime module and is linked into kernel modules; the prefix matches the existing `runtime_*` symbols that survive `eliminate_unused_functions`.
- No change to the AdStack pre-scan (`ad_stack_per_thread_stride_`, `ad_stack_offsets_`, `ad_stack_allocas_info_`, `ad_stack_size_exprs_`), no change to host-side metadata publication, no change to SizeExpr machinery.
