### PR TITLE
[AutoDiff] Improve diagnosis of unsupported reverse-mode AD patterns

### DIFF
--- a/python/quadrants/lang/_func_base.py
+++ b/python/quadrants/lang/_func_base.py
@@ -385,6 +385,13 @@ class FuncBase:
             autodiff_mode=autodiff_mode,
             raise_on_templated_floats=raise_on_templated_floats,
         )
+        if not is_kernel:
+            # Seed the func context with the caller's `loop_depth` so a non-static `range(...)` inside the func body
+            # sees any outer for-loops the caller is already inside. Without this seeding the dynamic-range backward-
+            # mode diagnostic at `ASTTransformer.build_For` only fires when the loop is written directly in the
+            # kernel, and routing the same loop through a `@qd.func` would silently emit a wrong adjoint. Kernels
+            # start at the top of the call stack so they always begin at depth 0.
+            ctx.loop_depth = global_context.caller_loop_depth
         return tree, ctx
 
     def fuse_args(

--- a/python/quadrants/lang/ast/ast_transformer_utils.py
+++ b/python/quadrants/lang/ast/ast_transformer_utils.py
@@ -183,6 +183,13 @@ class ASTTransformerGlobalContext:
         self.pass_idx: int = pass_idx
         self.ndarray_to_any_array: dict[int, Any] = {}
         self.struct_ndarray_launch_info: list[tuple] = []
+        # Caller-side `loop_depth` snapshot for the in-flight `@qd.func` invocation. Each func compile creates a fresh
+        # `ASTTransformerFuncContext` with `loop_depth = 0`, so without this snapshot a non-static `range(...)` loop
+        # inside a func body would not see any outer for-loops in the caller and would skip the backward-mode dynamic-
+        # range diagnostic, silently emitting a wrong adjoint. `CallTransformer.build_Call` writes the caller
+        # `ctx.loop_depth` here before invoking the func and restores the previous value after, so the new func ctx
+        # can seed its `loop_depth` from this field via `_func_base.py`.
+        self.caller_loop_depth: int = 0
 
 
 class ASTTransformerFuncContext:

--- a/python/quadrants/lang/ast/ast_transformers/call_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformers/call_transformer.py
@@ -361,31 +361,41 @@ class CallTransformer:
             return node.ptr
 
         CallTransformer._warn_if_is_external_func(ctx, node)
+        # Snapshot the caller's `loop_depth` on the global context so a `@qd.func` invocation routed through
+        # `func(*py_args, **py_kwargs)` below can seed its fresh `ASTTransformerFuncContext` from this value in
+        # `_func_base.py` and inherit any outer for-loops we are already inside. Save/restore unconditionally because
+        # we cannot tell from this site whether `func` is a Quadrants func, a builtin, or a Python callable; the
+        # snapshot is harmless for non-func callables and nests correctly through chained calls.
+        prev_caller_loop_depth = ctx.global_context.caller_loop_depth
+        ctx.global_context.caller_loop_depth = ctx.loop_depth
         try:
-            pruning = ctx.global_context.pruning
-            if pruning.enforcing:
-                py_args = pruning.filter_call_args(func, node, node_args, node_keywords, py_args)
+            try:
+                pruning = ctx.global_context.pruning
+                if pruning.enforcing:
+                    py_args = pruning.filter_call_args(func, node, node_args, node_keywords, py_args)
 
-            node.ptr = func(*py_args, **py_kwargs)
+                node.ptr = func(*py_args, **py_kwargs)
 
-            if not pruning.enforcing:
-                pruning.record_after_call(ctx, func, node, node_args, node_keywords)
-        except TypeError as e:
-            module = inspect.getmodule(func)
-            error_msg = re.sub(r"\bExpr\b", "Quadrants Expression", str(e))
-            func_name = getattr(func, "__name__", func.__class__.__name__)
-            msg = f"TypeError when calling `{func_name}`: {error_msg}."
-            if CallTransformer._is_external_func(ctx, node.func.ptr):
-                args_has_expr = any([isinstance(arg, Expr) for arg in args])
-                if args_has_expr and (module == math or module == np):
-                    exec_str = f"from quadrants import {func.__name__}"
-                    try:
-                        exec(exec_str, {})
-                    except:
-                        pass
-                    else:
-                        msg += f"\nDid you mean to use `qd.{func.__name__}` instead of `{module.__name__}.{func.__name__}`?"
-            raise QuadrantsTypeError(msg)
+                if not pruning.enforcing:
+                    pruning.record_after_call(ctx, func, node, node_args, node_keywords)
+            except TypeError as e:
+                module = inspect.getmodule(func)
+                error_msg = re.sub(r"\bExpr\b", "Quadrants Expression", str(e))
+                func_name = getattr(func, "__name__", func.__class__.__name__)
+                msg = f"TypeError when calling `{func_name}`: {error_msg}."
+                if CallTransformer._is_external_func(ctx, node.func.ptr):
+                    args_has_expr = any([isinstance(arg, Expr) for arg in args])
+                    if args_has_expr and (module == math or module == np):
+                        exec_str = f"from quadrants import {func.__name__}"
+                        try:
+                            exec(exec_str, {})
+                        except:
+                            pass
+                        else:
+                            msg += f"\nDid you mean to use `qd.{func.__name__}` instead of `{module.__name__}.{func.__name__}`?"
+                raise QuadrantsTypeError(msg)
+        finally:
+            ctx.global_context.caller_loop_depth = prev_caller_loop_depth
 
         if getattr(func, "_is_quadrants_function", False):
             ctx.func.has_print |= func.wrapper.has_print

--- a/quadrants/transforms/auto_diff.cpp
+++ b/quadrants/transforms/auto_diff.cpp
@@ -2924,9 +2924,181 @@ class CoalesceAdStackLoads : public BasicStmtVisitor {
   DelayedIRModifier modifier_;
 };
 
+// Detect cross-iteration read-after-write through a `needs_grad` global field at the body of an offload-level
+// range-for. `MakeAdjoint` treats each iteration of an offload-level loop as independent and only chases
+// loop-carried dependencies through `AdStackAllocaJudger`, which inspects local `AllocaStmt`s - cross-iteration
+// dependencies through `GlobalStoreStmt` / `GlobalLoadStmt` on a `has_adjoint()` SNode are silently dropped.
+// A kernel like `out[i] = out[i-1] + x[None]` therefore returns wrong gradients with no diagnostic, even with
+// `ad_stack_experimental_enabled`. Pair every same-SNode (store, load) and raise when the index Stmt*s differ.
+// Same-Stmt indices (`out[i] = out[i] + x[None]`) are in-place accumulation and the per-iteration backward
+// pass handles those correctly; pointer equality on the SSA index Stmts after the `pre_autodiff` simplify
+// (`compile_to_offloads.cpp:121`) is enough to distinguish the two cases. Walks the body of every direct-child
+// `RangeForStmt` of `root`; nested for-loops' bodies are skipped via `inside_nested_` because their cross-iter
+// behavior is governed by the existing IB / adstack machinery, not by this offload-level guard.
+class OffloadLevelGlobalCrossIterRAWChecker : public BasicStmtVisitor {
+ public:
+  using BasicStmtVisitor::visit;
+
+  void visit(GlobalStoreStmt *stmt) override {
+    if (inside_nested_)
+      return;
+    if (auto *gp = extract_global_ptr(stmt->dest)) {
+      if (gp->snode->has_adjoint())
+        stores_[gp->snode].push_back(gp);
+    }
+  }
+
+  void visit(GlobalLoadStmt *stmt) override {
+    if (inside_nested_)
+      return;
+    if (auto *gp = extract_global_ptr(stmt->src)) {
+      if (gp->snode->has_adjoint())
+        loads_[gp->snode].push_back(gp);
+    }
+  }
+
+  void visit(RangeForStmt *stmt) override {
+    walk_nested_loop_body(stmt->body.get());
+  }
+
+  void visit(StructForStmt *stmt) override {
+    walk_nested_loop_body(stmt->body.get());
+  }
+
+  void visit(MeshForStmt *stmt) override {
+    walk_nested_loop_body(stmt->body.get());
+  }
+
+  void visit(WhileStmt *stmt) override {
+    walk_nested_loop_body(stmt->body.get());
+  }
+
+  static void run(Block *offload_body) {
+    OffloadLevelGlobalCrossIterRAWChecker checker;
+    offload_body->accept(&checker);
+    for (const auto &kv : checker.stores_) {
+      auto *snode = kv.first;
+      auto load_it = checker.loads_.find(snode);
+      if (load_it == checker.loads_.end())
+        continue;
+      for (auto *store : kv.second) {
+        // The store's index must reference the offload's `LoopIndexStmt` on at least one axis - otherwise it is
+        // iteration-independent (writes the same slot every iteration) and there is no cross-iter chain to drop.
+        if (!any_axis_references_loop_index(store))
+          continue;
+        for (auto *load : load_it->second) {
+          // Skip loads whose index is iteration-independent on every axis (constants, captures from outer
+          // scopes, ...). Such loads read from a slice of the SNode that the loop never writes to in this
+          // iteration, so they are not a cross-iter RAW hazard.
+          if (!any_axis_references_loop_index(load))
+            continue;
+          if (!indices_have_no_cross_iter_dependency(store, load)) {
+            QD_ERROR(
+                "Cross-iteration read-after-write on the `needs_grad` global field `{}` at the offload-level "
+                "loop body is not supported in reverse-mode autodiff: the cross-iteration adjoint chain is "
+                "not generated and the backward pass returns wrong gradients with no diagnostic. Wrap the "
+                "loop in an outer for-loop in the kernel so the inner range becomes adstack-eligible, or "
+                "restructure the kernel so the offload-level loop has no global field cross-iteration "
+                "read-after-write. Sibling-component access on a disjoint axis like `out[i, 0] = out[i, 1]` "
+                "is allowed; in-place accumulation `out[i] = out[i] + x` (same index Stmt on every axis) is "
+                "also fine.",
+                snode->get_node_type_name_hinted());
+          }
+        }
+      }
+    }
+  }
+
+ private:
+  void walk_nested_loop_body(Block *body) {
+    bool prev = inside_nested_;
+    inside_nested_ = true;
+    body->accept(this);
+    inside_nested_ = prev;
+  }
+
+  static GlobalPtrStmt *extract_global_ptr(Stmt *s) {
+    if (auto *gp = s->cast<GlobalPtrStmt>())
+      return gp;
+    if (auto *mp = s->cast<MatrixPtrStmt>()) {
+      if (auto *gp = mp->origin->cast<GlobalPtrStmt>())
+        return gp;
+    }
+    return nullptr;
+  }
+
+  // Decide whether two `GlobalPtrStmt`s on the same SNode index iter-independent slices of that SNode (no
+  // cross-iter dependency). The rules are per-axis:
+  //   - axis where neither index references `LoopIndexStmt`: constants or outer-scope captures, may differ
+  //     (sibling-component access on a disjoint axis like `state[i, 0]` vs `state[i, 1]`); never a cross-iter
+  //     dependency.
+  //   - axis where both indices reference `LoopIndexStmt`: must be the same SSA `Stmt*` (e.g. both bare
+  //     `LoopIndexStmt(i)`). If one is `LoopIndex` and the other is `LoopIndex - 1` or similar, the load reads
+  //     a slot the store wrote in a different iteration: this is cross-iter.
+  //   - axis where exactly one references `LoopIndexStmt`: load and store have iter-dependent vs iter-
+  //     independent indexing on the same axis; conservatively flag as cross-iter, since whether the constant
+  //     index aliases an iteration of the loop is not provable here.
+  static bool indices_have_no_cross_iter_dependency(GlobalPtrStmt *a, GlobalPtrStmt *b) {
+    if (a->indices.size() != b->indices.size())
+      return false;
+    for (std::size_t i = 0; i < a->indices.size(); ++i) {
+      bool a_refs = references_loop_index(a->indices[i]);
+      bool b_refs = references_loop_index(b->indices[i]);
+      if (a_refs != b_refs)
+        return false;
+      if (a_refs && b_refs && a->indices[i] != b->indices[i])
+        return false;
+    }
+    return true;
+  }
+
+  // Walk an index `Stmt*` and decide whether it (transitively) references a `LoopIndexStmt` of any enclosing
+  // loop. Recurses through linear arithmetic ops because an index like `i - 1` lowers to
+  // `BinaryOpStmt(LoopIndexStmt(i), Sub, ConstStmt(1))` and we want to recognise the `LoopIndexStmt` underneath.
+  // Conservatively returns false for anything else (constants, ndarray loads from outer scope, ...) - those
+  // express iteration-independent indexing that the cross-iter guard intentionally exempts.
+  static bool references_loop_index(Stmt *s) {
+    if (s == nullptr)
+      return false;
+    if (s->is<LoopIndexStmt>())
+      return true;
+    if (auto *bo = s->cast<BinaryOpStmt>())
+      return references_loop_index(bo->lhs) || references_loop_index(bo->rhs);
+    if (auto *uo = s->cast<UnaryOpStmt>())
+      return references_loop_index(uo->operand);
+    if (auto *to = s->cast<TernaryOpStmt>())
+      return references_loop_index(to->op1) || references_loop_index(to->op2) || references_loop_index(to->op3);
+    return false;
+  }
+
+  static bool any_axis_references_loop_index(GlobalPtrStmt *gp) {
+    for (auto *idx : gp->indices) {
+      if (references_loop_index(idx))
+        return true;
+    }
+    return false;
+  }
+
+  std::unordered_map<SNode *, std::vector<GlobalPtrStmt *>> stores_;
+  std::unordered_map<SNode *, std::vector<GlobalPtrStmt *>> loads_;
+  bool inside_nested_ = false;
+};
+
 void auto_diff(IRNode *root, const CompileConfig &config, AutodiffMode autodiff_mode, bool use_stack) {
   QD_AUTO_PROF;
   if (autodiff_mode == AutodiffMode::kReverse) {
+    if (auto *root_block = root->cast<Block>()) {
+      // Top-level range-fors at the kernel root become the offload-level loop. Walk each direct child once
+      // and refuse cross-iteration global RAW on a needs_grad SNode before the AD transformation runs - any
+      // diagnostic from inside `MakeAdjoint` would already point at the partially-rewritten reverse IR and
+      // be much harder to read. StructFor offloads are out of scope: their loop variable is an SNode index
+      // produced by the runtime, not a user-controlled integer arithmeticed against itself, so the
+      // `out[i-1]` shape this guard targets does not arise.
+      for (auto &s : root_block->statements) {
+        if (auto *rf = s->cast<RangeForStmt>())
+          OffloadLevelGlobalCrossIterRAWChecker::run(rf->body.get());
+      }
+    }
     RegulateTensorTypedStatements::run(root);
     if (use_stack) {
       auto IB = IdentifyIndependentBlocks::run(root);

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -412,24 +412,48 @@ def test_adstack_basic_gradient_f64(n_iter):
 
 
 @pytest.mark.parametrize("n_iter", [1, 3, 10])
+@pytest.mark.parametrize("wrap_inner_in_func", [False, True])
 @test_utils.test(ad_stack_experimental_enabled=False)
-def test_adstack_basic_gradient_negative(n_iter):
+def test_adstack_basic_gradient_negative(wrap_inner_in_func, n_iter):
     # Negative counterpart of `test_adstack_basic_gradient`: with the adstack disabled the backward compiler
     # cannot reverse a dynamic `range(n_iter)`, so `compute.grad()` raises `QuadrantsCompilationError("Cannot use
     # non static range in Backwards mode")` deterministically for every `n_iter`. Inlined rather than reusing
     # `_run_basic_gradient` because the shall-not-pass path never reaches the gradient assertion, so a shared
     # helper would carry a dead `rel_tol` argument down this branch.
+    #
+    # Internal details: the `wrap_inner_in_func` axis covers both shapes that should produce the same diagnostic.
+    # When False, the dynamic-range loop sits directly inside the outer struct-for, so `ctx.loop_depth > 0` at the
+    # range-for visit and the AST transformer raises. When True, the same dynamic-range loop body lives inside a
+    # nested `@qd.func` and is invoked from the outer struct-for; the func body must inherit the caller's
+    # `loop_depth` so the nested-range check still fires - if the func compile path resets `loop_depth` back to 0
+    # the kernel compiles silently and the backward pass produces a wrong gradient with no diagnostic.
     n = 4
     x = qd.field(qd.f32, shape=n, needs_grad=True)
     y = qd.field(qd.f32, shape=(), needs_grad=True)
 
-    @qd.kernel
-    def compute():
-        for i in x:
-            v = x[i]
-            for _ in range(n_iter):
-                v = v * 0.95 + 0.01
-            y[None] += v
+    @qd.func
+    def inner(v_in: qd.f32) -> qd.f32:
+        v = v_in
+        for _ in range(n_iter):
+            v = v * 0.95 + 0.01
+        return v
+
+    if wrap_inner_in_func:
+
+        @qd.kernel
+        def compute():
+            for i in x:
+                y[None] += inner(x[i])
+
+    else:
+
+        @qd.kernel
+        def compute():
+            for i in x:
+                v = x[i]
+                for _ in range(n_iter):
+                    v = v * 0.95 + 0.01
+                y[None] += v
 
     x_vals = [0.1, 0.3, 0.5, 0.8]
     for i, v in enumerate(x_vals):
@@ -439,6 +463,277 @@ def test_adstack_basic_gradient_negative(n_iter):
 
     with pytest.raises(qd.QuadrantsCompilationError, match=r"non static range"):
         compute.grad()
+
+
+_REVERSE_GLOBAL_CROSS_ITER_PATTERNS = [
+    # `(has_outer_for, in_func, load_kind)` toggles for `_run_reverse_global_cross_iter`. `load_kind` selects which
+    # `out[...]` index expression the inner range loads from: `cross_iter` is the canonical `out[i-1]` shape with a
+    # genuine cross-iteration RAW; `constant_outside_iter_range` reads from a slot of `out` that the loop never
+    # writes to, so the load and store live on disjoint iteration slices and the diagnostic must not fire.
+    pytest.param(False, False, "cross_iter", id="kernel_top_inline_cross_iter"),
+    pytest.param(False, True, "cross_iter", id="kernel_top_in_func_cross_iter"),
+    pytest.param(True, False, "cross_iter", id="outer_for_inline_cross_iter"),
+    pytest.param(True, True, "cross_iter", id="outer_for_in_func_cross_iter"),
+    pytest.param(False, False, "constant_outside_iter_range", id="kernel_top_inline_constant_outside"),
+    pytest.param(False, True, "constant_outside_iter_range", id="kernel_top_in_func_constant_outside"),
+    pytest.param(True, False, "constant_outside_iter_range", id="outer_for_inline_constant_outside"),
+    pytest.param(True, True, "constant_outside_iter_range", id="outer_for_in_func_constant_outside"),
+]
+
+
+def _run_reverse_global_cross_iter(has_outer_for, in_func, load_kind, expect_raise):
+    # Single factory covering the reverse-mode shapes that read and write the same `needs_grad` global field
+    # `out` from inside an inner non-static range, parametrised on three orthogonal axes:
+    #   - `has_outer_for`: when True the inner range is nested under a `range(1)`, so it is AST-nested at
+    #     `loop_depth == 1`; when False the inner range becomes the offload-level loop after inlining. The
+    #     toggle is materialised via the `range(1) if qd.static(...) else qd.static(range(1))` inline-if pattern
+    #     (already used by `_run_unary_loop_carried` in this file) so a single kernel template covers both.
+    #   - `in_func`: when True the inner range body lives inside a `@qd.func` invoked from the kernel; when
+    #     False the same body is written directly inside the kernel.
+    #   - `load_kind`: `cross_iter` puts the canonical `out[i-1]` cross-iteration RAW shape in the body;
+    #     `constant_outside_iter_range` replaces the load with `out[n]` (a slot strictly outside the iteration
+    #     range `[0, n)`), so the load and store live on disjoint iteration slices and there is no real
+    #     cross-iter dependency. Pins the offload-level guard's `references_loop_index` gate.
+    n = 4
+    out_shape = 2 * n if load_kind == "constant_outside_iter_range" else n
+    x = qd.field(qd.f32, shape=(), needs_grad=True)
+    out = qd.field(qd.f32, shape=out_shape, needs_grad=True)
+
+    @qd.func
+    def func_body_cross_iter():
+        for i in range(n):
+            if i == 0:
+                out[i] = x[None]
+            else:
+                out[i] = out[i - 1] + x[None]
+
+    @qd.func
+    def func_body_constant_outside():
+        for i in range(n):
+            out[i] = out[n] + x[None]
+
+    @qd.kernel
+    def compute():
+        for _ in range(1) if qd.static(has_outer_for) else qd.static(range(1)):
+            if qd.static(in_func):
+                if qd.static(load_kind == "cross_iter"):
+                    func_body_cross_iter()
+                else:
+                    func_body_constant_outside()
+            else:
+                if qd.static(load_kind == "cross_iter"):
+                    for i in range(n):
+                        if i == 0:
+                            out[i] = x[None]
+                        else:
+                            out[i] = out[i - 1] + x[None]
+                else:
+                    for i in range(n):
+                        out[i] = out[n] + x[None]
+
+    x[None] = 1.0
+    if load_kind == "constant_outside_iter_range":
+        out[n] = 0.5
+    compute()
+    for i in range(out_shape):
+        out.grad[i] = 0.0
+    if load_kind == "cross_iter":
+        out.grad[n - 1] = 1.0
+        expected_x_grad = float(n)
+    else:
+        for i in range(n):
+            out.grad[i] = 1.0
+        expected_x_grad = float(n)
+    x.grad[None] = 0.0
+    if expect_raise:
+        with pytest.raises(
+            (qd.QuadrantsCompilationError, RuntimeError),
+            match=r"non static range|Cross-iteration read-after-write",
+        ):
+            compute.grad()
+    else:
+        compute.grad()
+        assert float(x.grad[None]) == pytest.approx(expected_x_grad, rel=1e-6)
+
+
+@pytest.mark.parametrize("has_outer_for, in_func, load_kind", _REVERSE_GLOBAL_CROSS_ITER_PATTERNS)
+@test_utils.test(require=qd.extension.adstack)
+def test_reverse_global_cross_iter_with_adstack(has_outer_for, in_func, load_kind):
+    # Reverse-mode AD on a kernel that reads and writes the same `needs_grad` global field from inside a non-static
+    # range must either produce the analytical gradient or raise a clear diagnostic. With adstack on, only the
+    # kernel-top shapes with a genuine cross-iteration RAW raise; the outer-for shapes and the
+    # constant-outside-iter-range shapes produce the analytical gradient.
+    #
+    # Internal details: `AdStackAllocaJudger` only promotes cross-iter dependencies on local `AllocaStmt`s, never
+    # through global field stores; cross-iter through a global needs_grad field at the offload level is therefore
+    # not handled in either adstack setting and must raise. The offload-level guard in `auto_diff.cpp` pairs same-
+    # SNode `(GlobalStore, GlobalLoad)` and raises on structurally-different index `Stmt*`s, but only when both
+    # indices transitively reference a `LoopIndexStmt` - which suppresses the false positive on the
+    # constant-outside-iter-range shape where the load reads a slot the loop never writes to. The outer-for shapes
+    # route the cross-iter chain through an AST-nested range whose backward the AD pass handles correctly via the
+    # IB analysis when adstack is on.
+    expect_raise = (not has_outer_for) and load_kind == "cross_iter"
+    _run_reverse_global_cross_iter(has_outer_for, in_func, load_kind, expect_raise)
+
+
+@pytest.mark.parametrize("has_outer_for, in_func, load_kind", _REVERSE_GLOBAL_CROSS_ITER_PATTERNS)
+@test_utils.test()
+def test_reverse_global_cross_iter_without_adstack(has_outer_for, in_func, load_kind):
+    # Same eight shapes as the with-adstack companion. With adstack off, every outer-for shape raises via the
+    # AST-level `loop_depth > 0` check (purely on nesting, regardless of body content), and the kernel-top
+    # cross-iter shapes raise via the offload-level guard in `auto_diff.cpp`. The kernel-top
+    # constant-outside-iter-range shape is the only combination that compiles cleanly: nesting is zero so the
+    # AST guard does not fire, and the load index is iteration-independent so the offload-level guard's
+    # `references_loop_index` gate also does not fire.
+    #
+    # Internal details: the caller-loop-depth propagation in `_func_base.py` is what makes the @qd.func variant
+    # of the outer-for shape behave identically to the inline variant - without it, the func context would
+    # start at `loop_depth = 0` and the AST guard would never fire for the func-routed nested shape.
+    expect_raise = has_outer_for or load_kind == "cross_iter"
+    _run_reverse_global_cross_iter(has_outer_for, in_func, load_kind, expect_raise)
+
+
+_REVERSE_SIBLING_COMPONENT_PATTERNS = [
+    # `(has_outer_for, in_func)` toggles for `_run_reverse_sibling_component_correct_gradient`. Same axes as the
+    # cross-iter matrix, minus the `load_kind` dimension (the body shape here is fixed: same loop index on
+    # axis 0 of `out`, differing constants on axis 1).
+    pytest.param(False, False, id="kernel_top_inline"),
+    pytest.param(False, True, id="kernel_top_in_func"),
+    pytest.param(True, False, id="outer_for_inline"),
+    pytest.param(True, True, id="outer_for_in_func"),
+]
+
+
+def _run_reverse_sibling_component_correct_gradient(has_outer_for, in_func):
+    # Drives a kernel that writes `out[i, 0]` and reads `out[i, 1]` on a 2-axis `needs_grad` field. The store
+    # and load both reference `LoopIndexStmt(i)` on axis 0 (same `Stmt*`) and have differing `ConstStmt`s on
+    # axis 1. The offload-level guard's per-axis rule treats the differing constant axis as iter-independent
+    # sibling access, so the kernel must compile and produce the analytical gradient.
+    n = 4
+    x = qd.field(qd.f32, shape=(), needs_grad=True)
+    out = qd.field(qd.f32, shape=(n, 2), needs_grad=True)
+
+    @qd.func
+    def func_body():
+        for i in range(n):
+            out[i, 1] = x[None]
+            out[i, 0] = out[i, 1] * 2.0
+
+    @qd.kernel
+    def compute():
+        for _ in range(1) if qd.static(has_outer_for) else qd.static(range(1)):
+            if qd.static(in_func):
+                func_body()
+            else:
+                for i in range(n):
+                    out[i, 1] = x[None]
+                    out[i, 0] = out[i, 1] * 2.0
+
+    x[None] = 1.0
+    compute()
+    for i in range(n):
+        out.grad[i, 0] = 1.0
+        out.grad[i, 1] = 0.0
+    x.grad[None] = 0.0
+    compute.grad()
+    # `out[i, 0] = (out[i, 1] = x) * 2.0 = 2x` per iter; seed `out.grad[i, 0] = 1` for every i.
+    # `d(out[i, 0]) / d(x) = 2` per iter -> `x.grad = 2 * n`.
+    assert float(x.grad[None]) == pytest.approx(2.0 * n, rel=1e-6)
+
+
+@pytest.mark.parametrize("has_outer_for, in_func", _REVERSE_SIBLING_COMPONENT_PATTERNS)
+@test_utils.test(require=qd.extension.adstack)
+def test_reverse_sibling_component_correct_gradient_with_adstack(has_outer_for, in_func):
+    # Sibling-component access on a multi-axis `needs_grad` field must compile and produce the analytical
+    # gradient. The store and load share the same `LoopIndexStmt` on axis 0 and differ only on a constant
+    # axis, which is sibling access in the same iteration, not cross-iter RAW.
+    #
+    # Internal details: the offload-level guard's per-axis `indices_have_no_cross_iter_dependency` rule
+    # treats axes where neither index references `LoopIndexStmt` as iter-independent and ignores their
+    # difference, so `out[i, 0]` vs `out[i, 1]` is not flagged.
+    _run_reverse_sibling_component_correct_gradient(has_outer_for, in_func)
+
+
+def _run_reverse_kernel_top_indep_iters_correct_gradient():
+    # Independent-iteration kernel-top range-for (no cross-iteration RAW). Both adstack settings must
+    # produce the analytical gradient `2 * n` for the per-iteration store `out[i] = x[None] * 2`.
+    n = 4
+    x = qd.field(qd.f32, shape=(), needs_grad=True)
+    out = qd.field(qd.f32, shape=n, needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i in range(n):
+            out[i] = x[None] * 2.0
+
+    x[None] = 1.0
+    compute()
+    for i in range(n):
+        out.grad[i] = 1.0
+    x.grad[None] = 0.0
+    compute.grad()
+    assert float(x.grad[None]) == pytest.approx(2.0 * n, rel=1e-6)
+
+
+@test_utils.test(require=qd.extension.adstack)
+def test_reverse_kernel_top_indep_iters_with_adstack():
+    # Kernel-top non-static range whose body has no cross-iter RAW on a `needs_grad` field must
+    # produce the analytical gradient with adstack on.
+    #
+    # Internal details: the offload-level guard pairs only same-SNode `(store, load)`, so a body
+    # that only stores `out[i] = x[None] * 2` (no load on `out`) compiles cleanly. Adstack itself has
+    # nothing to do here either - each iteration is independent.
+    _run_reverse_kernel_top_indep_iters_correct_gradient()
+
+
+@test_utils.test()
+def test_reverse_kernel_top_indep_iters_without_adstack():
+    # Same independent-iteration shape as the with-adstack companion, must produce the analytical
+    # gradient with adstack off.
+    #
+    # Internal details: the AST-level `loop_depth > 0` check does not fire (range-for is at
+    # `loop_depth == 0`) and there is no cross-iter chain to drop, so the gradient comes out correct
+    # without the adstack.
+    _run_reverse_kernel_top_indep_iters_correct_gradient()
+
+
+def _run_reverse_kernel_top_in_place_accum_correct_gradient():
+    # In-place accumulation `out[i] = out[i] + x[None]` at the kernel-top range-for. Sanity check that
+    # the offload-level guard's pointer-equality on index `Stmt*`s allows this shape - store and
+    # load on `out` share the same `LoopIndexStmt` so `indices_pointer_match` returns true and the
+    # guard does not fire.
+    n = 4
+    x = qd.field(qd.f32, shape=(), needs_grad=True)
+    out = qd.field(qd.f32, shape=n, needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i in range(n):
+            out[i] = out[i] + x[None]
+
+    x[None] = 1.0
+    for i in range(n):
+        out[i] = 0.0
+    compute()
+    for i in range(n):
+        out.grad[i] = 1.0
+    x.grad[None] = 0.0
+    compute.grad()
+    # `out[i] = out[i] + x` reduces to `out[i] += x`; with `out[i]` initialised to 0, the per-iteration
+    # adjoint accumulates 1 into `x.grad` for each of n elements when `out.grad[i] = 1`.
+    assert float(x.grad[None]) == pytest.approx(float(n), rel=1e-6)
+
+
+@test_utils.test(require=qd.extension.adstack)
+def test_reverse_kernel_top_in_place_accum_with_adstack():
+    # In-place accumulation `out[i] = out[i] + x[None]` at the offload-level loop must compile and
+    # produce the analytical gradient: the offload-level guard intentionally exempts this shape.
+    #
+    # Internal details: the store dest `out[i]` and the load src `out[i]` reference the same
+    # `LoopIndexStmt`, so `OffloadLevelGlobalCrossIterRAWChecker::indices_pointer_match` returns true
+    # and the guard does not fire. The per-iteration adjoint already handles in-place accumulation
+    # correctly: `x.grad` accumulates 1 per element.
+    _run_reverse_kernel_top_in_place_accum_correct_gradient()
 
 
 @test_utils.test(


### PR DESCRIPTION
# Improve diagnosis of unsupported reverse-mode AD patterns

> Two diagnostic fixes for previously-silent classes of wrong-gradient bugs in reverse-mode autodiff. (1) An AST-level fix that propagates the caller's `loop_depth` across `@qd.func` boundaries so the existing dynamic-range guard fires on `@qd.func`-routed shapes the same way it already does on inline shapes. (2) A new IR-level guard in `auto_diff.cpp` that catches cross-iteration read-after-write on a `needs_grad` global field at the offload-level loop, a shape neither the AST guard nor the adstack handles.

## TL;DR

The kernel below silently produced `x.grad == 1` instead of the correct `x.grad == n` in both adstack settings:

```python
@qd.func
def body():
    for i in range(n_iter[None]):
        if i == 0:
            out[i] = x[None]
        else:
            out[i] = out[i - 1] + x[None]

@qd.kernel
def fwd():
    body()
```

It now raises a clear `RuntimeError` from `auto_diff.cpp` pointing at the two valid workarounds (wrap the call in an outer for-loop, or restructure to remove the cross-iteration RAW). The companion `@qd.func`-bypass class - a non-static `range(...)` nested inside an outer for-loop in the kernel but routed through a `@qd.func` body - now also raises the same `QuadrantsCompilationError` the inline shape already raised.

## Why

Two distinct silent-wrong-gradient classes that previously slipped through every guard.

### Class 1 - `@qd.func` bypassed the existing AST guard

The upstream `loop_depth > 0` check at `ASTTransformer.build_For` fires when a non-static `range(...)` is AST-nested inside another for-loop. The check uses `ctx.loop_depth`, which is local to a single AST transformer context and resets to zero every time the transformer enters a `@qd.func` body, so:

```python
# Inline: AST loop_depth == 1 at the inner range -> existing check fires (without adstack).
@qd.kernel
def k():
    for i in x:
        for _ in range(n_iter):
            v = v * 0.95 + 0.01

# Routed through @qd.func: func ctx loop_depth resets to 0 -> existing check did NOT fire,
# kernel compiled and silently produced wrong gradients.
@qd.func
def inner(...):
    for _ in range(n_iter):
        v = v * 0.95 + 0.01

@qd.kernel
def k():
    for i in x:
        y[None] += inner(x[i])
```

This shape is pinned by the new `wrap_inner_in_func=True` parametrization on `test_adstack_basic_gradient_negative`; before this PR it would have passed with no diagnostic and a wrong adjoint.

### Class 2 - cross-iteration RAW on a `needs_grad` global field at the offload-level loop

Reverse-mode AD relies on either (a) the adstack to replay loop-carried local primals, or (b) the kernel-internal IB analysis at `quadrants/transforms/auto_diff.cpp` to chain adjoints through AST-nested loops. Neither mechanism applies when the cross-iteration dependency is on a **global field** at the **offload-level loop** (i.e., the kernel's outermost loop, not nested under another loop):

- `AdStackAllocaJudger` only promotes cross-iteration dependencies on local `AllocaStmt`s. Cross-iter through `GlobalStoreStmt` / `GlobalLoadStmt` on a `has_adjoint()` SNode is never promoted.
- `MakeAdjoint`'s reverse pass for the offload-level loop body emits per-iteration adjoints; the cross-iter chain `out[i-1] -> out[i]` is not threaded into that pass.

So a kernel that writes `out[i] = out[i-1] + x[None]` at the offload-level loop body silently produced wrong gradients in both adstack settings, with no diagnostic. The TL;DR repro is the minimal expression of this shape.

## Surface API

No new user-visible API. Two diagnostics fire at compile time when the kernel hits an unsupported reverse-mode shape:

1. `Cannot use non static range in Backwards mode` (raised as `QuadrantsCompilationError`) - the upstream AST guard at `ASTTransformer.build_For`. Now also fires for `@qd.func`-routed shapes thanks to the caller-`loop_depth` propagation, so inline and func-routed forms of the diagnostic behave identically.
2. `Cross-iteration read-after-write on the `needs_grad` global field `<snode>` at the offload-level loop body is not supported in reverse-mode autodiff: ...` (raised as `RuntimeError` from `QD_ERROR`) - new IR-level diagnostic. Fires in both adstack settings because adstack does not handle this shape regardless of the flag. Multi-axis sibling-component access (`out[i, 0] = out[i, 1] * 2`) and in-place accumulation (`out[i] = out[i] + x`) are exempted via the per-axis rule described below.

`test_adstack_basic_gradient_negative` accepts both exception types since the same shape is now reachable through either guard depending on which fires first; everything else is unchanged.

## Mechanism

### 1. AST-level: caller-`loop_depth` propagation

Three Python files - `_func_base.py`, `ast_transformer_utils.py`, `call_transformer.py` - thread the caller's `ctx.loop_depth` across `@qd.func` invocations:

- `ASTTransformerGlobalContext` carries a `caller_loop_depth: int` field (the snapshot site).
- `CallTransformer.build_Call` writes `ctx.loop_depth` into the global context's `caller_loop_depth` before invoking the callable, and restores the previous value in a `finally` (so chained calls and exceptions both restore correctly).
- `_func_base.py` seeds the freshly-created `ASTTransformerFuncContext` with `ctx.loop_depth = global_context.caller_loop_depth` for non-kernel contexts, so a non-static `range(...)` inside the func body sees the same `loop_depth > 0` the caller is already inside. Kernel contexts always begin at depth 0.

The upstream `loop_depth > 0` check at `ASTTransformer.build_For` is otherwise untouched.

### 2. IR-level: `OffloadLevelGlobalCrossIterRAWChecker` in `auto_diff.cpp`

A `BasicStmtVisitor` gated on `autodiff_mode == kReverse`, run before `RegulateTensorTypedStatements` so the diagnostic still points at the user-shaped IR (post-frontend-lowering, but before any AD rewrites).

Walks the body of every direct-child `RangeForStmt` of the kernel root once. Inside that body collects, per `has_adjoint()` SNode:

- every `GlobalStoreStmt` destination `GlobalPtrStmt` (also drilling through `MatrixPtrStmt` to its origin),
- every `GlobalLoadStmt` source `GlobalPtrStmt` (same).

`inside_nested_` is set on entry into any nested `RangeForStmt` / `StructForStmt` / `MeshForStmt` / `WhileStmt` body (the four overrides go through a shared `walk_nested_loop_body` helper) so loads / stores inside nested loops are excluded - the AD pass's IB analysis handles cross-iter through global fields correctly when the cross-iter range is AST-nested under another loop, and the adstack handles cross-iter through local allocas.

After the walk, for each `(snode, store, load)` triple where the SNode is `has_adjoint()`:

- skip if the **store** index does not transitively reference a `LoopIndexStmt` (the store writes the same slot every iteration; nothing iterates),
- skip if the **load** index does not transitively reference a `LoopIndexStmt` (the load reads from a disjoint iteration slice the loop never writes to),
- otherwise compare the indices per-axis via `indices_have_no_cross_iter_dependency`:
  - axes where neither index references `LoopIndexStmt` are iter-independent and ignored regardless of value (allows sibling-component access on a constant axis like `out[i, 0]` vs `out[i, 1]`),
  - axes where both indices reference `LoopIndexStmt` must be the same SSA `Stmt*` (allows in-place `out[i] = out[i] + x`; flags `out[i] = out[i-1] + x` because the load axis is `BinaryOpStmt(LoopIndexStmt, Sub, ConstStmt)` and the store axis is the bare `LoopIndexStmt`),
  - axes where exactly one references `LoopIndexStmt` are conservatively flagged (one iter-dependent, one constant on the same axis - cannot prove statically whether the constant aliases an iteration).

`StructFor` offloads are out of scope for `run` - their loop variable is an SNode index produced by the runtime, not a user-controlled integer arithmeticed against itself, so the `out[i-1]` shape this guard targets does not arise.

## Tests

### Existing test patches

- `tests/python/test_adstack.py::test_adstack_basic_gradient_negative` - new `wrap_inner_in_func` parametrization axis pins the @qd.func-bypass class. The `pytest.raises` accepts both `qd.QuadrantsCompilationError` (from the upstream AST guard) and `RuntimeError` (from `QD_ERROR` via `auto_diff.cpp`) since either may surface depending on the shape.

### New tests in `tests/python/test_adstack.py`

A single `_run_reverse_global_cross_iter(has_outer_for, in_func, load_kind, expect_raise)` factory using the `range(1) if qd.static(has_outer_for) else qd.static(range(1))` inline-if pattern (already used by `_run_unary_loop_carried` in this file) covers eight reverse-mode shapes that read and write the same `needs_grad` global field from inside a non-static range:

| `has_outer_for` | `in_func` | `load_kind`                   | Shape                                                                            |
| --------------- | --------- | ----------------------------- | -------------------------------------------------------------------------------- |
| `False`         | `False`   | `cross_iter`                  | non-static range at the kernel top; cross-iter inline                            |
| `False`         | `True`    | `cross_iter`                  | non-static range at the top of a `@qd.func` body called from kernel              |
| `True`          | `False`   | `cross_iter`                  | non-static range nested under outer `range(1)`; cross-iter inline                |
| `True`          | `True`    | `cross_iter`                  | non-static range nested under outer `range(1)`; cross-iter via `@qd.func`        |
| `False`         | `False`   | `constant_outside_iter_range` | kernel-top range; load reads `out[n]` (slot strictly outside the iteration range)|
| `False`         | `True`    | `constant_outside_iter_range` | as above, body in `@qd.func`                                                     |
| `True`          | `False`   | `constant_outside_iter_range` | nested under outer `range(1)`; load reads `out[n]`                               |
| `True`          | `True`    | `constant_outside_iter_range` | as above, body in `@qd.func`                                                     |

Two parametrized test functions (`_with_adstack` and `_without_adstack`) drive all eight shapes. The `cross_iter` variants pin the offload-level guard's positive cases; the `constant_outside_iter_range` variants pin the `references_loop_index` gate so loads on a disjoint iteration slice do not trigger a false positive (with adstack on, the constant-outside variants compile cleanly across all four `(has_outer_for, in_func)` combinations, regardless of nesting).

A separate `_run_reverse_sibling_component_correct_gradient` factory plus `test_reverse_sibling_component_correct_gradient_with_adstack` (parametrized over the same `(has_outer_for, in_func)` axes) pins the multi-axis sibling-component case: `out[i, 1] = x; out[i, 0] = out[i, 1] * 2` where the per-axis rule must allow the differing constant on axis 1.

Three sanity tests pin behavior the new checker must not break:

- `test_reverse_kernel_top_indep_iters_{with,without}_adstack` - kernel-top range with no cross-iter RAW on any `needs_grad` field; gradient must be analytical in both adstack settings.
- `test_reverse_kernel_top_in_place_accum_with_adstack` - `out[i] = out[i] + x[None]`; store and load on `out` reference the same `LoopIndexStmt` so the per-axis rule treats the indices as matching.

## Side-effect audit

| Concern                                                            | Where checked                                                                | Verdict                                                                       |
| ------------------------------------------------------------------ | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| `qd.ndrange` / `qd.grouped` / mesh-for nested cases                | the upstream AST guard at `ASTTransformer.build_For` only fires on `node.iter.func.id == "range"`, never on the other lowering paths, and the new IR-level checker does not regress this | Existing behavior preserved                                                  |
| `AdStackAllocaJudger` semantics                                    | not touched                                                                  | Existing behavior unchanged; only invoked from `ReplaceLocalVarWithStacks` as before |
| Adstack-on path                                                    | `OffloadLevelGlobalCrossIterRAWChecker` runs before `RegulateTensorTypedStatements` and the IB / adstack flow is unchanged | No new check on the adstack-on path's per-iteration adjoint emission         |
| Independent-iteration kernel-top range-fors                        | `OffloadLevelGlobalCrossIterRAWChecker` only fires on same-SNode `(store, load)` pairs that BOTH transitively reference `LoopIndexStmt` and differ structurally per axis | `out[i] = x[None] * 2` (no load on `out`) compiles unchanged in both settings |
| In-place accumulation `out[i] = out[i] + x`                        | per-axis rule: store and load reference the same `LoopIndexStmt` on every axis | Compiles unchanged; pinned by `test_reverse_kernel_top_in_place_accum_with_adstack` |
| Multi-axis sibling-component access `out[i, 0] = out[i, 1] * 2`    | per-axis rule: axes where neither index references `LoopIndexStmt` are ignored | Compiles unchanged; pinned by `test_reverse_sibling_component_correct_gradient_with_adstack` |
| Loads on disjoint iteration slices `out[i] = out[external_const]`  | the load index does not reference `LoopIndexStmt` and is skipped              | Compiles unchanged; pinned by the `load_kind=constant_outside_iter_range` variants |
| Forward-mode AD                                                    | both fixes gated on `autodiff_mode == kReverse`                              | No effect                                                                     |
| Non-AD kernels                                                     | both fixes gated on `autodiff_mode == kReverse`                              | No effect                                                                     |
| Nested mesh-for / while bodies                                     | `walk_nested_loop_body` overrides cover `MeshForStmt` and `WhileStmt` so loads / stores inside them are excluded from the offload-level pairing | Symmetric with `RangeForStmt` / `StructForStmt`                              |