### PR TITLE
[Vulkan] Move adstack-sizer scratch out of Function-scope memory to fix SPIR-V pipeline build failures

### DIFF
--- a/quadrants/codegen/spirv/adstack_sizer_shader.cpp
+++ b/quadrants/codegen/spirv/adstack_sizer_shader.cpp
@@ -114,15 +114,21 @@ void store_buf_u32(IRBuilder &ir, Value buffer, Value word_idx, Value value) {
   ir.store_variable(ptr, value);
 }
 
-// Access an i64 slot inside a local alloca'd i64 array. `array_ptr` is the alloca result.
-Value array_i64_access_ptr(IRBuilder &ir, Value array_ptr, Value index) {
-  SType ptr_ty = ir.get_pointer_type(ir.i64_type(), spv::StorageClassFunction);
-  return ir.make_value(spv::OpAccessChain, ptr_ty, array_ptr, index);
+// Access an i64 / i32 slot inside the per-invocation interpreter scratch state. The state is hosted in two
+// `StorageBuffer` SSBOs (binding 3 = i64 scratch, binding 4 = i32 scratch) rather than `Function`-storage arrays
+// because Blackwell-class NVIDIA Vulkan drivers cap per-thread private memory at a budget the cumulative
+// `i64[kMaxNodes] + i64[kMaxVars] + 8x array[kMaxPending]` (~34 KiB) blows through, failing `vkCreateComputePipelines`
+// with `VK_ERROR_UNKNOWN`. Each per-array slice within a scratch SSBO has a fixed compile-time base index
+// (`base_in_elems`); element access is `base_in_elems + index` then `OpAccessChain` through the SSBO's runtime array.
+// The sizer dispatches `1x1x1` so cross-thread aliasing is impossible.
+Value array_i64_access_ptr(IRBuilder &ir, Value scratch_i64_buf, uint32_t base_in_elems, Value index) {
+  Value abs_idx = ir.add(ir.uint_immediate_number(ir.u32_type(), base_in_elems), ir.cast(ir.u32_type(), index));
+  return ir.struct_array_access(ir.i64_type(), scratch_i64_buf, abs_idx);
 }
 
-Value array_i32_access_ptr(IRBuilder &ir, Value array_ptr, Value index) {
-  SType ptr_ty = ir.get_pointer_type(ir.i32_type(), spv::StorageClassFunction);
-  return ir.make_value(spv::OpAccessChain, ptr_ty, array_ptr, index);
+Value array_i32_access_ptr(IRBuilder &ir, Value scratch_i32_buf, uint32_t base_in_elems, Value index) {
+  Value abs_idx = ir.add(ir.uint_immediate_number(ir.u32_type(), base_in_elems), ir.cast(ir.u32_type(), index));
+  return ir.struct_array_access(ir.i32_type(), scratch_i32_buf, abs_idx);
 }
 
 // PSB load of one scalar from a physical-storage-buffer-addressed pointer. `base_u64` is the pointer value
@@ -170,23 +176,42 @@ Value psb_load_scalar(IRBuilder &ir,
 // Takes all the state variables so it can read/write them directly. Returns `std::nullopt`-equivalent by
 // always branching to `after_dispatch_label` (the kind-switch merge point). The caller sets up the switch
 // surround.
+// Compile-time element offsets into the i64 scratch SSBO. Layout: values_arr | scope_arr | pending_cur_i |
+// pending_end | pending_max_accum. Total element count is published as `kAdStackSizerScratchI64Elems` in
+// `adstack_sizer_shader.h` for the host launcher to size the binding-3 buffer.
+constexpr uint32_t kI64BaseValuesArr = 0;
+constexpr uint32_t kI64BaseScopeArr = kMaxNodes;
+constexpr uint32_t kI64BasePendingCurI = kMaxNodes + kMaxVars;
+constexpr uint32_t kI64BasePendingEnd = kMaxNodes + kMaxVars + kMaxPending;
+constexpr uint32_t kI64BasePendingMaxAccum = kMaxNodes + kMaxVars + 2 * kMaxPending;
+
+// Compile-time element offsets into the i32 scratch SSBO. Layout: pending_mor_idx | pending_body_start |
+// pending_body_end | pending_var_id | pending_saved_max_k. Total element count is published as
+// `kAdStackSizerScratchI32Elems` in `adstack_sizer_shader.h`.
+constexpr uint32_t kI32BasePendingMorIdx = 0;
+constexpr uint32_t kI32BasePendingBodyStart = kMaxPending;
+constexpr uint32_t kI32BasePendingBodyEnd = 2 * kMaxPending;
+constexpr uint32_t kI32BasePendingVarId = 3 * kMaxPending;
+constexpr uint32_t kI32BasePendingSavedMaxK = 4 * kMaxPending;
+static_assert(kI64BasePendingMaxAccum + kMaxPending == static_cast<uint32_t>(kAdStackSizerScratchI64Elems),
+              "i64 scratch layout drifted from header element count");
+static_assert(kI32BasePendingSavedMaxK + kMaxPending == static_cast<uint32_t>(kAdStackSizerScratchI32Elems),
+              "i32 scratch layout drifted from header element count");
+
 struct ShaderState {
-  Value values_arr;           // alloca i64[kMaxNodes]
-  Value scope_arr;            // alloca i64[kMaxVars]
-  Value pending_mor_idx_arr;  // alloca i32[kMaxPending]
-  Value pending_body_start_arr;
-  Value pending_body_end_arr;
-  Value pending_cur_i_arr;        // alloca i64[kMaxPending]
-  Value pending_end_arr;          // alloca i64[kMaxPending]
-  Value pending_var_id_arr;       // alloca i32[kMaxPending]
-  Value pending_max_accum_arr;    // alloca i64[kMaxPending]
-  Value pending_saved_max_k_arr;  // alloca i32[kMaxPending]
-  Value current_var;              // alloca i32
-  Value max_k_var;                // alloca i32
-  Value sp_var;                   // alloca i32
-  Value nodes_base_word_var;      // alloca u32 (base word offset of nodes array)
-  Value indices_base_word_var;    // alloca u32
-  Value tree_start_var;           // alloca i32, global node index of the current stack's tree root-walk origin
+  // Scratch SSBOs hosting the interpreter state. The per-array slices below live at compile-time element
+  // offsets into these buffers; see `kI64Base*` / `kI32Base*` above.
+  Value scratch_i64_buf;
+  Value scratch_i32_buf;
+  // Per-thread scalar variables. These are tiny (a handful of u32 / i32) so Function storage is fine -
+  // Blackwell's per-thread-private cap only kicked in for the cumulative ~34 KiB of array storage that now
+  // lives in the scratch SSBOs.
+  Value current_var;            // alloca i32
+  Value max_k_var;              // alloca i32
+  Value sp_var;                 // alloca i32
+  Value nodes_base_word_var;    // alloca u32 (base word offset of nodes array)
+  Value indices_base_word_var;  // alloca u32
+  Value tree_start_var;         // alloca i32, global node index of the current stack's tree root-walk origin
   Value bytecode_buf;
   Value metadata_buf;
   Value args_buf;
@@ -207,22 +232,22 @@ Value local_values_idx(IRBuilder &ir, const ShaderState &st, Value global_index_
 }
 
 Value load_values_at(IRBuilder &ir, const ShaderState &st, Value index_i32) {
-  Value ptr = array_i64_access_ptr(ir, st.values_arr, local_values_idx(ir, st, index_i32));
+  Value ptr = array_i64_access_ptr(ir, st.scratch_i64_buf, kI64BaseValuesArr, local_values_idx(ir, st, index_i32));
   return ir.load_variable(ptr, ir.i64_type());
 }
 
 void store_values_at(IRBuilder &ir, const ShaderState &st, Value index_i32, Value v_i64) {
-  Value ptr = array_i64_access_ptr(ir, st.values_arr, local_values_idx(ir, st, index_i32));
+  Value ptr = array_i64_access_ptr(ir, st.scratch_i64_buf, kI64BaseValuesArr, local_values_idx(ir, st, index_i32));
   ir.store_variable(ptr, v_i64);
 }
 
 Value load_scope_at(IRBuilder &ir, const ShaderState &st, Value var_id_i32) {
-  Value ptr = array_i64_access_ptr(ir, st.scope_arr, var_id_i32);
+  Value ptr = array_i64_access_ptr(ir, st.scratch_i64_buf, kI64BaseScopeArr, var_id_i32);
   return ir.load_variable(ptr, ir.i64_type());
 }
 
 void store_scope_at(IRBuilder &ir, const ShaderState &st, Value var_id_i32, Value v_i64) {
-  Value ptr = array_i64_access_ptr(ir, st.scope_arr, var_id_i32);
+  Value ptr = array_i64_access_ptr(ir, st.scratch_i64_buf, kI64BaseScopeArr, var_id_i32);
   ir.store_variable(ptr, v_i64);
 }
 
@@ -448,21 +473,21 @@ void emit_tree_eval_loop(IRBuilder &ir, const ShaderState &st) {
   // top_idx = sp - 1
   Value top_idx = ir.sub(sp_now, ir.int_immediate_number(ir.i32_type(), 1));
   // body_result = values[pending_body_end[top_idx]]
-  Value body_end_ptr = array_i32_access_ptr(ir, st.pending_body_end_arr, top_idx);
+  Value body_end_ptr = array_i32_access_ptr(ir, st.scratch_i32_buf, kI32BasePendingBodyEnd, top_idx);
   Value body_end_node = ir.load_variable(body_end_ptr, ir.i32_type());
   Value body_result = load_values_at(ir, st, body_end_node);
   // top_max = max(pending_max_accum[top_idx], body_result)
-  Value max_accum_ptr = array_i64_access_ptr(ir, st.pending_max_accum_arr, top_idx);
+  Value max_accum_ptr = array_i64_access_ptr(ir, st.scratch_i64_buf, kI64BasePendingMaxAccum, top_idx);
   Value cur_max_accum = ir.load_variable(max_accum_ptr, ir.i64_type());
   Value body_gt_accum = ir.gt(body_result, cur_max_accum);
   Value new_max_accum = ir.select(body_gt_accum, body_result, cur_max_accum);
   ir.store_variable(max_accum_ptr, new_max_accum);
   // top_cur_i = pending_cur_i[top_idx] + 1
-  Value cur_i_ptr = array_i64_access_ptr(ir, st.pending_cur_i_arr, top_idx);
+  Value cur_i_ptr = array_i64_access_ptr(ir, st.scratch_i64_buf, kI64BasePendingCurI, top_idx);
   Value cur_i = ir.load_variable(cur_i_ptr, ir.i64_type());
   Value next_i = ir.add(cur_i, ir.int_immediate_number(ir.i64_type(), 1));
   // if next_i < pending_end[top_idx]: update cur_i, jump to body_start
-  Value end_ptr = array_i64_access_ptr(ir, st.pending_end_arr, top_idx);
+  Value end_ptr = array_i64_access_ptr(ir, st.scratch_i64_buf, kI64BasePendingEnd, top_idx);
   Value end_val = ir.load_variable(end_ptr, ir.i64_type());
   Value more = ir.lt(next_i, end_val);
   Label more_lbl = ir.new_label();
@@ -474,11 +499,11 @@ void emit_tree_eval_loop(IRBuilder &ir, const ShaderState &st) {
   ir.start_label(more_lbl);
   ir.store_variable(cur_i_ptr, next_i);
   // scope[pending_var_id[top_idx]] = next_i
-  Value var_id_ptr = array_i32_access_ptr(ir, st.pending_var_id_arr, top_idx);
+  Value var_id_ptr = array_i32_access_ptr(ir, st.scratch_i32_buf, kI32BasePendingVarId, top_idx);
   Value var_id = ir.load_variable(var_id_ptr, ir.i32_type());
   store_scope_at(ir, st, var_id, next_i);
   // current = pending_body_start[top_idx]
-  Value body_start_ptr = array_i32_access_ptr(ir, st.pending_body_start_arr, top_idx);
+  Value body_start_ptr = array_i32_access_ptr(ir, st.scratch_i32_buf, kI32BasePendingBodyStart, top_idx);
   Value body_start_val = ir.load_variable(body_start_ptr, ir.i32_type());
   ir.store_variable(st.current_var, body_start_val);
   // max_k stays (we're still iterating the same MOR body)
@@ -494,13 +519,13 @@ void emit_tree_eval_loop(IRBuilder &ir, const ShaderState &st) {
   // OOB PSB load (Metal: hung command buffer; Vulkan with robustBufferAccess: silent zero feeding a later
   // `Adstack overflow`). Zeroing here preserves the "scope[var_id] == 0 is a safe spurious-read target
   // because index 0 is always valid for any non-empty ndarray" invariant the outer walk relies on.
-  Value pop_var_id_ptr = array_i32_access_ptr(ir, st.pending_var_id_arr, top_idx);
+  Value pop_var_id_ptr = array_i32_access_ptr(ir, st.scratch_i32_buf, kI32BasePendingVarId, top_idx);
   Value pop_var_id = ir.load_variable(pop_var_id_ptr, ir.i32_type());
-  Value pop_scope_ptr = array_i64_access_ptr(ir, st.scope_arr, pop_var_id);
+  Value pop_scope_ptr = array_i64_access_ptr(ir, st.scratch_i64_buf, kI64BaseScopeArr, pop_var_id);
   ir.store_variable(pop_scope_ptr, ir.int_immediate_number(ir.i64_type(), 0));
 
   // values[pending_mor_idx[top_idx]] = new_max_accum
-  Value mor_idx_ptr = array_i32_access_ptr(ir, st.pending_mor_idx_arr, top_idx);
+  Value mor_idx_ptr = array_i32_access_ptr(ir, st.scratch_i32_buf, kI32BasePendingMorIdx, top_idx);
   Value mor_idx = ir.load_variable(mor_idx_ptr, ir.i32_type());
   store_values_at(ir, st, mor_idx, new_max_accum);
   // current = pending_mor_idx[top_idx] + 1. The encoder emits `MaxOverRange` in post-order, i.e. body nodes
@@ -511,7 +536,7 @@ void emit_tree_eval_loop(IRBuilder &ir, const ShaderState &st) {
   Value cur_next = ir.add(mor_idx, ir.int_immediate_number(ir.i32_type(), 1));
   ir.store_variable(st.current_var, cur_next);
   // max_k = pending_saved_max_k[top_idx]
-  Value saved_max_k_ptr = array_i32_access_ptr(ir, st.pending_saved_max_k_arr, top_idx);
+  Value saved_max_k_ptr = array_i32_access_ptr(ir, st.scratch_i32_buf, kI32BasePendingSavedMaxK, top_idx);
   Value saved_max_k = ir.load_variable(saved_max_k_ptr, ir.i32_type());
   ir.store_variable(st.max_k_var, saved_max_k);
   // sp -= 1
@@ -741,16 +766,16 @@ void emit_tree_eval_loop(IRBuilder &ir, const ShaderState &st) {
       Value end_gt_cap = ir.gt(end_i64, cap_end);
       Value effective_end = ir.select(end_gt_cap, cap_end, end_i64);
       Value sp_val = ir.load_variable(st.sp_var, ir.i32_type());
-      ir.store_variable(array_i32_access_ptr(ir, st.pending_mor_idx_arr, sp_val), current_now);
+      ir.store_variable(array_i32_access_ptr(ir, st.scratch_i32_buf, kI32BasePendingMorIdx, sp_val), current_now);
       Value body_start = ir.add(op_b_i32, ir.int_immediate_number(ir.i32_type(), 1));
-      ir.store_variable(array_i32_access_ptr(ir, st.pending_body_start_arr, sp_val), body_start);
-      ir.store_variable(array_i32_access_ptr(ir, st.pending_body_end_arr, sp_val), body_node_i32);
-      ir.store_variable(array_i64_access_ptr(ir, st.pending_cur_i_arr, sp_val), begin_i64);
-      ir.store_variable(array_i64_access_ptr(ir, st.pending_end_arr, sp_val), effective_end);
-      ir.store_variable(array_i32_access_ptr(ir, st.pending_var_id_arr, sp_val), var_id_i32);
-      ir.store_variable(array_i64_access_ptr(ir, st.pending_max_accum_arr, sp_val),
+      ir.store_variable(array_i32_access_ptr(ir, st.scratch_i32_buf, kI32BasePendingBodyStart, sp_val), body_start);
+      ir.store_variable(array_i32_access_ptr(ir, st.scratch_i32_buf, kI32BasePendingBodyEnd, sp_val), body_node_i32);
+      ir.store_variable(array_i64_access_ptr(ir, st.scratch_i64_buf, kI64BasePendingCurI, sp_val), begin_i64);
+      ir.store_variable(array_i64_access_ptr(ir, st.scratch_i64_buf, kI64BasePendingEnd, sp_val), effective_end);
+      ir.store_variable(array_i32_access_ptr(ir, st.scratch_i32_buf, kI32BasePendingVarId, sp_val), var_id_i32);
+      ir.store_variable(array_i64_access_ptr(ir, st.scratch_i64_buf, kI64BasePendingMaxAccum, sp_val),
                         ir.int_immediate_number(ir.i64_type(), 0));
-      ir.store_variable(array_i32_access_ptr(ir, st.pending_saved_max_k_arr, sp_val), max_k_now);
+      ir.store_variable(array_i32_access_ptr(ir, st.scratch_i32_buf, kI32BasePendingSavedMaxK, sp_val), max_k_now);
 
       Value new_sp = ir.add(sp_val, ir.int_immediate_number(ir.i32_type(), 1));
       ir.store_variable(st.sp_var, new_sp);
@@ -816,41 +841,29 @@ std::vector<uint32_t> build_adstack_sizer_spirv(Arch arch, const DeviceCapabilit
   ir.init_header();
 
   // Storage-buffer bindings (set 0): bytecode in, metadata out, args in. Using `buffer_argument` because
-  // all three are plain uint32[] arrays.
+  // all three are plain uint32[] arrays. The two scratch buffers (binding 3 = i64 scratch, binding 4 = i32
+  // scratch) host the per-invocation interpreter state. Hosting that state in `StorageBuffer` SSBOs rather
+  // than `Function`-storage `OpVariable`s sidesteps Blackwell-class NVIDIA driver per-thread private memory
+  // caps that fail `vkCreateComputePipelines` with `VK_ERROR_UNKNOWN` once the cumulative stack-frame
+  // exceeds ~32 KiB. The sizer dispatches `1x1x1` so cross-thread aliasing through the scratch SSBOs is
+  // impossible; the host launcher allocates the scratch buffers fresh per `GfxRuntime` and binds them on
+  // every dispatch.
   Value bytecode_buf = ir.buffer_argument(ir.u32_type(), 0, 0, "adstack_sizer_bytecode");
   Value metadata_buf = ir.buffer_argument(ir.u32_type(), 0, 1, "adstack_sizer_metadata");
   Value args_buf = ir.buffer_argument(ir.u32_type(), 0, 2, "adstack_sizer_args");
+  Value scratch_i64_buf = ir.buffer_argument(ir.i64_type(), 0, 3, "adstack_sizer_scratch_i64");
+  Value scratch_i32_buf = ir.buffer_argument(ir.i32_type(), 0, 4, "adstack_sizer_scratch_i32");
 
   Value main_func = ir.new_function();
   ir.start_function(main_func);
   ir.set_work_group_size({1, 1, 1});
 
-  // Allocate local arrays. `alloca_variable` on an array type gives us a Function-storage pointer; the
-  // array elements are accessed via `OpAccessChain` with a scalar index (see `array_i64_access_ptr` /
-  // `array_i32_access_ptr`).
   ShaderState st;
   st.bytecode_buf = bytecode_buf;
   st.metadata_buf = metadata_buf;
   st.args_buf = args_buf;
-
-  // Use `get_function_array_type` rather than `get_array_type` for these per-invocation arrays. The latter
-  // emits an `ArrayStride` decoration on the resulting `OpTypeArray`, which Vulkan rejects on a
-  // Function-scope `OpVariable` per `VUID-StandaloneSpirv-None-10684` ("Invalid explicit layout decorations
-  // on type"); Blackwell-class NVIDIA Vulkan drivers ship the SPIR-V validator and fail pipeline creation.
-  SType values_arr_ty = ir.get_function_array_type(ir.i64_type(), kMaxNodes);
-  st.values_arr = ir.alloca_variable(values_arr_ty);
-  SType scope_arr_ty = ir.get_function_array_type(ir.i64_type(), kMaxVars);
-  st.scope_arr = ir.alloca_variable(scope_arr_ty);
-  SType pending_i32_ty = ir.get_function_array_type(ir.i32_type(), kMaxPending);
-  SType pending_i64_ty = ir.get_function_array_type(ir.i64_type(), kMaxPending);
-  st.pending_mor_idx_arr = ir.alloca_variable(pending_i32_ty);
-  st.pending_body_start_arr = ir.alloca_variable(pending_i32_ty);
-  st.pending_body_end_arr = ir.alloca_variable(pending_i32_ty);
-  st.pending_cur_i_arr = ir.alloca_variable(pending_i64_ty);
-  st.pending_end_arr = ir.alloca_variable(pending_i64_ty);
-  st.pending_var_id_arr = ir.alloca_variable(pending_i32_ty);
-  st.pending_max_accum_arr = ir.alloca_variable(pending_i64_ty);
-  st.pending_saved_max_k_arr = ir.alloca_variable(pending_i32_ty);
+  st.scratch_i64_buf = scratch_i64_buf;
+  st.scratch_i32_buf = scratch_i32_buf;
 
   st.current_var = ir.alloca_variable(ir.i32_type());
   st.max_k_var = ir.alloca_variable(ir.i32_type());
@@ -871,7 +884,7 @@ std::vector<uint32_t> build_adstack_sizer_spirv(Arch arch, const DeviceCapabilit
   Value zero_i64_for_scope_init = ir.int_immediate_number(ir.i64_type(), 0);
   for (int vi = 0; vi < kMaxVars; ++vi) {
     Value idx = ir.int_immediate_number(ir.i32_type(), vi);
-    ir.store_variable(array_i64_access_ptr(ir, st.scope_arr, idx), zero_i64_for_scope_init);
+    ir.store_variable(array_i64_access_ptr(ir, st.scratch_i64_buf, kI64BaseScopeArr, idx), zero_i64_for_scope_init);
   }
 
   // Read header: n_stacks, total_nodes.
@@ -1038,7 +1051,7 @@ std::vector<uint32_t> build_adstack_sizer_spirv(Arch arch, const DeviceCapabilit
   ir.make_inst(spv::OpReturn);
   ir.make_inst(spv::OpFunctionEnd);
 
-  std::vector<Value> entry_args = {bytecode_buf, metadata_buf, args_buf};
+  std::vector<Value> entry_args = {bytecode_buf, metadata_buf, args_buf, scratch_i64_buf, scratch_i32_buf};
   // Entry point name MUST be "main" to match the rest of the Quadrants SPIR-V codegen
   // (see `spirv_codegen.cpp:commit_kernel_function(..., "main", ...)`). The Metal RHI renames
   // the SPIR-V `main` to `main0` during MSL cross-compilation and then looks up the compute

--- a/quadrants/codegen/spirv/adstack_sizer_shader.cpp
+++ b/quadrants/codegen/spirv/adstack_sizer_shader.cpp
@@ -19,12 +19,12 @@ namespace {
 // produces an unusually deep or wide tree; the host-side encoder hard-errors rather than let the shader
 // silently truncate (see `encode_adstack_size_expr_device_bytecode_for_spirv`), so exceeding a cap surfaces
 // as a clear compile-time diagnostic rather than a mysterious overflow at the next `stack_push`.
-// Per-stack node-count cap for the eval state. Each invocation gets its own private `values_arr` of this
-// size indexed by the *local* offset within the stack's subtree (not the global bytecode-wide node index),
-// so this cap applies only per-stack, not per-kernel. Observed reverse-mode kernels have a handful of stacks
-// with ~1k-node symbolic trees (`MaxOverRange` over ndarray reads with a nested `Max` of per-substep trip
-// counts), so the cap needs to comfortably exceed that. 4096 * 8 B = 32 KiB of i64 private memory per
-// invocation; the sizer runs as a single-thread dispatch so this is not multiplied by workgroup size.
+// Per-stack node-count cap for the eval state. The shader hosts its `values_arr` slice in the i64 scratch
+// SSBO (binding 3) sized at `kAdStackSizerScratchI64Elems`; the slice is indexed by the *local* offset
+// within the stack's subtree (not the global bytecode-wide node index), so this cap applies only per-stack,
+// not per-kernel. Observed reverse-mode kernels have a handful of stacks with ~1k-node symbolic trees
+// (`MaxOverRange` over ndarray reads with a nested `Max` of per-substep trip counts); 65536 * 8 B = 512 KiB
+// of device memory per `GfxRuntime` (allocated once, reused across every sizer dispatch).
 constexpr int kMaxNodes = kAdStackSizerMaxNodesPerStack;
 // `kMaxVars` sizes the per-invocation `scope_arr` indexed by dense bound-var id; must match
 // `kAdStackSizeExprDeviceMaxBoundVars` so every id the host-side dense-remap hands out lands in bounds. `kMaxPending`

--- a/quadrants/codegen/spirv/adstack_sizer_shader.cpp
+++ b/quadrants/codegen/spirv/adstack_sizer_shader.cpp
@@ -833,12 +833,16 @@ std::vector<uint32_t> build_adstack_sizer_spirv(Arch arch, const DeviceCapabilit
   st.metadata_buf = metadata_buf;
   st.args_buf = args_buf;
 
-  SType values_arr_ty = ir.get_array_type(ir.i64_type(), kMaxNodes);
+  // Use `get_function_array_type` rather than `get_array_type` for these per-invocation arrays. The latter
+  // emits an `ArrayStride` decoration on the resulting `OpTypeArray`, which Vulkan rejects on a
+  // Function-scope `OpVariable` per `VUID-StandaloneSpirv-None-10684` ("Invalid explicit layout decorations
+  // on type"); Blackwell-class NVIDIA Vulkan drivers ship the SPIR-V validator and fail pipeline creation.
+  SType values_arr_ty = ir.get_function_array_type(ir.i64_type(), kMaxNodes);
   st.values_arr = ir.alloca_variable(values_arr_ty);
-  SType scope_arr_ty = ir.get_array_type(ir.i64_type(), kMaxVars);
+  SType scope_arr_ty = ir.get_function_array_type(ir.i64_type(), kMaxVars);
   st.scope_arr = ir.alloca_variable(scope_arr_ty);
-  SType pending_i32_ty = ir.get_array_type(ir.i32_type(), kMaxPending);
-  SType pending_i64_ty = ir.get_array_type(ir.i64_type(), kMaxPending);
+  SType pending_i32_ty = ir.get_function_array_type(ir.i32_type(), kMaxPending);
+  SType pending_i64_ty = ir.get_function_array_type(ir.i64_type(), kMaxPending);
   st.pending_mor_idx_arr = ir.alloca_variable(pending_i32_ty);
   st.pending_body_start_arr = ir.alloca_variable(pending_i32_ty);
   st.pending_body_end_arr = ir.alloca_variable(pending_i32_ty);

--- a/quadrants/codegen/spirv/adstack_sizer_shader.h
+++ b/quadrants/codegen/spirv/adstack_sizer_shader.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "quadrants/ir/adstack_size_expr_device.h"
 #include "quadrants/rhi/arch.h"
 #include "quadrants/rhi/public_device.h"
 
@@ -47,5 +48,15 @@ constexpr int kAdStackSizerMaxNodesPerStack = 4096;
 // (`pending_*_arr`). The host-side encoder hard-errors when a tree's MOR nesting exceeds this so the shader's
 // fixed-size access-chain stays in bounds without a runtime guard. 16 covers every observed real kernel.
 constexpr int kAdStackSizerMaxPendingFrames = 16;
+
+// Per-invocation interpreter state element counts in each scratch SSBO. Layout in the i64 buffer is
+// `[values_arr | scope_arr | pending_cur_i | pending_end | pending_max_accum]`; layout in the i32 buffer is
+// `[pending_mor_idx | pending_body_start | pending_body_end | pending_var_id | pending_saved_max_k]`. The
+// host launcher uses these to size the two scratch buffers it binds on every sizer dispatch (binding 3 = i64
+// scratch, binding 4 = i32 scratch). Mirrors the in-shader `kI64Base*` / `kI32Base*` constants in
+// `adstack_sizer_shader.cpp`.
+constexpr int kAdStackSizerScratchI64Elems =
+    kAdStackSizerMaxNodesPerStack + kAdStackSizeExprDeviceMaxBoundVars + 3 * kAdStackSizerMaxPendingFrames;
+constexpr int kAdStackSizerScratchI32Elems = 5 * kAdStackSizerMaxPendingFrames;
 
 }  // namespace quadrants::lang::spirv

--- a/quadrants/codegen/spirv/adstack_sizer_shader.h
+++ b/quadrants/codegen/spirv/adstack_sizer_shader.h
@@ -39,10 +39,18 @@ namespace quadrants::lang::spirv {
 std::vector<uint32_t> build_adstack_sizer_spirv(Arch arch, const DeviceCapabilityConfig *caps);
 
 // Maximum number of `SerializedSizeExpr` nodes a single adstack's tree may contribute to the device bytecode.
-// The sizer shader's `values_arr` private i64 scratch is sized to this, indexed by the per-stack local offset.
-// Exceeding it on the shader would silently truncate; the host-side encoder must hard-error before emitting
-// bytecode past this cap so the failure is attributable to a specific alloca at compile time.
-constexpr int kAdStackSizerMaxNodesPerStack = 4096;
+// The sizer shader's `values_arr` slice of the i64 scratch SSBO is sized to this, indexed by the per-stack
+// local offset. Exceeding it on the shader would silently truncate; the host-side encoder must hard-error
+// before emitting bytecode past this cap so the failure is attributable to a specific alloca at compile time.
+// The cap maps directly into device-memory bytes via `kAdStackSizerScratchI64Elems` (allocated once per
+// `GfxRuntime` as a `StorageBuffer` SSBO bound to the sizer dispatch on slot 3): at 65536 i64 entries the
+// per-runtime allocation is 512 KiB plus the i32 buffer, negligible against any modern GPU's VRAM budget.
+// The previous 4096-cap was chosen to fit the cumulative per-thread private memory budget Blackwell-class
+// NVIDIA Vulkan drivers enforce on Function-storage `OpVariable`s; with the scratch state in an SSBO that
+// constraint is gone and the cap exists only to keep the encoder's hard-error attached to a fixed compile-
+// time ceiling so an unexpectedly deep symbolic tree surfaces as an attributable diagnostic at encode time
+// rather than as an out-of-bounds shader access at dispatch time.
+constexpr int kAdStackSizerMaxNodesPerStack = 65536;
 
 // Maximum `MaxOverRange` nesting depth the sizer shader can hold on its per-invocation pending-frame stack
 // (`pending_*_arr`). The host-side encoder hard-errors when a tree's MOR nesting exceeds this so the shader's

--- a/quadrants/codegen/spirv/spirv_codegen.cpp
+++ b/quadrants/codegen/spirv/spirv_codegen.cpp
@@ -322,7 +322,12 @@ void TaskCodegen::visit(AllocaStmt *alloca) {
     spirv::SType elem_type;
     maybe_retype_alloca(*ir_, *caps_, alloca, tensor_type, shared_float_allocas_with_atomic_rmw_,
                         uint_backed_shared_float_ptr_stmts_, elem_num, elem_type);
-    spirv::SType arr_type = ir_->get_array_type(elem_type, elem_num);
+    // Use `get_function_array_type` rather than `get_array_type`: the resulting array type backs an
+    // `OpVariable` in either `Workgroup` (shared) or `Function` storage class, neither of which is a
+    // storage-buffer / PSB / Uniform interface, so the `ArrayStride` decoration `get_array_type` adds
+    // would be illegal per `VUID-StandaloneSpirv-None-10684` and Blackwell-class NVIDIA Vulkan drivers
+    // refuse the resulting compute pipeline. Older drivers tolerated the over-decoration.
+    spirv::SType arr_type = ir_->get_function_array_type(elem_type, elem_num);
     if (alloca->is_shared) {  // for shared memory / workgroup memory
       ptr_val = ir_->alloca_workgroup_array(arr_type);
       shared_array_binds_.push_back(ptr_val);

--- a/quadrants/codegen/spirv/spirv_ir_builder.cpp
+++ b/quadrants/codegen/spirv/spirv_ir_builder.cpp
@@ -479,6 +479,7 @@ SType IRBuilder::get_array_type(const SType &_value_type, uint32_t num_elems) {
     }
   }
 
+  // decorate the array type
   this->decorate(spv::OpDecorate, arr_type, spv::DecorationArrayStride, nbytes);
 
   return arr_type;

--- a/quadrants/codegen/spirv/spirv_ir_builder.cpp
+++ b/quadrants/codegen/spirv/spirv_ir_builder.cpp
@@ -427,7 +427,7 @@ SType IRBuilder::get_storage_pointer_type(const SType &value_type) {
   return get_pointer_type(value_type, storage_class);
 }
 
-SType IRBuilder::get_array_type(const SType &_value_type, uint32_t num_elems) {
+SType IRBuilder::get_function_array_type(const SType &_value_type, uint32_t num_elems) {
   auto value_type = _value_type;
   if (value_type.dt->is_primitive(PrimitiveTypeID::u1)) {
     value_type = i32_type();
@@ -443,6 +443,14 @@ SType IRBuilder::get_array_type(const SType &_value_type, uint32_t num_elems) {
   } else {
     ib_.begin(spv::OpTypeRuntimeArray).add_seq(arr_type, value_type).commit(&global_);
   }
+
+  return arr_type;
+}
+
+SType IRBuilder::get_array_type(const SType &value_type, uint32_t num_elems) {
+  // Identical bookkeeping to `get_function_array_type` plus the `ArrayStride` decoration the storage-buffer
+  // / PSB / Uniform interface requires. Delegate to keep the two in sync.
+  SType arr_type = get_function_array_type(value_type, num_elems);
 
   uint32_t nbytes;
   if (value_type.flag == TypeKind::kPrimitive) {
@@ -462,7 +470,6 @@ SType IRBuilder::get_array_type(const SType &_value_type, uint32_t num_elems) {
     }
   }
 
-  // decorate the array type
   this->decorate(spv::OpDecorate, arr_type, spv::DecorationArrayStride, nbytes);
 
   return arr_type;

--- a/quadrants/codegen/spirv/spirv_ir_builder.cpp
+++ b/quadrants/codegen/spirv/spirv_ir_builder.cpp
@@ -447,10 +447,19 @@ SType IRBuilder::get_function_array_type(const SType &_value_type, uint32_t num_
   return arr_type;
 }
 
-SType IRBuilder::get_array_type(const SType &value_type, uint32_t num_elems) {
+SType IRBuilder::get_array_type(const SType &_value_type, uint32_t num_elems) {
   // Identical bookkeeping to `get_function_array_type` plus the `ArrayStride` decoration the storage-buffer
-  // / PSB / Uniform interface requires. Delegate to keep the two in sync.
-  SType arr_type = get_function_array_type(value_type, num_elems);
+  // / PSB / Uniform interface requires. Delegate the `OpTypeArray` emission to keep the two in sync, then
+  // add the decoration on top.
+  SType arr_type = get_function_array_type(_value_type, num_elems);
+
+  // Mirror `get_function_array_type`'s `u1 -> i32` rewrite so the stride below matches the `OpTypeArray`
+  // element type (`bool` is 1-byte on every host but the array is emitted with `i32` elements; without this
+  // rewrite the stride would land on `1` and `spirv-val` rejects `ArrayStride < element_size`).
+  auto value_type = _value_type;
+  if (value_type.dt->is_primitive(PrimitiveTypeID::u1)) {
+    value_type = i32_type();
+  }
 
   uint32_t nbytes;
   if (value_type.flag == TypeKind::kPrimitive) {

--- a/quadrants/codegen/spirv/spirv_ir_builder.h
+++ b/quadrants/codegen/spirv/spirv_ir_builder.h
@@ -335,6 +335,11 @@ class IRBuilder {
   // Get the pointer type that points to value_type
   SType get_pointer_type(const SType &value_type, spv::StorageClass storage_class);
   SType get_array_type(const SType &value_type, uint32_t num_elems);
+  // Same as `get_array_type` but emits no `ArrayStride` decoration on the resulting `OpTypeArray`. Use this
+  // whenever the resulting type is fed straight to `alloca_variable`: Vulkan rejects layout decorations on
+  // `Function` / `Private` variable types under `VUID-StandaloneSpirv-None-10684`, and Blackwell-class NVIDIA
+  // drivers fail pipeline creation when the validator catches it.
+  SType get_function_array_type(const SType &value_type, uint32_t num_elems);
   // Get a struct{ value_type[num_elems] } type
   SType get_struct_array_type(const SType &value_type, uint32_t num_elems);
   // Construct a struct type

--- a/quadrants/rhi/vulkan/vulkan_api.cpp
+++ b/quadrants/rhi/vulkan/vulkan_api.cpp
@@ -310,9 +310,6 @@ IVkPipeline create_compute_pipeline(VkDevice device,
 
   VkResult res =
       vkCreateComputePipelines(device, cache ? cache->cache : VK_NULL_HANDLE, 1, &info, nullptr, &obj->pipeline);
-  if (res != VK_SUCCESS) {
-    fprintf(stderr, "vkCreateComputePipelines failed: VkResult=%d\n", static_cast<int>(res));
-  }
   RHI_THROW_UNLESS(res == VK_SUCCESS, std::runtime_error("vkCreateComputePipelines failed"));
 
   return obj;

--- a/quadrants/rhi/vulkan/vulkan_api.cpp
+++ b/quadrants/rhi/vulkan/vulkan_api.cpp
@@ -310,6 +310,9 @@ IVkPipeline create_compute_pipeline(VkDevice device,
 
   VkResult res =
       vkCreateComputePipelines(device, cache ? cache->cache : VK_NULL_HANDLE, 1, &info, nullptr, &obj->pipeline);
+  if (res != VK_SUCCESS) {
+    fprintf(stderr, "vkCreateComputePipelines failed: VkResult=%d\n", static_cast<int>(res));
+  }
   RHI_THROW_UNLESS(res == VK_SUCCESS, std::runtime_error("vkCreateComputePipelines failed"));
 
   return obj;

--- a/quadrants/runtime/gfx/adstack_sizer_launch.cpp
+++ b/quadrants/runtime/gfx/adstack_sizer_launch.cpp
@@ -182,6 +182,18 @@ std::vector<PerTaskAdStackRuntime> GfxRuntime::publish_adstack_metadata_spirv(
     PipelineSourceDesc source_desc{PipelineSourceType::spirv_binary, (void *)spirv.data(),
                                    spirv.size() * sizeof(uint32_t)};
     auto [pipeline, res] = device_->create_pipeline_unique(source_desc, "adstack_sizer", backend_cache_.get());
+    if (res != RhiResult::success) {
+      const char *path = "/tmp/adstack_sizer_dump.spv";
+      FILE *f = std::fopen(path, "wb");
+      if (f != nullptr) {
+        std::fwrite(spirv.data(), sizeof(uint32_t), spirv.size(), f);
+        std::fclose(f);
+        fprintf(stderr,
+                "[adstack-sizer] wrote SPIR-V dump to %s (%zu words). Disassemble with `spirv-dis %s` "
+                "and validate with `spirv-val --target-env vulkan1.4 %s`.\n",
+                path, spirv.size(), path, path);
+      }
+    }
     QD_ERROR_IF(res != RhiResult::success, "Failed to create pipeline for the adstack SizeExpr sizer shader (err: {})",
                 int(res));
     adstack_sizer_pipeline_ = std::move(pipeline);

--- a/quadrants/runtime/gfx/adstack_sizer_launch.cpp
+++ b/quadrants/runtime/gfx/adstack_sizer_launch.cpp
@@ -182,21 +182,29 @@ std::vector<PerTaskAdStackRuntime> GfxRuntime::publish_adstack_metadata_spirv(
     PipelineSourceDesc source_desc{PipelineSourceType::spirv_binary, (void *)spirv.data(),
                                    spirv.size() * sizeof(uint32_t)};
     auto [pipeline, res] = device_->create_pipeline_unique(source_desc, "adstack_sizer", backend_cache_.get());
-    if (res != RhiResult::success) {
-      const char *path = "/tmp/adstack_sizer_dump.spv";
-      FILE *f = std::fopen(path, "wb");
-      if (f != nullptr) {
-        std::fwrite(spirv.data(), sizeof(uint32_t), spirv.size(), f);
-        std::fclose(f);
-        fprintf(stderr,
-                "[adstack-sizer] wrote SPIR-V dump to %s (%zu words). Disassemble with `spirv-dis %s` "
-                "and validate with `spirv-val --target-env vulkan1.4 %s`.\n",
-                path, spirv.size(), path, path);
-      }
-    }
     QD_ERROR_IF(res != RhiResult::success, "Failed to create pipeline for the adstack SizeExpr sizer shader (err: {})",
                 int(res));
     adstack_sizer_pipeline_ = std::move(pipeline);
+  }
+
+  // Lazily allocate the two scratch SSBOs that host the sizer's per-invocation interpreter state. Bound on
+  // every sizer dispatch at slots 3 (i64) and 4 (i32). Sizes are fixed by the shader-side layout constants;
+  // see `kAdStackSizerScratchI64Elems` / `kAdStackSizerScratchI32Elems` in `adstack_sizer_shader.h`.
+  if (!adstack_sizer_scratch_i64_buffer_) {
+    auto [buf, res] = device_->allocate_memory_unique(
+        {static_cast<size_t>(spirv::kAdStackSizerScratchI64Elems) * sizeof(int64_t),
+         /*host_write=*/false, /*host_read=*/false, /*export_sharing=*/false, AllocUsage::Storage});
+    QD_ASSERT_INFO(res == RhiResult::success, "Failed to allocate adstack sizer i64 scratch buffer ({} bytes)",
+                   static_cast<size_t>(spirv::kAdStackSizerScratchI64Elems) * sizeof(int64_t));
+    adstack_sizer_scratch_i64_buffer_ = std::move(buf);
+  }
+  if (!adstack_sizer_scratch_i32_buffer_) {
+    auto [buf, res] = device_->allocate_memory_unique(
+        {static_cast<size_t>(spirv::kAdStackSizerScratchI32Elems) * sizeof(int32_t),
+         /*host_write=*/false, /*host_read=*/false, /*export_sharing=*/false, AllocUsage::Storage});
+    QD_ASSERT_INFO(res == RhiResult::success, "Failed to allocate adstack sizer i32 scratch buffer ({} bytes)",
+                   static_cast<size_t>(spirv::kAdStackSizerScratchI32Elems) * sizeof(int32_t));
+    adstack_sizer_scratch_i32_buffer_ = std::move(buf);
   }
 
   // Encode per-task bytecodes and compute per-task metadata sizes. Each task's starting offset inside the
@@ -290,6 +298,11 @@ std::vector<PerTaskAdStackRuntime> GfxRuntime::publish_adstack_metadata_spirv(
     // valid allocation is safe to bind here. Fall back to the bytecode buffer rather than plumbing a
     // conditional null-binding path that every RHI backend would need to support.
     bindings->rw_buffer(2, args_buffer ? *args_buffer : *adstack_sizer_bytecode_buffer_);
+    // Per-invocation interpreter scratch (see allocation site above). The contents are entirely overwritten on every
+    // dispatch (the shader zero-inits its `scope_arr` slice and writes-before-reads the rest as it walks the bytecode),
+    // so no inter-launch state needs to survive.
+    bindings->rw_buffer(3, *adstack_sizer_scratch_i64_buffer_);
+    bindings->rw_buffer(4, *adstack_sizer_scratch_i32_buffer_);
 
     sizer_cmdlist->bind_pipeline(adstack_sizer_pipeline_.get());
     RhiResult bind_res = sizer_cmdlist->bind_shader_resources(bindings.get());

--- a/quadrants/runtime/gfx/runtime.h
+++ b/quadrants/runtime/gfx/runtime.h
@@ -216,6 +216,17 @@ class QD_DLL_EXPORT GfxRuntime {
   std::unique_ptr<Pipeline> adstack_sizer_pipeline_{nullptr};
   std::unique_ptr<DeviceAllocationGuard> adstack_sizer_bytecode_buffer_;
   size_t adstack_sizer_bytecode_buffer_size_{0};
+  // Per-invocation interpreter scratch buffers for the on-device adstack sizer. The shader hosts its
+  // `values_arr` / `scope_arr` / `pending_*_arr` state in these SSBOs (binding 3 = i64-typed, binding 4 =
+  // i32-typed) rather than in `Function`-storage `OpVariable`s because Blackwell-class NVIDIA Vulkan
+  // drivers fail `vkCreateComputePipelines` with `VK_ERROR_UNKNOWN` once the cumulative per-thread private
+  // memory crosses ~32 KiB. Sizes are fixed at compile time
+  // (`kAdStackSizerScratchI64Elems` * `sizeof(int64_t)` and `kAdStackSizerScratchI32Elems` *
+  // `sizeof(int32_t)`); both are allocated lazily on the first sizer dispatch and reused across every
+  // subsequent dispatch in the runtime's lifetime - the sizer is `1x1x1` so there is no cross-thread
+  // contention to size around.
+  std::unique_ptr<DeviceAllocationGuard> adstack_sizer_scratch_i64_buffer_;
+  std::unique_ptr<DeviceAllocationGuard> adstack_sizer_scratch_i32_buffer_;
 
   // Owning `ProgramImpl` back-reference; propagated from `Params::program_impl`. See the comment on
   // `Params::program_impl` for the contract.


### PR DESCRIPTION
# Move the on-device adstack `SizeExpr` sizer's per-invocation interpreter state from `Function`-scope `OpVariable`s into two `StorageBuffer` scratch SSBOs

> Three-commit PR. The headline fix is the SSBO move (commit 3): on Blackwell-class NVIDIA Vulkan drivers (RTX 5090, RTX 6000 Blackwell) the cumulative `i64[kMaxNodes=4096] + i64[kMaxVars] + 8x array[kMaxPending]` (~34 KiB) of per-thread private memory the sizer shader reserved was over the driver's hidden compute-shader stack-frame budget, and `vkCreateComputePipelines` failed with `VK_ERROR_UNKNOWN`. The two earlier commits address a separate but related strict-validation issue the same Blackwell drivers also enforce on Function- / Workgroup-scope `OpVariable` types under VUID-StandaloneSpirv-None-10684 (`Invalid explicit layout decorations on type`), surfaced first by the same RTX 5090 reproducer.

## TL;DR

On a Blackwell GPU running any reverse-mode kernel whose `SizeExpr` requires the on-device sizer, `publish_adstack_metadata_spirv` failed at pipeline creation. The chain of root causes uncovered while debugging:

1. **VUID-StandaloneSpirv-None-10684** on the sizer's `Function`-scope array `OpVariable`s. The SPIR-V validator that ships with Vulkan 1.4 Blackwell drivers refuses any layout decoration on a `Function` / `Private` / `Workgroup` variable type. The sizer's `IRBuilder::alloca_variable(get_array_type(i64, 4096))` produced a Function-scope variable whose pointee type carried `DecorationArrayStride`, tripping the validator. **Fix**: new `IRBuilder::get_function_array_type` helper that reuses the existing `get_array_type` body but drops the `ArrayStride` decoration, plus a parallel migration in `spirv_codegen.cpp:325` for user-kernel tensor allocas in `Function` / `Workgroup` storage that hit the same VUID. (commits 1 + 2)

2. **`VK_ERROR_UNKNOWN` from the driver compiler** on the sizer pipeline build. With (1) fixed the SPIR-V module validated cleanly but the Blackwell driver's NV-internal SASS lowering still rejected the shader. Bisecting on `kMaxNodes` showed the cap was the trigger: at 4096 (32 KiB of per-thread `i64[]` private memory) the build failed; at 256 (2 KiB) it succeeded. The driver caps the per-thread compute-shader stack frame at a budget that varies by SM target, and Blackwell sets it lower than older NVIDIA generations. **Fix**: rehost every per-invocation array into two `StorageBuffer` SSBOs (binding 3 = i64 scratch, binding 4 = i32 scratch), allocated once in `GfxRuntime` and bound on every sizer dispatch. The sizer is `1x1x1` so cross-thread aliasing is impossible. (commit 3)

3. **`kAdStackSizerMaxNodesPerStack = 4096` was sized to fit per-thread private memory.** With the SSBO move that constraint is gone; the cap is now backed by ~512 KiB of device memory per `GfxRuntime` and exists only to keep the host encoder's hard-error attached to a fixed compile-time ceiling. Raised to 65536 so reverse-mode kernels with deep symbolic trees no longer hit the cap. (commit 4)

Reproduces on:
- RTX 5090 (consumer Blackwell)
- RTX 6000 Blackwell (data-center)

## Why

The sizer shader was originally written assuming Function-storage `OpVariable`s were a free-of-charge per-invocation scratch space, and the cumulative ~34 KiB sat well under what older NVIDIA / AMD / Apple Vulkan drivers tolerated. Blackwell drivers ship a stricter SPIR-V validator (catching the layout-decoration-on-Function-variable case) **and** a tighter per-thread compute-shader stack-frame budget (catching the 32 KiB cumulative). Both have to be addressed; (1) alone leaves the driver still rejecting at SASS lowering with `VK_ERROR_UNKNOWN`.

## Mechanism

### `IRBuilder::get_function_array_type` (commit 1)

New helper in `quadrants/codegen/spirv/spirv_ir_builder.{h,cpp}`. Emits the same `OpTypeArray` (or `OpTypeRuntimeArray`) and id-allocation bookkeeping as `get_array_type`, but skips the `ArrayStride` decoration. `get_array_type` now delegates the emission to `get_function_array_type` and adds the decoration on top, so the two stay in sync by construction (no duplicated body).

### User-kernel tensor allocas (commit 2)

`TaskCodegen::visit(AllocaStmt)` at `quadrants/codegen/spirv/spirv_codegen.cpp:325` was building a tensor-type array via `get_array_type` and feeding the result into either `alloca_workgroup_array` (`Workgroup` storage) or `alloca_variable` (`Function` storage). Both storage classes are subject to VUID-StandaloneSpirv-None-10684. Switched to `get_function_array_type`. Same commit also fixes a `u1`->`i32` rewrite regression in `get_array_type`'s body that an earlier draft of `get_function_array_type` introduced (the rewrite was applied only on the local copy inside the helper, leaving the `ArrayStride` computation upstream reading the unrewritten `u1` and emitting `ArrayStride 1` on a 4-byte-element array).

### Sizer scratch SSBO migration (commit 3)

The sizer's `ShaderState` previously held nine `Function`-storage `Value`s for the interpreter scratch (`values_arr`, `scope_arr`, eight `pending_*_arr`s). Now hosted as compile-time element offsets into two SSBOs:

- Binding 3: `int64[]` scratch, layout `[values_arr | scope_arr | pending_cur_i | pending_end | pending_max_accum]`. Total elements = `kAdStackSizerScratchI64Elems`.
- Binding 4: `int32[]` scratch, layout `[pending_mor_idx | pending_body_start | pending_body_end | pending_var_id | pending_saved_max_k]`. Total elements = `kAdStackSizerScratchI32Elems`.

`array_i64_access_ptr` / `array_i32_access_ptr` now take the SSBO + a compile-time base index + a runtime index, route through `struct_array_access`, and return a `StorageBuffer` pointer the existing `load_variable` / `store_variable` helpers consume unchanged. `GfxRuntime` allocates both buffers once on first sizer dispatch and reuses them for the lifetime of the runtime; the sizer is `1x1x1` so there is no cross-thread aliasing through the buffers.

### `kMaxNodes` cap raise (commit 4)

Bumped `kAdStackSizerMaxNodesPerStack` from 4096 to 65536. The cap concept is preserved (the host-side encoder hard-errors above the ceiling so an unexpectedly deep symbolic tree surfaces as an attributable encode-time diagnostic rather than as an out-of-bounds shader access), but at the new value the per-`GfxRuntime` device-memory allocation is 512 KiB plus the i32 buffer - negligible against any modern GPU's VRAM budget. Reverse-mode kernels with up to 64k symbolic tree nodes per stack now go through the on-device sizer instead of failing.

## Per-driver coverage matrix

| Driver | Pre-PR sizer pipeline build | Post-PR |
| --- | --- | --- |
| NVIDIA Blackwell (RTX 5090, RTX 6000 Blackwell) Vulkan | **Fails at `vkCreateComputePipelines`: VUID-StandaloneSpirv-None-10684 then `VK_ERROR_UNKNOWN`** | Passes |
| NVIDIA Ada / Ampere / Turing Vulkan | Passes (older drivers tolerated both issues) | Passes |
| AMD ROCm Vulkan | Passes | Passes |
| Apple Metal / MoltenVK | Passes | Passes |
| LLVM CPU / CUDA / AMDGPU paths | Unaffected (no SPIR-V) | Unaffected |

| User-kernel SPIR-V path | Pre-PR on Blackwell | Post-PR |
| --- | --- | --- |
| Tensor / shared-array allocas (`spirv_codegen.cpp:325`) | Fails VUID-StandaloneSpirv-None-10684 the same way the sizer did | Passes (commit 2 migration) |

## Tests

- `pytest tests/python/test_adstack.py -n 8`: 753 passed, 10 xfailed locally on macOS Vulkan / arm64 / Metal (each commit verified independently).
- The Blackwell reproducer `test_ad_ndarray_torch.py::test_tape_torch_tensor_grad_none[arch=vulkan]` should pass on RTX 5090 / RTX 6000 Blackwell once this lands.

## Side-effect audit

| Concern | Where checked | Verdict |
| --- | --- | --- |
| Storage-buffer / PSB / Uniform interface arrays still get `ArrayStride` | `get_array_type` body delegates to `get_function_array_type` then adds the decoration; every existing call site of `get_array_type` keeps the decorated path | Identical to pre-PR for those callers |
| `u1`->`i32` rewrite for layout-decorated array types | `get_array_type` re-applies the rewrite at the top before computing `nbytes`, mirroring pre-PR behaviour | Identical to pre-PR |
| Sizer SSBO scratch layout vs in-shader access pattern | `static_assert`s pin the i64 / i32 element-count totals against the shader-side `kI64Base*` / `kI32Base*` offsets; access helpers route through `struct_array_access` with the same `base + index` arithmetic the existing `load_buf_*` helpers use for the bytecode / args buffers | Layout drift would fail the static_asserts at compile time |
| Cross-thread aliasing of sizer scratch | The sizer is `1x1x1` (`set_work_group_size({1,1,1})`); the two scratch SSBOs are bound to that single dispatch and not visible to any other shader | No aliasing concern |
| Behaviour on non-Blackwell drivers | The pre-PR shader already worked there; the SSBO move is layout-equivalent (both paths read / write the same logical state in the same access order); `get_function_array_type` removes a decoration that was always invalid for Function-scope variables but tolerated by older validators | Unchanged |
| Encoder hard-error at the new cap | `encode_adstack_size_expr_device_bytecode_for_spirv` continues to compare against `kAdStackSizerMaxNodesPerStack`; the only effect of the bump is that more trees slip below the ceiling | Unchanged contract |