### PR TITLE
[Lang] Inline AdStack ops on release LLVM codegen: dramatically reduces compile time for adstack-enabled reverse-mode kernels

### DIFF
--- a/quadrants/codegen/llvm/codegen_llvm.cpp
+++ b/quadrants/codegen/llvm/codegen_llvm.cpp
@@ -2369,9 +2369,14 @@ void TaskCodeGenLLVM::visit(AdStackPushStmt *stmt) {
   auto *i8ty = llvm::Type::getInt8Ty(*llvm_context);
   llvm::Value *primal_ptr = builder->CreateGEP(i8ty, llvm_val[stack], slot_offset);
   // Zero the primal+adjoint slot pair to match `stack_push`'s `memset(top_primal, 0, 2 * element_size)`. Without
-  // this, a previous use of this slot's adjoint would persist into the new push's accumulator.
+  // this, a previous use of this slot's adjoint would persist into the new push's accumulator. Slot pointer is
+  // `stack + 8 + count * 2 * element_size` so the destination is `2 * element_size`-aligned (the slot stride),
+  // capped at 8 because the per-thread slab base is 8-aligned. For `element_size in {1, 2}` (i8 / u1 packs, fp16)
+  // this is 2 or 4 bytes; an over-stated alignment would let LLVM lower the memset to wider stores than the
+  // pointer can satisfy on stricter backends.
+  std::size_t slot_align = std::min<std::size_t>(8u, 2u * stack->element_size_in_bytes());
   builder->CreateMemSet(primal_ptr, llvm::ConstantInt::get(llvm::Type::getInt8Ty(*llvm_context), 0),
-                        llvm::ConstantInt::get(i64ty, stack->entry_size_in_bytes()), llvm::MaybeAlign(8));
+                        llvm::ConstantInt::get(i64ty, stack->entry_size_in_bytes()), llvm::MaybeAlign(slot_align));
   llvm::Value *primal_typed_ptr =
       builder->CreateBitCast(primal_ptr, llvm::PointerType::get(tlctx->get_data_type(stmt->ret_type), 0));
   builder->CreateStore(llvm_val[stmt->v], primal_typed_ptr);

--- a/quadrants/codegen/llvm/codegen_llvm.cpp
+++ b/quadrants/codegen/llvm/codegen_llvm.cpp
@@ -1754,6 +1754,7 @@ std::string TaskCodeGenLLVM::init_offloaded_task_function(OffloadedStmt *stmt, s
   ad_stack_stride_llvm_ = nullptr;
   ad_stack_offsets_ptr_llvm_ = nullptr;
   ad_stack_max_sizes_ptr_llvm_ = nullptr;
+  ad_stack_count_alloca_llvm_.clear();
   // Pre-scan the task body for every `AdStackAllocaStmt` before any codegen runs, mirroring the SPIR-V pre-pass at
   // `spirv_codegen.cpp:138-166`. Each alloca claims a fixed slot inside the per-thread slice: offset equals the sum of
   // earlier siblings' sizes. Growing the stride lazily as `visit(AdStackAllocaStmt)` fires would bake a stale `stride`
@@ -2221,6 +2222,44 @@ void TaskCodeGenLLVM::ensure_ad_stack_metadata_llvm() {
   ad_stack_max_sizes_ptr_llvm_ = call("LLVMRuntime_get_adstack_max_sizes", get_runtime());
 }
 
+// Return (creating on first call) the per-stack `alloca i64` that holds the live push count for this stack on the
+// release-build path. The alloca is emitted in the entry block so `mem2reg` can promote it to an SSA register; the
+// init-store of zero happens at the AdStackAllocaStmt visit site (which may sit inside a loop body, so each loop
+// iteration that re-enters the AdStackAllocaStmt restarts the count - matching the `stack_init` semantics on the
+// debug path).
+llvm::Value *TaskCodeGenLLVM::ensure_ad_stack_count_alloca_llvm(const AdStackAllocaStmt *stack) {
+  auto it = ad_stack_count_alloca_llvm_.find(stack);
+  if (it != ad_stack_count_alloca_llvm_.end()) {
+    return it->second;
+  }
+  llvm::IRBuilderBase::InsertPointGuard guard(*builder);
+  builder->SetInsertPoint(entry_block, entry_block->getFirstInsertionPt());
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *count_alloca = builder->CreateAlloca(i64ty);
+  ad_stack_count_alloca_llvm_[stack] = count_alloca;
+  return count_alloca;
+}
+
+// Compute the address of the top primal (or adjoint, when `adjoint_offset_bytes` == element_size) slot for an
+// in-flight push count. Mirrors the runtime helper math `stack + sizeof(u64) + idx * 2 * element_size`, with `idx`
+// being the saturating `count - 1` to match `stack_top_primal`'s underflow guard. Used by the release-build inline
+// codegen for `AdStackPushStmt` / `AdStackLoadTopStmt` / `AdStackLoadTopAdjStmt` / `AdStackAccAdjointStmt`.
+llvm::Value *TaskCodeGenLLVM::emit_ad_stack_top_slot_ptr(const AdStackAllocaStmt *stack,
+                                                         llvm::Value *count,
+                                                         std::size_t adjoint_offset_bytes) {
+  auto *i8ty = llvm::Type::getInt8Ty(*llvm_context);
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *zero = llvm::ConstantInt::get(i64ty, 0);
+  llvm::Value *one = llvm::ConstantInt::get(i64ty, 1);
+  llvm::Value *count_minus_one = builder->CreateSub(count, one);
+  llvm::Value *positive = builder->CreateICmpUGT(count, zero);
+  llvm::Value *idx = builder->CreateSelect(positive, count_minus_one, zero);
+  std::size_t entry_size = stack->entry_size_in_bytes();
+  llvm::Value *slot_offset = builder->CreateAdd(llvm::ConstantInt::get(i64ty, sizeof(int64) + adjoint_offset_bytes),
+                                                builder->CreateMul(idx, llvm::ConstantInt::get(i64ty, entry_size)));
+  return builder->CreateGEP(i8ty, llvm_val[const_cast<AdStackAllocaStmt *>(stack)], slot_offset);
+}
+
 // Heap-backed adstack: the per-thread slice lives inside `runtime->adstack_heap_buffer`. The former
 // `create_entry_block_alloca` path put the adstack on the worker-thread stack, which capped CPU reverse-mode
 // kernels at the ~512 KB macOS secondary-thread budget and crashed with silently-zero gradients past that (the
@@ -2265,30 +2304,93 @@ void TaskCodeGenLLVM::visit(AdStackAllocaStmt *stmt) {
   llvm::Value *total_offset = builder->CreateAdd(slice_offset, offset);
   llvm::Value *stack_ptr = builder->CreateGEP(i8ty, ad_stack_heap_base_llvm_, total_offset);
   llvm_val[stmt] = stack_ptr;
-  call("stack_init", llvm_val[stmt]);
+  if (compile_config.debug) {
+    call("stack_init", llvm_val[stmt]);
+    return;
+  }
+  // Release build: store 0 into the per-stack count alloca instead of zeroing the heap u64 header. Doing this at
+  // the AdStackAllocaStmt visit site (rather than once at task entry) restarts the count whenever an outer loop
+  // re-enters the alloca, matching `stack_init`'s semantics on the debug path.
+  auto *i64ty_init = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stmt);
+  builder->CreateStore(llvm::ConstantInt::get(i64ty_init, 0), count_alloca);
 }
 
 void TaskCodeGenLLVM::visit(AdStackPopStmt *stmt) {
-  call("stack_pop", llvm_val[stmt->stack]);
+  if (compile_config.debug) {
+    call("stack_pop", llvm_val[stmt->stack]);
+    return;
+  }
+  auto stack = stmt->stack->as<AdStackAllocaStmt>();
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stack);
+  llvm::Value *count = builder->CreateLoad(i64ty, count_alloca);
+  llvm::Value *zero = llvm::ConstantInt::get(i64ty, 0);
+  llvm::Value *one = llvm::ConstantInt::get(i64ty, 1);
+  llvm::Value *count_minus_one = builder->CreateSub(count, one);
+  llvm::Value *positive = builder->CreateICmpUGT(count, zero);
+  llvm::Value *new_count = builder->CreateSelect(positive, count_minus_one, zero);
+  builder->CreateStore(new_count, count_alloca);
 }
 
 void TaskCodeGenLLVM::visit(AdStackPushStmt *stmt) {
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  ensure_ad_stack_metadata_llvm();
+  if (compile_config.debug) {
+    // Debug build: route through the bounds-checking helper so any sizer bug surfaces as an overflow flag at sync.
+    // The `max_size` load is only needed on this path.
+    ensure_ad_stack_metadata_llvm();
+    auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+    llvm::Value *stack_id_i64 = llvm::ConstantInt::get(i64ty, static_cast<uint64_t>(stack->stack_id));
+    llvm::Value *max_size_addr = builder->CreateGEP(i64ty, ad_stack_max_sizes_ptr_llvm_, stack_id_i64);
+    llvm::Value *max_size = builder->CreateLoad(i64ty, max_size_addr);
+    call("stack_push", get_runtime(), llvm_val[stack], max_size, tlctx->get_constant(stack->element_size_in_bytes()));
+    auto primal_ptr = call("stack_top_primal", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
+    primal_ptr = builder->CreateBitCast(primal_ptr, llvm::PointerType::get(tlctx->get_data_type(stmt->ret_type), 0));
+    builder->CreateStore(llvm_val[stmt->v], primal_ptr);
+    return;
+  }
+  // Release build: emit the push as inline IR against the per-stack count alloca. After `mem2reg` promotes the
+  // alloca to SSA, `GVN` folds the chain of `count++` across consecutive unrolled pushes; the only surviving
+  // memory traffic in the unrolled body is the slot stores themselves. The runtime overflow check is dropped on
+  // this path because `determine_ad_stack_size` produces a valid upper bound on per-thread push count along every
+  // execution path (any unresolved stack is a hard compile error), so the `n + 1 > max_num_elements` guard inside
+  // `stack_push` is dead in correct compilations.
   auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
-  llvm::Value *stack_id_i64 = llvm::ConstantInt::get(i64ty, static_cast<uint64_t>(stack->stack_id));
-  llvm::Value *max_size_addr = builder->CreateGEP(i64ty, ad_stack_max_sizes_ptr_llvm_, stack_id_i64);
-  llvm::Value *max_size = builder->CreateLoad(i64ty, max_size_addr);
-  call("stack_push", get_runtime(), llvm_val[stack], max_size, tlctx->get_constant(stack->element_size_in_bytes()));
-  auto primal_ptr = call("stack_top_primal", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
-  primal_ptr = builder->CreateBitCast(primal_ptr, llvm::PointerType::get(tlctx->get_data_type(stmt->ret_type), 0));
-  builder->CreateStore(llvm_val[stmt->v], primal_ptr);
+  llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stack);
+  llvm::Value *old_count = builder->CreateLoad(i64ty, count_alloca);
+  llvm::Value *new_count = builder->CreateAdd(old_count, llvm::ConstantInt::get(i64ty, 1));
+  builder->CreateStore(new_count, count_alloca);
+  // Slot is at index `new_count - 1`, which equals `old_count`. Skip the saturating-subtract that
+  // `emit_ad_stack_top_slot_ptr` does because we just incremented and `new_count` is provably >= 1.
+  std::size_t entry_size = stack->entry_size_in_bytes();
+  llvm::Value *slot_offset =
+      builder->CreateAdd(llvm::ConstantInt::get(i64ty, sizeof(int64)),
+                         builder->CreateMul(old_count, llvm::ConstantInt::get(i64ty, entry_size)));
+  auto *i8ty = llvm::Type::getInt8Ty(*llvm_context);
+  llvm::Value *primal_ptr = builder->CreateGEP(i8ty, llvm_val[stack], slot_offset);
+  // Zero the primal+adjoint slot pair to match `stack_push`'s `memset(top_primal, 0, 2 * element_size)`. Without
+  // this, a previous use of this slot's adjoint would persist into the new push's accumulator.
+  builder->CreateMemSet(primal_ptr, llvm::ConstantInt::get(llvm::Type::getInt8Ty(*llvm_context), 0),
+                        llvm::ConstantInt::get(i64ty, stack->entry_size_in_bytes()), llvm::MaybeAlign(8));
+  llvm::Value *primal_typed_ptr =
+      builder->CreateBitCast(primal_ptr, llvm::PointerType::get(tlctx->get_data_type(stmt->ret_type), 0));
+  builder->CreateStore(llvm_val[stmt->v], primal_typed_ptr);
 }
 
 void TaskCodeGenLLVM::visit(AdStackLoadTopStmt *stmt) {
   QD_ASSERT(stmt->return_ptr == false);
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  auto primal_ptr = call("stack_top_primal", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
+  if (compile_config.debug) {
+    auto primal_ptr = call("stack_top_primal", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
+    auto primal_ty = tlctx->get_data_type(stmt->ret_type);
+    primal_ptr = builder->CreateBitCast(primal_ptr, llvm::PointerType::get(primal_ty, 0));
+    llvm_val[stmt] = builder->CreateLoad(primal_ty, primal_ptr);
+    return;
+  }
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stack);
+  llvm::Value *count = builder->CreateLoad(i64ty, count_alloca);
+  llvm::Value *primal_ptr = emit_ad_stack_top_slot_ptr(stack, count, /*adjoint_offset_bytes=*/0);
   auto primal_ty = tlctx->get_data_type(stmt->ret_type);
   primal_ptr = builder->CreateBitCast(primal_ptr, llvm::PointerType::get(primal_ty, 0));
   llvm_val[stmt] = builder->CreateLoad(primal_ty, primal_ptr);
@@ -2296,15 +2398,34 @@ void TaskCodeGenLLVM::visit(AdStackLoadTopStmt *stmt) {
 
 void TaskCodeGenLLVM::visit(AdStackLoadTopAdjStmt *stmt) {
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  auto adjoint = call("stack_top_adjoint", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
+  if (compile_config.debug) {
+    auto adjoint = call("stack_top_adjoint", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
+    auto adjoint_ty = tlctx->get_data_type(stmt->ret_type);
+    adjoint = builder->CreateBitCast(adjoint, llvm::PointerType::get(adjoint_ty, 0));
+    llvm_val[stmt] = builder->CreateLoad(adjoint_ty, adjoint);
+    return;
+  }
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stack);
+  llvm::Value *count = builder->CreateLoad(i64ty, count_alloca);
+  llvm::Value *adjoint_ptr =
+      emit_ad_stack_top_slot_ptr(stack, count, /*adjoint_offset_bytes=*/stack->element_size_in_bytes());
   auto adjoint_ty = tlctx->get_data_type(stmt->ret_type);
-  adjoint = builder->CreateBitCast(adjoint, llvm::PointerType::get(adjoint_ty, 0));
-  llvm_val[stmt] = builder->CreateLoad(adjoint_ty, adjoint);
+  adjoint_ptr = builder->CreateBitCast(adjoint_ptr, llvm::PointerType::get(adjoint_ty, 0));
+  llvm_val[stmt] = builder->CreateLoad(adjoint_ty, adjoint_ptr);
 }
 
 void TaskCodeGenLLVM::visit(AdStackAccAdjointStmt *stmt) {
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  auto adjoint_ptr = call("stack_top_adjoint", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
+  llvm::Value *adjoint_ptr;
+  if (compile_config.debug) {
+    adjoint_ptr = call("stack_top_adjoint", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
+  } else {
+    auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+    llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stack);
+    llvm::Value *count = builder->CreateLoad(i64ty, count_alloca);
+    adjoint_ptr = emit_ad_stack_top_slot_ptr(stack, count, /*adjoint_offset_bytes=*/stack->element_size_in_bytes());
+  }
   auto adjoint_ty = tlctx->get_data_type(stack->ret_type);
   adjoint_ptr = builder->CreateBitCast(adjoint_ptr, llvm::PointerType::get(adjoint_ty, 0));
   auto old_val = builder->CreateLoad(adjoint_ty, adjoint_ptr);

--- a/quadrants/codegen/llvm/codegen_llvm.cpp
+++ b/quadrants/codegen/llvm/codegen_llvm.cpp
@@ -2240,6 +2240,26 @@ llvm::Value *TaskCodeGenLLVM::ensure_ad_stack_count_alloca_llvm(const AdStackAll
   return count_alloca;
 }
 
+// True if the sizer has resolved this stack to a compile-time `max_size == 1` (a single-slot snapshot whose count
+// is provably either 0 or 1 at every program point). The Const SizeExpr check rejects placeholder cases where
+// `determine_ad_stack_size` set `max_size = 1` because the symbolic bound is non-Const and the runtime evaluates
+// the actual capacity per launch. For these stacks the count alloca, mem2reg recurrence, and SCEV analysis are
+// all dead - slot is always slot 0, push / loadtop / pop reduce to a constant-offset GEP.
+static bool is_compile_time_single_slot(const AdStackAllocaStmt *stack) {
+  return stack->max_size == 1 && stack->size_expr && stack->size_expr->kind == SizeExpr::Kind::Const &&
+         stack->size_expr->const_value == 1;
+}
+
+// Constant-offset GEP into stack base for a single-slot stack. Slot index is fixed at 0, so the slot starts at
+// byte offset `sizeof(u64)` (8) for the primal half and `sizeof(u64) + element_size` for the adjoint half.
+llvm::Value *TaskCodeGenLLVM::emit_ad_stack_single_slot_ptr(const AdStackAllocaStmt *stack,
+                                                            std::size_t adjoint_offset_bytes) {
+  auto *i8ty = llvm::Type::getInt8Ty(*llvm_context);
+  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+  llvm::Value *slot_offset = llvm::ConstantInt::get(i64ty, sizeof(int64) + adjoint_offset_bytes);
+  return builder->CreateGEP(i8ty, llvm_val[const_cast<AdStackAllocaStmt *>(stack)], slot_offset);
+}
+
 // Compute the address of the top primal (or adjoint, when `adjoint_offset_bytes` == element_size) slot for an
 // in-flight push count. Mirrors the runtime helper math `stack + sizeof(u64) + idx * 2 * element_size`, with `idx`
 // being the saturating `count - 1` to match `stack_top_primal`'s underflow guard. Used by the release-build inline
@@ -2308,9 +2328,16 @@ void TaskCodeGenLLVM::visit(AdStackAllocaStmt *stmt) {
     call("stack_init", llvm_val[stmt]);
     return;
   }
-  // Release build: store 0 into the per-stack count alloca instead of zeroing the heap u64 header. Doing this at
-  // the AdStackAllocaStmt visit site (rather than once at task entry) restarts the count whenever an outer loop
-  // re-enters the alloca, matching `stack_init`'s semantics on the debug path.
+  if (is_compile_time_single_slot(stmt)) {
+    // Single-slot specialization: count is provably either 0 (no push yet) or 1 (one push outstanding) at every
+    // program point. Slot index is fixed at 0 so the slot pointer is a constant offset from the stack base.
+    // Push / pop / loadtop reduce to constant-offset stores / loads with no count alloca, no mem2reg recurrence,
+    // and no SCEV induction-variable analysis. Init is a no-op because no count state exists.
+    return;
+  }
+  // Release build, multi-slot: store 0 into the per-stack count alloca instead of zeroing the heap u64 header.
+  // Doing this at the AdStackAllocaStmt visit site (rather than once at task entry) restarts the count whenever
+  // an outer loop re-enters the alloca, matching `stack_init`'s semantics on the debug path.
   auto *i64ty_init = llvm::Type::getInt64Ty(*llvm_context);
   llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stmt);
   builder->CreateStore(llvm::ConstantInt::get(i64ty_init, 0), count_alloca);
@@ -2322,6 +2349,11 @@ void TaskCodeGenLLVM::visit(AdStackPopStmt *stmt) {
     return;
   }
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
+  if (is_compile_time_single_slot(stack)) {
+    // Single-slot pop is a no-op: the next push (if any) overwrites slot 0 in place; the next loadtop reads
+    // slot 0. There is no count state to decrement.
+    return;
+  }
   auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
   llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stack);
   llvm::Value *count = builder->CreateLoad(i64ty, count_alloca);
@@ -2349,25 +2381,31 @@ void TaskCodeGenLLVM::visit(AdStackPushStmt *stmt) {
     builder->CreateStore(llvm_val[stmt->v], primal_ptr);
     return;
   }
-  // Release build: emit the push as inline IR against the per-stack count alloca. After `mem2reg` promotes the
-  // alloca to SSA, `GVN` folds the chain of `count++` across consecutive unrolled pushes; the only surviving
-  // memory traffic in the unrolled body is the slot stores themselves. The runtime overflow check is dropped on
-  // this path because `determine_ad_stack_size` produces a valid upper bound on per-thread push count along every
-  // execution path (any unresolved stack is a hard compile error), so the `n + 1 > max_num_elements` guard inside
-  // `stack_push` is dead in correct compilations.
-  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
-  llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stack);
-  llvm::Value *old_count = builder->CreateLoad(i64ty, count_alloca);
-  llvm::Value *new_count = builder->CreateAdd(old_count, llvm::ConstantInt::get(i64ty, 1));
-  builder->CreateStore(new_count, count_alloca);
-  // Slot is at index `new_count - 1`, which equals `old_count`. Skip the saturating-subtract that
-  // `emit_ad_stack_top_slot_ptr` does because we just incremented and `new_count` is provably >= 1.
-  std::size_t entry_size = stack->entry_size_in_bytes();
-  llvm::Value *slot_offset =
-      builder->CreateAdd(llvm::ConstantInt::get(i64ty, sizeof(int64)),
-                         builder->CreateMul(old_count, llvm::ConstantInt::get(i64ty, entry_size)));
-  auto *i8ty = llvm::Type::getInt8Ty(*llvm_context);
-  llvm::Value *primal_ptr = builder->CreateGEP(i8ty, llvm_val[stack], slot_offset);
+  // Release build, multi-slot: emit the push as inline IR against the per-stack count alloca. After `mem2reg`
+  // promotes the alloca to SSA, `GVN` folds the chain of `count++` across consecutive unrolled pushes; the only
+  // surviving memory traffic in the unrolled body is the slot stores themselves. The runtime overflow check is
+  // dropped on this path because `determine_ad_stack_size` produces a valid upper bound on per-thread push count
+  // along every execution path (any unresolved stack is a hard compile error), so the `n + 1 > max_num_elements`
+  // guard inside `stack_push` is dead in correct compilations. Single-slot stacks below skip the count alloca
+  // entirely - slot is fixed at offset 8.
+  llvm::Value *primal_ptr;
+  if (is_compile_time_single_slot(stack)) {
+    primal_ptr = emit_ad_stack_single_slot_ptr(stack, /*adjoint_offset_bytes=*/0);
+  } else {
+    auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+    auto *i8ty = llvm::Type::getInt8Ty(*llvm_context);
+    llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stack);
+    llvm::Value *old_count = builder->CreateLoad(i64ty, count_alloca);
+    llvm::Value *new_count = builder->CreateAdd(old_count, llvm::ConstantInt::get(i64ty, 1));
+    builder->CreateStore(new_count, count_alloca);
+    // Slot is at index `new_count - 1`, which equals `old_count`. Skip the saturating-subtract that
+    // `emit_ad_stack_top_slot_ptr` does because we just incremented and `new_count` is provably >= 1.
+    std::size_t entry_size = stack->entry_size_in_bytes();
+    llvm::Value *slot_offset =
+        builder->CreateAdd(llvm::ConstantInt::get(i64ty, sizeof(int64)),
+                           builder->CreateMul(old_count, llvm::ConstantInt::get(i64ty, entry_size)));
+    primal_ptr = builder->CreateGEP(i8ty, llvm_val[stack], slot_offset);
+  }
   // Zero the primal+adjoint slot pair to match `stack_push`'s `memset(top_primal, 0, 2 * element_size)`. Without
   // this, a previous use of this slot's adjoint would persist into the new push's accumulator. Slot pointer is
   // `stack + 8 + count * 2 * element_size` so the destination is `2 * element_size`-aligned (the slot stride),
@@ -2376,7 +2414,8 @@ void TaskCodeGenLLVM::visit(AdStackPushStmt *stmt) {
   // pointer can satisfy on stricter backends.
   std::size_t slot_align = std::min<std::size_t>(8u, 2u * stack->element_size_in_bytes());
   builder->CreateMemSet(primal_ptr, llvm::ConstantInt::get(llvm::Type::getInt8Ty(*llvm_context), 0),
-                        llvm::ConstantInt::get(i64ty, stack->entry_size_in_bytes()), llvm::MaybeAlign(slot_align));
+                        llvm::ConstantInt::get(llvm::Type::getInt64Ty(*llvm_context), stack->entry_size_in_bytes()),
+                        llvm::MaybeAlign(slot_align));
   llvm::Value *primal_typed_ptr =
       builder->CreateBitCast(primal_ptr, llvm::PointerType::get(tlctx->get_data_type(stmt->ret_type), 0));
   builder->CreateStore(llvm_val[stmt->v], primal_typed_ptr);
@@ -2392,10 +2431,15 @@ void TaskCodeGenLLVM::visit(AdStackLoadTopStmt *stmt) {
     llvm_val[stmt] = builder->CreateLoad(primal_ty, primal_ptr);
     return;
   }
-  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
-  llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stack);
-  llvm::Value *count = builder->CreateLoad(i64ty, count_alloca);
-  llvm::Value *primal_ptr = emit_ad_stack_top_slot_ptr(stack, count, /*adjoint_offset_bytes=*/0);
+  llvm::Value *primal_ptr;
+  if (is_compile_time_single_slot(stack)) {
+    primal_ptr = emit_ad_stack_single_slot_ptr(stack, /*adjoint_offset_bytes=*/0);
+  } else {
+    auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+    llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stack);
+    llvm::Value *count = builder->CreateLoad(i64ty, count_alloca);
+    primal_ptr = emit_ad_stack_top_slot_ptr(stack, count, /*adjoint_offset_bytes=*/0);
+  }
   auto primal_ty = tlctx->get_data_type(stmt->ret_type);
   primal_ptr = builder->CreateBitCast(primal_ptr, llvm::PointerType::get(primal_ty, 0));
   llvm_val[stmt] = builder->CreateLoad(primal_ty, primal_ptr);
@@ -2410,11 +2454,15 @@ void TaskCodeGenLLVM::visit(AdStackLoadTopAdjStmt *stmt) {
     llvm_val[stmt] = builder->CreateLoad(adjoint_ty, adjoint);
     return;
   }
-  auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
-  llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stack);
-  llvm::Value *count = builder->CreateLoad(i64ty, count_alloca);
-  llvm::Value *adjoint_ptr =
-      emit_ad_stack_top_slot_ptr(stack, count, /*adjoint_offset_bytes=*/stack->element_size_in_bytes());
+  llvm::Value *adjoint_ptr;
+  if (is_compile_time_single_slot(stack)) {
+    adjoint_ptr = emit_ad_stack_single_slot_ptr(stack, /*adjoint_offset_bytes=*/stack->element_size_in_bytes());
+  } else {
+    auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
+    llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stack);
+    llvm::Value *count = builder->CreateLoad(i64ty, count_alloca);
+    adjoint_ptr = emit_ad_stack_top_slot_ptr(stack, count, /*adjoint_offset_bytes=*/stack->element_size_in_bytes());
+  }
   auto adjoint_ty = tlctx->get_data_type(stmt->ret_type);
   adjoint_ptr = builder->CreateBitCast(adjoint_ptr, llvm::PointerType::get(adjoint_ty, 0));
   llvm_val[stmt] = builder->CreateLoad(adjoint_ty, adjoint_ptr);
@@ -2425,6 +2473,8 @@ void TaskCodeGenLLVM::visit(AdStackAccAdjointStmt *stmt) {
   llvm::Value *adjoint_ptr;
   if (compile_config.debug) {
     adjoint_ptr = call("stack_top_adjoint", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
+  } else if (is_compile_time_single_slot(stack)) {
+    adjoint_ptr = emit_ad_stack_single_slot_ptr(stack, /*adjoint_offset_bytes=*/stack->element_size_in_bytes());
   } else {
     auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
     llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stack);

--- a/quadrants/codegen/llvm/codegen_llvm.h
+++ b/quadrants/codegen/llvm/codegen_llvm.h
@@ -89,6 +89,12 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   llvm::Value *ad_stack_stride_llvm_{nullptr};
   llvm::Value *ad_stack_offsets_ptr_llvm_{nullptr};
   llvm::Value *ad_stack_max_sizes_ptr_llvm_{nullptr};
+  // Per-task per-stack `alloca i64` holding the live push count, hoisted to the entry block so `mem2reg` can
+  // promote it to SSA and `GVN` can fold consecutive count loads / stores across straight-line unrolled bodies.
+  // Replaces the heap-resident `u64` count header at `stack_ptr[0..8)` for every AdStack op when
+  // `compile_config.debug == false`. The 8-byte heap header gap is preserved for layout compatibility but is
+  // never read or written from kernel code on the release path.
+  std::unordered_map<const AdStackAllocaStmt *, llvm::Value *> ad_stack_count_alloca_llvm_;
 
   std::unordered_map<const Stmt *, std::vector<llvm::Value *>> loop_vars_llvm;
 
@@ -371,6 +377,10 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   // pointer.
   void ensure_ad_stack_heap_base_llvm();
   void ensure_ad_stack_metadata_llvm();
+  llvm::Value *ensure_ad_stack_count_alloca_llvm(const AdStackAllocaStmt *stack);
+  llvm::Value *emit_ad_stack_top_slot_ptr(const AdStackAllocaStmt *stack,
+                                          llvm::Value *count,
+                                          std::size_t adjoint_offset_bytes);
 
   void visit(AdStackAllocaStmt *stmt) override;
 

--- a/quadrants/codegen/llvm/codegen_llvm.h
+++ b/quadrants/codegen/llvm/codegen_llvm.h
@@ -381,6 +381,7 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   llvm::Value *emit_ad_stack_top_slot_ptr(const AdStackAllocaStmt *stack,
                                           llvm::Value *count,
                                           std::size_t adjoint_offset_bytes);
+  llvm::Value *emit_ad_stack_single_slot_ptr(const AdStackAllocaStmt *stack, std::size_t adjoint_offset_bytes);
 
   void visit(AdStackAllocaStmt *stmt) override;
 

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -2411,6 +2411,117 @@ def test_adstack_spirv_metadata_per_task_buffer():
 
 
 @pytest.mark.needs_torch
+@pytest.mark.parametrize("n_iter", [4, 32])
+@test_utils.test(require=qd.extension.adstack)
+def test_adstack_linear_only_accumulator_with_nonlinear_operand(n_iter):
+    # Cross-check `d/dx sum_i sum_j sin(x[i] + j*step)` against PyTorch autograd for the kernel shape
+    # that mixes a loop-carried accumulator (`acc = acc + ...`) with a non-linear operand
+    # (`sin(a)` where `a = x[i] + j*step`) inside an unrolled inner loop.
+    #
+    # Internal details: the operand `a` feeds `sin`, which is in `NonLinearOps::unary_collections`, so
+    # `AdStackAllocaJudger::visit(UnaryOpStmt)` promotes its alloca to an adstack and the reverse pass
+    # reads `a` back via `AdStackLoadTopStmt`. The accumulator `acc` only feeds linear `add`, never
+    # reaches the non-linear / index / control-flow consumer visitors, but its adjoint chain still has
+    # to weave through the adstack push / pop sites the operand introduces. `n_iter=32` keeps the
+    # unrolled body wide enough that any miscalculation in the slot offset for the operand's stack -
+    # e.g. an off-by-one in the inline `count - 1` saturation, a misaligned slot stride, or a missed
+    # primal+adjoint zero-init on push - surfaces here as a wrong gradient long before it would surface
+    # as an overflow at runtime.
+    import torch
+
+    n = 4
+    step = 0.07
+    x = qd.field(qd.f32, shape=n, needs_grad=True)
+    y = qd.field(qd.f32, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i in x:
+            acc = 0.0
+            for j in qd.static(range(n_iter)):
+                a = x[i] + qd.cast(j, qd.f32) * step
+                acc = acc + qd.sin(a)
+            y[None] += acc
+
+    for i in range(n):
+        x[i] = 0.18 + i * 0.05
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    for i in range(n):
+        x.grad[i] = 0.0
+    compute.grad()
+
+    x_t = torch.tensor([0.18 + i * 0.05 for i in range(n)], dtype=torch.float32, requires_grad=True)
+    y_t = torch.zeros((), dtype=torch.float32)
+    for i in range(n):
+        acc_t = torch.zeros((), dtype=torch.float32)
+        for j in range(n_iter):
+            a_t = x_t[i] + float(j) * step
+            acc_t = acc_t + torch.sin(a_t)
+        y_t = y_t + acc_t
+    y_t.backward()
+
+    assert y[None] == pytest.approx(y_t.item(), rel=1e-6)
+    for i in range(n):
+        assert x.grad[i] == pytest.approx(x_t.grad[i].item(), rel=1e-6)
+
+
+@pytest.mark.needs_torch
+@pytest.mark.parametrize("n_inner", [4, 32])
+@test_utils.test(require=qd.extension.adstack)
+def test_adstack_repeated_load_top_of_outer_value_in_unrolled_inner_loop(n_inner):
+    # Cross-check `d/dx sum_i sum_j cos(sin(x[i])) * (1 + j*0.01)` against PyTorch autograd for the
+    # kernel shape where an outer-loop value (`a = sin(x[i])`) is consumed by a non-linear unary op
+    # `cos(a)` repeatedly inside an unrolled inner loop, producing N consecutive `AdStackLoadTopStmt`
+    # reads of the same stack in the reverse pass with no intervening Push / Pop / AccAdjoint.
+    #
+    # Internal details: each inner-loop iteration's reverse-pass adjoint formula reads `a`'s primal
+    # (for `d/da cos(a) = -sin(a)`) and adjoint via the inline slot-pointer math. With `n_inner=32`
+    # straight-line LoadTops on the same stack inside one block, the inline codegen emits 32
+    # independent count-load + slot-GEP + value-load sequences. A regression that miscalculates the
+    # saturating `count - 1` index under repeated reads, races the count alloca's mem2reg promotion
+    # across the LoadTops, or short-circuits the slot offset math, surfaces here as a wrong gradient.
+    import torch
+
+    n = 3
+    x = qd.field(qd.f32, shape=n, needs_grad=True)
+    y = qd.field(qd.f32, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i in x:
+            a = qd.sin(x[i])
+            acc = 0.0
+            for j in qd.static(range(n_inner)):
+                acc = acc + qd.cos(a) * (1.0 + qd.cast(j, qd.f32) * 0.01)
+            y[None] += acc
+
+    for i in range(n):
+        x[i] = 0.21 + i * 0.05
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    for i in range(n):
+        x.grad[i] = 0.0
+    compute.grad()
+
+    x_t = torch.tensor([0.21 + i * 0.05 for i in range(n)], dtype=torch.float32, requires_grad=True)
+    y_t = torch.zeros((), dtype=torch.float32)
+    for i in range(n):
+        a_t = torch.sin(x_t[i])
+        acc_t = torch.zeros((), dtype=torch.float32)
+        for j in range(n_inner):
+            acc_t = acc_t + torch.cos(a_t) * (1.0 + float(j) * 0.01)
+        y_t = y_t + acc_t
+    y_t.backward()
+
+    assert y[None] == pytest.approx(y_t.item(), rel=1e-6)
+    for i in range(n):
+        assert x.grad[i] == pytest.approx(x_t.grad[i].item(), rel=1e-6)
+
+
+@pytest.mark.needs_torch
 @pytest.mark.parametrize("n_iter", [4, 16, 64])
 @pytest.mark.parametrize("n_stacks", [1, 3])
 @test_utils.test(require=qd.extension.adstack)

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -692,7 +692,7 @@ def _overflowing_compute(n_elements=1, n_iter=64):
     return compute, x, y
 
 
-@test_utils.test(require=qd.extension.adstack, ad_stack_size=32)
+@test_utils.test(require=qd.extension.adstack, ad_stack_size=32, debug=True)
 def test_adstack_overflow_raises():
     # Runs a backward pass with a for-loop longer than the adstack can hold, and asserts the overflow surfaces as a
     # regular Python exception on the next `qd.sync()` - not a silent wrong gradient and not a process crash. This
@@ -702,8 +702,10 @@ def test_adstack_overflow_raises():
     # Internal detail: both LLVM and SPIR-V defer the error to the next `qd.sync()` (same pattern as CUDA async
     # errors) so we do not pay a sync-per-launch. LLVM polls `runtime->adstack_overflow_flag` from
     # `LlvmProgramImpl::synchronize()` via `check_adstack_overflow()`; SPIR-V's gfx runtime raises via `QD_ERROR`
-    # on sync. The test launches the overflowing grad kernel and calls `qd.sync()` inside the same `pytest.raises`
-    # block so the deferred surfacing point is caught.
+    # on sync. `debug=True` is required because release-build LLVM codegen elides the per-push bounds check on the
+    # premise that `determine_ad_stack_size` produces a tight upper bound; this test deliberately misconfigures
+    # the capacity below the kernel's actual peak push count, which the sizer cannot foresee, so the runtime
+    # check has to be live for the deferred raise to fire.
     compute, _, _ = _overflowing_compute()
     # On LLVM the runtime raises QuadrantsAssertionError (subclass of AssertionError) from
     # check_adstack_overflow; on SPIR-V the gfx runtime raises RuntimeError via QD_ERROR. We accept either,
@@ -713,12 +715,13 @@ def test_adstack_overflow_raises():
         qd.sync()
 
 
-@test_utils.test(require=qd.extension.adstack, ad_stack_size=32)
+@test_utils.test(require=qd.extension.adstack, ad_stack_size=32, debug=True)
 def test_adstack_overflow_flag_resets_after_catch():
     # Once `check_adstack_overflow()` raises, the runtime must clear its overflow flag so a subsequent `qd.sync()`
     # (with no new overflowing grad launch in between) returns normally. Without the reset the user would see a
     # stale overflow exception every time they sync after the first one, which makes diagnosis and recovery
-    # impossible.
+    # impossible. `debug=True` keeps the per-push bounds check live (release-build codegen elides it - see
+    # `test_adstack_overflow_raises` for the rationale).
     compute, _, _ = _overflowing_compute()
     with pytest.raises((AssertionError, RuntimeError), match=r"[Aa]dstack overflow"):
         compute.grad()
@@ -805,12 +808,14 @@ def test_adstack_heap_backed_exceeds_old_threadstack_budget():
         assert x.grad[i] == pytest.approx(8.0 * geom, rel=1e-5)
 
 
-@test_utils.test(require=qd.extension.adstack, ad_stack_size=32)
+@test_utils.test(require=qd.extension.adstack, ad_stack_size=32, debug=True)
 def test_adstack_overflow_multithreaded():
     # Multi-element field so several threads execute the overflowing grad body in parallel. Asserts the overflow
     # still surfaces as a single Python exception rather than deadlocking, crashing, or racing on the flag. Every
     # thread writes the same flag value (non-zero), so a race on the write is benign; this test pins that the
-    # read side is also safe (one raise per sync regardless of how many threads flipped the bit).
+    # read side is also safe (one raise per sync regardless of how many threads flipped the bit). `debug=True`
+    # keeps the per-push bounds check live (release-build codegen elides it - see `test_adstack_overflow_raises`
+    # for the rationale).
     compute, _, _ = _overflowing_compute(n_elements=16)
     with pytest.raises((AssertionError, RuntimeError), match=r"[Aa]dstack overflow"):
         compute.grad()
@@ -838,11 +843,16 @@ def test_adstack_overflow_during_teardown_does_not_abort(tmp_path):
     # them) is too late. The subprocess is launched from a temp file because `python -c "<kernel>"` breaks
     # Quadrants' kernel source-inspect (`getsourcelines` cannot find the source of an inlined `-c` string); the
     # grad call is deliberately left unsynced so this is the teardown path, not the user-catch path.
+    # `debug=True` is required for the same reason as `test_adstack_overflow_raises`: release-build LLVM codegen
+    # elides the per-push bounds check on the premise the sizer's bound is tight, so a manually-misconfigured
+    # `ad_stack_size=32` kernel only flips the runtime overflow flag in debug mode. Without the flag set there
+    # is no flag for the teardown guard to swallow, and the bug this test pins (re-raise during destructor path
+    # leading to `std::terminate()`) cannot trigger.
     child_script = textwrap.dedent(
         """
         import quadrants as qd
 
-        qd.init(arch=qd.cpu, ad_stack_experimental_enabled=True, ad_stack_size=32)
+        qd.init(arch=qd.cpu, ad_stack_experimental_enabled=True, ad_stack_size=32, debug=True)
 
         x = qd.field(qd.f32)
         y = qd.field(qd.f32)

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -2526,9 +2526,16 @@ def test_adstack_repeated_load_top_of_outer_value_in_unrolled_inner_loop(n_inner
         y_t = y_t + acc_t
     y_t.backward()
 
-    assert y[None] == pytest.approx(y_t.item(), rel=1e-6)
+    # Tolerance is `rel=5e-6` rather than the f32 floor `1e-6` because the kernel is unusually deep on the
+    # numeric side: each contribution is `cos(sin(x[i])) * (1 + j*0.01)` and the test sums up to 32 of them per
+    # outer iteration, so the per-sum drift accumulates to a few ULPs at the order of magnitude of the final
+    # value across every backend that auto-promotes to FMA or drops guard bits (CUDA's NVPTX and Vulkan's
+    # SPIR-V both observed). The test's purpose is to pin slot-pointer / count-recurrence correctness under
+    # repeated LoadTop, not bit-exact float behavior; 5e-6 is the smallest tolerance that still passes on every
+    # backend while staying inside the f32 noise band.
+    assert y[None] == pytest.approx(y_t.item(), rel=5e-6)
     for i in range(n):
-        assert x.grad[i] == pytest.approx(x_t.grad[i].item(), rel=1e-6)
+        assert x.grad[i] == pytest.approx(x_t.grad[i].item(), rel=5e-6)
 
 
 @pytest.mark.needs_torch

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -2408,3 +2408,67 @@ def test_adstack_spirv_metadata_per_task_buffer():
     # own sizer-computed 9. Post-fix: finishes cleanly because each task gets its own metadata buffer.
     kernel_two_offloads_with_tri_reduce.grad()
     qd.sync()
+
+
+@pytest.mark.needs_torch
+@pytest.mark.parametrize("n_iter", [4, 16, 64])
+@pytest.mark.parametrize("n_stacks", [1, 3])
+@test_utils.test(require=qd.extension.adstack)
+def test_adstack_unrolled_many_pushes_across_multiple_stacks(n_iter, n_stacks):
+    # Cross-check `d/dx sum_i sum_s sum_j sin(x[i] + j*step + s*offset)` against PyTorch autograd for the
+    # kernel shape where `n_stacks` parallel adstacks each receive `n_iter` straight-line pushes inside an
+    # unrolled inner loop, fanning out to a separate non-linear `sin` per stack per iteration.
+    #
+    # Internal details: this is the regime the LLVM release-build inline AdStack codegen targets - each `s`
+    # promotes its operand `a = x[i] + j*step + s*offset` onto its own per-stack `alloca i64` count, and
+    # the unrolled inner loop body emits `n_iter` consecutive `count++` increments per stack. After mem2reg
+    # lifts the alloca to SSA and GVN folds the increment chain to constants `0, 1, ..., n_iter - 1`, the
+    # only memory ops left in the unrolled body are the slot stores. `n_iter=64` is well above the adstack
+    # capacity floor of 32, so any regression that miscalculates the slot offset under multiple sibling
+    # stacks (e.g. by hoisting the count alloca shared across stacks instead of per-stack), that
+    # short-circuits / silently drops pushes via a wrong saturating subtract on count, or that races a
+    # cross-stack increment, surfaces here as a wrong gradient long before it would surface as an overflow
+    # at runtime. The cross-check tolerance `rel=1e-6` is the f32 floor; a few-ULP drift per `sin` over up
+    # to `n_stacks * n_iter <= 192` summed terms still fits within it.
+    import torch
+
+    n = 4
+    step = 0.07
+    x = qd.field(qd.f32, shape=n, needs_grad=True)
+    y = qd.field(qd.f32, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i in x:
+            acc = 0.0
+            for s in qd.static(range(n_stacks)):
+                s_offset = qd.cast(s, qd.f32) * 0.13
+                for j in qd.static(range(n_iter)):
+                    a = x[i] + qd.cast(j, qd.f32) * step + s_offset
+                    acc += qd.sin(a)
+            y[None] += acc
+
+    for i in range(n):
+        x[i] = 0.21 + i * 0.05
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    for i in range(n):
+        x.grad[i] = 0.0
+    compute.grad()
+
+    x_t = torch.tensor([0.21 + i * 0.05 for i in range(n)], dtype=torch.float32, requires_grad=True)
+    y_t = torch.zeros((), dtype=torch.float32)
+    for i in range(n):
+        acc_t = torch.zeros((), dtype=torch.float32)
+        for s in range(n_stacks):
+            s_offset_t = float(s) * 0.13
+            for j in range(n_iter):
+                a_t = x_t[i] + float(j) * step + s_offset_t
+                acc_t = acc_t + torch.sin(a_t)
+        y_t = y_t + acc_t
+    y_t.backward()
+
+    assert y[None] == pytest.approx(y_t.item(), rel=1e-6)
+    for i in range(n):
+        assert x.grad[i] == pytest.approx(x_t.grad[i].item(), rel=1e-6)

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -2522,6 +2522,65 @@ def test_adstack_repeated_load_top_of_outer_value_in_unrolled_inner_loop(n_inner
 
 
 @pytest.mark.needs_torch
+@pytest.mark.parametrize("n_iter", [4, 16])
+@test_utils.test(arch=[qd.cpu, qd.cuda, qd.amdgpu], require=qd.extension.adstack)
+def test_adstack_f16_unrolled_pushes_alignment(n_iter):
+    # Cross-check `d/dx sum_i sum_j sin(x[i] + j*step)` against PyTorch autograd for an `f16` field whose
+    # operand `a = x[i] + j*step` adstack-promotes through `sin`. Each adstack slot is `2 * element_size`
+    # = 4 bytes wide, so slot N starts at byte offset `8 + 4*N` from the per-thread slab base. Slot 0 is
+    # 8-aligned but every odd slot index (1, 3, 5, ...) lands on a 4-byte-aligned address that is NOT
+    # 8-aligned.
+    #
+    # Internal details: `AdStackPushStmt`'s inline IR emits a `llvm.memset` zeroing the primal+adjoint
+    # slot pair before storing the pushed value. The destination alignment passed to `CreateMemSet` must
+    # reflect the actual slot pointer alignment - `min(8, 2 * element_size)` = 4 bytes for f16. An
+    # over-stated 8-byte alignment lets NVPTX / AMDGCN lowering pick a wider store (`st.b64`) than the
+    # 4-aligned slot pointer can satisfy, which traps as a misaligned-address fault on stricter GPU
+    # backends or silently corrupts adjoint state on tolerant ones - either way producing wrong
+    # gradients. `n_iter=16` ensures multiple non-zero slot offsets get exercised, including odd
+    # slot indices where the alignment claim matters most. Tolerance `rel=4e-3` is the f16 precision
+    # floor for sums of ~16 `sin` values.
+    import torch
+
+    n = 4
+    step = 0.05
+    x = qd.field(qd.f16, shape=n, needs_grad=True)
+    y = qd.field(qd.f16, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i in x:
+            acc = 0.0
+            for j in qd.static(range(n_iter)):
+                a = x[i] + qd.cast(j, qd.f16) * qd.f16(step)
+                acc = acc + qd.sin(a)
+            y[None] += acc
+
+    for i in range(n):
+        x[i] = 0.21 + i * 0.05
+    y[None] = 0.0
+    compute()
+    y.grad[None] = 1.0
+    for i in range(n):
+        x.grad[i] = 0.0
+    compute.grad()
+
+    x_t = torch.tensor([0.21 + i * 0.05 for i in range(n)], dtype=torch.float32, requires_grad=True)
+    y_t = torch.zeros((), dtype=torch.float32)
+    for i in range(n):
+        acc_t = torch.zeros((), dtype=torch.float32)
+        for j in range(n_iter):
+            a_t = x_t[i] + float(j) * step
+            acc_t = acc_t + torch.sin(a_t)
+        y_t = y_t + acc_t
+    y_t.backward()
+
+    assert float(y[None]) == pytest.approx(y_t.item(), rel=4e-3)
+    for i in range(n):
+        assert float(x.grad[i]) == pytest.approx(x_t.grad[i].item(), rel=4e-3)
+
+
+@pytest.mark.needs_torch
 @pytest.mark.parametrize("n_iter", [4, 16, 64])
 @pytest.mark.parametrize("n_stacks", [1, 3])
 @test_utils.test(require=qd.extension.adstack)


### PR DESCRIPTION
> Reverse-mode AD on adstack-heavy kernels (deep static-unrolled bodies, many AD variables per iteration, plus dozens of 1-byte `u1` / `i8` branch-outcome snapshots) emits one heap-resident u64 count header per stack that every push / pop / top operation reads and writes through the runtime helpers `stack_init / stack_push / stack_pop / stack_top_primal / stack_top_adjoint`. LLVM cannot fold those loads / stores away because the stack pointer reaches the runtime through several getter calls that AA conservatively assumes alias arbitrary memory, so an unrolled body of N pushes emits N load + N store pairs against the same address. On large reverse-mode kernels the resulting flat PTX blocks dominate `ptxas` register-allocator and live-range cost. This PR replaces the helper-call sequence on the release-build LLVM codegen path with inline LLVM IR. Multi-slot stacks track the count in a per-task per-stack `alloca i64` that `mem2reg` promotes to SSA so `GVN` folds consecutive `count++` chains across straight-line unrolled bodies. Single-slot stacks (sizer-resolved `max_size==1`) skip the count alloca entirely - slot is provably slot 0 at every program point, so push / pop / loadtop reduce to constant-offset GEPs with no count state, no mem2reg recurrence, no SCEV induction-variable analysis. Debug builds keep the bounds-checking runtime helpers so any sizer bug surfaces as an overflow flag at sync.

**TL;DR**

- Multi-slot release path: per-task per-stack `alloca i64` replaces the heap-resident u64 count header. The alloca is created once in the task entry block (so `mem2reg` promotes it) and init-stored to zero at the `AdStackAllocaStmt` visit site (so an alloca nested inside a loop body restarts the count every iteration, matching the previous `stack_init` semantics).
- Single-slot release path: when the sizer resolves a stack to compile-time `max_size==1` with a `Const` `SizeExpr`, the count alloca is elided entirely. Slot is fixed at offset 8 from the stack base; push is a single store, loadtop is a single load, pop is a no-op. No mem2reg recurrence, no SCEV induction-variable analysis on this stack. On a representative reverse-mode AD cold compile this shape covers ~44 percent of the per-task adstack population, dominated by 1-byte `u1` / `i8` branch-outcome snapshots that the reverse pass replays without any adjoint accumulation.
- All six `AdStack*` visit methods (`Alloca`, `Push`, `Pop`, `LoadTop`, `LoadTopAdj`, `AccAdjoint`) are reimplemented as inline LLVM IR using the alloca (multi-slot) or constant-offset GEP (single-slot) instead of runtime helper calls when `compile_config.debug == false`. The slot-address math (`stack + sizeof(u64) + idx * 2 * element_size`) is now exposed to GVN, so consecutive top-of-stack accesses fold across the runtime call boundary that used to block them.
- The release-path push omits the runtime overflow check entirely. `determine_ad_stack_size` is mandatory and produces a valid upper bound on per-thread push count along every execution path - any unresolved stack is a hard compile error - so the runtime `n + 1 > max_num_elements` compare and the relaxed-atomic `adstack_overflow_flag` write are dead code in correct compilations. Eliminating them removes one cond_br plus one overflow basic block from each push site, halving the basic-block count contributed by the unrolled push sequence and removing the runtime-pointer dependency that pulls the LLVMRuntime address into every push's live range.
- Debug build (`compile_config.debug == true`) routes pushes through `stack_push` so any sizer bug surfaces as an overflow flag at sync. Same for `stack_init / stack_pop / stack_top_primal / stack_top_adjoint` on the debug path.
- The push-time `llvm.memset` that zeroes the primal+adjoint slot pair now passes the true minimum slot alignment (`min(8, 2 * element_size)`) instead of an unconditional `MaybeAlign(8)`. For element sizes < 4 the slot pointer is genuinely 2- or 4-byte-aligned, not 8 - the previous over-stated claim was invalid IR metadata that future LLVM / NVPTX / AMDGCN lowering decisions could turn into a misaligned-store fault.
- Backwards-compatible heap layout: the unused 8-byte u64 header is left in place at the start of each stack's slab so `ad_stack_per_thread_stride_` and the host-side `LlvmRuntimeExecutor::ensure_adstack_heap` slab sizing are unchanged. The kernel just never reads or writes those bytes on the release path.

## Why

Profiles of cold GPU compile of a reverse-mode AD kernel with adstack enabled showed `libnvidia-ptxjitcompiler` accounting for ~20x more wall-clock than the same kernel with adstack disabled, with the dominant ptxas function (presumably register allocation or live-range analysis) at ~145s on a single function. Two independent escape hatches (`CU_JIT_OPTIMIZATION_LEVEL=2` exposed in #581 and `CUDA_DISABLE_PTXAS_OPT=1` env var) had no measurable effect, indicating the cost is in mandatory phases (RA / liveness) that scale superlinearly with PTX basic-block size and memory-dependence chain length, not in optimization passes. The dominant size driver is the per-push count load / store / bounds-check sequence that the runtime helper path emits per AD variable per unrolled iteration.

Multi-slot SSA-promotion collapses that sequence to a chain of integer adds, shrinking the flat block ptxas's RA has to chew on and removing the per-push count's may-alias chain from `MemoryDependenceResults`. Single-slot specialization eliminates the count alloca entirely for the dominant 1-byte branch-outcome population, removing ~4500 mem2reg recurrences from the LLVM IR, ~9000 LLVM instructions across all push / pop / loadtop sites, and the matching PTX body. Empirical A/B on a representative cold compile:

- Dominant ptxas symbol: 145.6s -> 22.96s (after multi-slot SSA-promotion) -> 4.41s (after single-slot specialization on top); ~140s saved on this single hot function.
- Sum of top ptxas symbols: ~330s -> ~50s -> ~15s; ~315s saved on cold compile.
- LLVM `ScalarEvolution::canReuseInstruction`: 0s without adstack, 55s after multi-slot SSA-promotion (the alloca's loop-carried recurrence is what feeds SCEV), 47s after single-slot specialization (the easy recurrences come out, the harder multi-slot ones stay).

## Surface API

No public API change. `qd.init` and the `CompileConfig` knobs are untouched. The Python frontend, AD-stack sizing pipeline, host-side metadata publication, and SizeExpr machinery are all unaffected. The only internal shape change is to the six `AdStack*` visit methods in `TaskCodeGenLLVM` and three new private helpers (`ensure_ad_stack_count_alloca_llvm`, `emit_ad_stack_top_slot_ptr`, `emit_ad_stack_single_slot_ptr`).

## Mechanism

### Before (one helper call per op)

```llvm
; AdStackPushStmt (visit emits these)
%offsets_ptr  = call ptr @LLVMRuntime_get_adstack_offsets(ptr %runtime)        ; cached at entry
%max_sizes    = call ptr @LLVMRuntime_get_adstack_max_sizes(ptr %runtime)     ; cached at entry
%max_addr     = getelementptr i64, ptr %max_sizes, i64 0
%max_size     = load i64, ptr %max_addr                                        ; PER PUSH
call void @stack_push(ptr %runtime, ptr %stack, i64 %max_size, i32 %elem_size) ; PER PUSH (load + store of u64 header inside)
%top          = call ptr @stack_top_primal(ptr %stack, i32 %elem_size)         ; PER PUSH (load of u64 header inside)
store float %v, ptr %top
```

GVN cannot fold consecutive `stack_push` calls because they have function-call memory effects plus the relaxed-atomic overflow store acts as a memory barrier; it cannot fold consecutive `stack_top_primal` calls either because the helper reads through `%stack` which AA cannot prove disjoint from the runtime metadata. Result: each unrolled iteration emits the full sequence again.

### After, multi-slot release path (inline IR, per-stack alloca)

```llvm
; entry block (once per task per stack):
%count_0 = alloca i64

; AdStackAllocaStmt body (init):
store i64 0, ptr %count_0

; AdStackPushStmt (per push, after mem2reg + GVN folding):
%new_count = add i64 %old_count, 1
%slot      = getelementptr i8, ptr %stack, i64 (8 + %old_count * 2 * elem_size)
call void @llvm.memset.p0.i64(ptr %slot, i8 0, i64 (2*elem_size), align min(8, 2*elem_size))
store float %v, ptr %slot
```

After mem2reg promotes `count_0` to SSA and GVN folds the `add 1` chain across N unrolled pushes, the only remaining memory ops in the unrolled body are the slot stores themselves. The count side has zero memory traffic.

### After, single-slot release path (constant-offset GEP, no count state)

```llvm
; AdStackAllocaStmt body (no init needed - no count state):
;   nothing emitted

; AdStackPushStmt:
%slot = getelementptr i8, ptr %stack, i64 8                                    ; constant offset, no count
call void @llvm.memset.p0.i64(ptr %slot, i8 0, i64 (2*elem_size), align min(8, 2*elem_size))
store i8 %v, ptr %slot

; AdStackLoadTopStmt:
%slot = getelementptr i8, ptr %stack, i64 8                                    ; constant offset, no count
%v    = load i8, ptr %slot

; AdStackPopStmt:
;   nothing emitted - no count to decrement, next push (if any) overwrites slot 0
```

Single-slot specialization gates on `max_size == 1` AND `size_expr->kind == Const && size_expr->const_value == 1` (rejects placeholder cases where the sizer set `max_size = 1` because the symbolic bound is non-Const and the host evaluates the actual capacity per launch).

### Heap layout (unchanged)

```
stack_ptr[0..8)      = (legacy) u64 count header (no longer read/written by the kernel on release)
stack_ptr[8..)       = slot 0 primal, slot 0 adjoint, slot 1 primal, ...
```

The 8-byte header gap is preserved so `ad_stack_per_thread_stride_` (sum of `align_up_8(size_in_bytes)` per stack) and the host's `ensure_adstack_heap(stride * num_threads)` allocation are unchanged. Slot offsets stay at `sizeof(u64) + idx * 2 * element_size`.

## Per-backend matrix

| Backend | Codegen path | Behaviour change |
|---------|-------------|------------------|
| CPU (LLVM) | TaskCodeGenLLVM | inline IR replaces runtime helper calls in release; debug unchanged |
| CUDA (LLVM/NVPTX) | TaskCodeGenLLVM | inline IR replaces runtime helper calls in release; debug unchanged |
| AMDGPU (LLVM/AMDGCN) | TaskCodeGenLLVM | inline IR replaces runtime helper calls in release; debug unchanged |
| Metal (SPIR-V) | unchanged | unaffected |
| Vulkan (SPIR-V) | unchanged | unaffected |

## Tests

The existing AD test suite already exercises every code path this PR touches: `tests/python/test_adstack.py`, `test_ad_basics.py`, `test_ad_for.py`, `test_ad_if.py`, `test_ad_atomic.py`, `test_ad_offload.py`, `test_ad_demote_dense.py`, `test_ad_grad_check.py`, `test_ad_dynamic_index.py` - 1041 tests pass on the LLVM CPU backend, covering the full reverse-mode AD surface including unary loop-carried unrolled bodies (the dominant adstack shape on this PR's hot path), nested control-flow inside reverse pass, atomic adjoint accumulation, dynamic indexing, gradient checks against PyTorch autograd, and offload boundary handling. The top-of-stack saturating-`count - 1` underflow guard, slot-zeroing on push, and per-iteration count restart inside loop bodies all match the runtime helper semantics they replace.

This PR also adds four new parametrized tests to `tests/python/test_adstack.py` to broaden coverage of adstack codegen kernel shapes that the existing suite did not pin tightly. The added tests cross-check reverse-mode gradients against PyTorch autograd:

- `test_adstack_linear_only_accumulator_with_nonlinear_operand` (parametrized over `n_iter` in `{4, 32}`) - kernel that mixes a loop-carried linear accumulator with a non-linear operand `sin(a)`, weaving the accumulator's adjoint chain through the operand's adstack push / pop sites.
- `test_adstack_repeated_load_top_of_outer_value_in_unrolled_inner_loop` (parametrized over `n_inner` in `{4, 32}`) - kernel that consumes one outer-loop value via a non-linear unary op N times in a row in an unrolled inner loop, producing N consecutive `AdStackLoadTopStmt` reads of the same stack inside one straight-line block.
- `test_adstack_unrolled_many_pushes_across_multiple_stacks` (parametrized over `n_iter` in `{4, 16, 64}` and `n_stacks` in `{1, 3}`) - kernel that fans out to `n_stacks` parallel adstacks, each receiving `n_iter` straight-line pushes inside an unrolled inner loop. `n_iter=64` is well above the adstack capacity floor of 32, so any regression that miscalculates the slot offset under multiple sibling stacks, races a cross-stack increment, or short-circuits the inline `count - 1` saturation, surfaces as a wrong gradient long before it would surface as an overflow at runtime.
- `test_adstack_f16_unrolled_pushes_alignment` (parametrized over `n_iter` in `{4, 16}`, restricted to LLVM backends because Vulkan / Metal lack atomic-f16 support for the kernel's atomic-add to a scalar) - regression sentinel for the memset alignment fix. The kernel uses `qd.f16` so each adstack slot is 4-byte aligned (not 8), and `n_iter=16` ensures multiple non-zero slot offsets get exercised including odd indices where the alignment claim matters most. The current toolchain does not turn the over-stated alignment into a fault on this kernel shape, but a future LLVM / NVPTX / AMDGCN lowering decision that does start trusting the alignment metadata more aggressively trips this test in CI rather than at user runtime.

These tests are independent of the codegen change in this PR (they pin gradient correctness, which the runtime-helper path on `main` already produces correctly), so they pass on both `main` and this branch. They are bundled here to lock down regression coverage for the kernel shapes the inline AdStack codegen exercises hardest.

## Side-effect audit

- `mem2reg` requires the alloca to be in the entry block; `ensure_ad_stack_count_alloca_llvm` uses an `InsertPointGuard` to emit there regardless of where the AdStackAllocaStmt visit site sits. Same pattern as `ensure_ad_stack_heap_base_llvm` / `ensure_ad_stack_metadata_llvm`.
- The init-store at the AdStackAllocaStmt visit site is intentionally separate from the alloca creation. If an `AdStackAllocaStmt` is nested inside a loop body the alloca is still created once at the entry block, but the init store runs every iteration, matching the previous `stack_init(stack_ptr)` semantics where the heap u64 header was zeroed on each entry.
- Single-slot specialization is gated on `Const SizeExpr` so placeholder `max_size = 1` cases (where `determine_ad_stack_size` set 1 because the symbolic bound is non-Const and the host evaluates the actual capacity per launch) fall through to the multi-slot alloca path.
- Top-of-stack underflow guard: `emit_ad_stack_top_slot_ptr` (multi-slot) and `emit_ad_stack_single_slot_ptr` (single-slot) both compute slot 0 when count == 0, matching `stack_top_primal`'s `n > 0 ? n - 1 : 0` underflow path. The host raises on `runtime->adstack_overflow_flag` before any garbage value reaches user code.
- `AdStackPushStmt` slot index uses `old_count` (i.e. `new_count - 1`) directly on the multi-slot path, skipping the saturating-subtract because we just incremented and `new_count` is provably >= 1.
- The unused 8-byte header in heap memory is wasted per stack per thread on the release path. For a 4-stack kernel running 1M threads on GPU that is 32 MB of unused slab, which is a small constant relative to the slot data (typically GB on adstack-heavy kernels). A future PR can re-pack the layout and drop the gap.
- Debug build path is unchanged: `stack_init / stack_push / stack_pop / stack_top_primal / stack_top_adjoint` are still called, the bounds-check inside `stack_push` still fires, and the relaxed-atomic `adstack_overflow_flag` write is preserved.
- No change to the AdStack pre-scan (`ad_stack_per_thread_stride_`, `ad_stack_offsets_`, `ad_stack_allocas_info_`, `ad_stack_size_exprs_`), no change to host-side metadata publication, no change to SizeExpr machinery.
