### PR TITLE
[SPIR-V] Shrink reverse-grad kernel MSL by ~50%

### DIFF
--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -102,7 +102,7 @@ Per-backend support:
 |---------|------------------|
 | CPU | yes |
 | CUDA | yes |
-| AMDGPU | no (compile error) |
+| AMDGPU | no (silently dropped) |
 | Metal | no (silently dropped) |
 | Vulkan | yes (via debug-printf SPIR-V extension) |
 

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -36,11 +36,9 @@ x[3] = 10.0   # AssertionError in debug mode, silent corruption otherwise
 a = x[-1]     # AssertionError in debug mode
 ```
 
-The same flag also enables a deferred runtime check on the adstack used by reverse-mode autodiff: a push past the per-stack capacity (set via `qd.init(ad_stack_size=...)` or per-alloca by `determine_ad_stack_size`) raises `RuntimeError("[Aa]dstack overflow")` on the next `qd.sync()`. Without bounds-checking, an adstack overflow silently writes past the per-thread slab and produces a wrong gradient.
+### Adstack overflow check
 
-`debug=True` is a superset of `check_out_of_bound=True`. Setting `qd.init(check_out_of_bound=True)` without `debug=True` enables the field bounds check and the adstack overflow check, but skips kernel `assert` evaluation, integer overflow detection on arithmetic, and the other checks listed below. Use this when you want bounds-safety in a release-build app without paying the full debug-mode cost.
-
-On the Metal and Vulkan backends, `check_out_of_bound=True` is silently disabled at `qd.init` time because those backends lack the in-kernel assertion extension that the field bounds check relies on; passing it on its own gives you neither the field bounds check nor the adstack overflow check. Pass `debug=True` instead: that keeps the adstack overflow check live (it is gated independently and does not need the assertion extension), but the field bounds check still does not fire on these backends.
+`debug=True` also enables a deferred runtime check on the adstack used by reverse-mode autodiff. A push past the per-stack capacity (set via `qd.init(ad_stack_size=...)` or per-alloca by `determine_ad_stack_size`) raises `RuntimeError("[Aa]dstack overflow")` on the next `qd.sync()`. Without the check, an adstack overflow silently writes past the per-thread slab and produces a wrong gradient.
 
 ### Assertions in kernels
 
@@ -66,6 +64,8 @@ Debug mode adds runtime checks to every field access and assertion, which can si
 A typical workflow:
 1. Develop with `debug=True` to catch bounds errors and logic bugs
 2. Switch to `debug=False` (the default) for benchmarking and production runs
+
+For bounds safety in a release build without the rest of debug mode, set [`check_out_of_bound=True`](./init_options.md#check_out_of_bound) instead. `debug=True` always implies `check_out_of_bound=True`.
 
 ## Other debugging tools
 

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -36,6 +36,10 @@ x[3] = 10.0   # AssertionError in debug mode, silent corruption otherwise
 a = x[-1]     # AssertionError in debug mode
 ```
 
+The same flag also enables a deferred runtime check on the adstack used by reverse-mode autodiff: a push past the per-stack capacity (set via `qd.init(ad_stack_size=...)` or per-alloca by `determine_ad_stack_size`) raises `RuntimeError("[Aa]dstack overflow")` on the next `qd.sync()`. Without bounds-checking, an adstack overflow silently writes past the per-thread slab and produces a wrong gradient.
+
+`debug=True` is a superset of `check_out_of_bound=True`. Setting `qd.init(check_out_of_bound=True)` without `debug=True` enables the field bounds check and the adstack overflow check, but skips kernel `assert` evaluation, integer overflow detection on arithmetic, and the other checks listed below. Use this when you want bounds-safety in a release-build app without paying the full debug-mode cost.
+
 ### Assertions in kernels
 
 The `assert` statement works inside kernels when debug mode is enabled:

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -106,9 +106,9 @@ Per-backend support:
 | Metal | no (silently dropped) |
 | Vulkan | yes (via debug-printf SPIR-V extension) |
 
-Output from GPU kernels may appear out of order due to parallel execution.
+**Note.** Output from GPU kernels may appear out of order due to parallel execution.
 
-Important: remove kernel `print()` calls before benchmarking. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears at the right place in the log; this synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow makes the `print()` unreachable. The cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
+**Important.** Remove kernel `print()` calls before benchmarking. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears at the right place in the log. The synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow makes the `print()` unreachable; the cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
 
 ### Dumping compiled IR
 

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -108,7 +108,7 @@ Per-backend support:
 
 **Note.** Output from GPU kernels may appear out of order due to parallel execution.
 
-**Important.** Avoid kernel `print()` calls in production code if possible. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears at the right place in the log. The synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow leaves the `print()` unreached at runtime; the cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
+**Important.** Avoid kernel `print()` calls in production code if possible. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears as close as possible to the call site. The synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow leaves the `print()` unreached at runtime; the cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
 
 ### Dumping compiled IR
 

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -108,7 +108,7 @@ Per-backend support:
 
 **Note.** Output from GPU kernels may appear out of order due to parallel execution.
 
-**Important.** Avoid kernel `print()` calls in production code. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears at the right place in the log. The synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow leaves the `print()` unreached at runtime; the cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
+**Important.** Avoid kernel `print()` calls in production code if possible. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears at the right place in the log. The synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow leaves the `print()` unreached at runtime; the cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
 
 ### Dumping compiled IR
 

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -106,8 +106,6 @@ Per-backend support:
 | Metal | no (silently dropped) |
 | Vulkan | yes (via debug-printf SPIR-V extension) |
 
-**Note.** Output from GPU kernels may appear out of order due to parallel execution.
-
 **Important.** Avoid kernel `print()` calls in production code where you can. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears as close as possible to the call site. The synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow leaves the `print()` unreached at runtime; the cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
 
 ### Dumping compiled IR

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -87,7 +87,7 @@ See also [Troubleshooting](./troubleshooting.md).
 
 ### Printing from kernels
 
-`print()` works inside kernels for scalar values, which can be useful for debugging:
+`print()` works inside kernels for scalar values:
 
 ```python
 @qd.kernel
@@ -96,7 +96,19 @@ def debug_kernel(a: qd.Template) -> None:
         print("i =", i, "val =", a[i])
 ```
 
-Note that print output from GPU kernels may appear out of order due to parallel execution.
+Per-backend support:
+
+| Backend | Kernel `print()` |
+|---------|------------------|
+| CPU | yes |
+| CUDA | yes |
+| AMDGPU | no (compile error) |
+| Metal | no (silently dropped) |
+| Vulkan | yes (via debug-printf SPIR-V extension) |
+
+Output from GPU kernels may appear out of order due to parallel execution.
+
+Important: remove kernel `print()` calls before benchmarking. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears at the right place in the log; this synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow makes the `print()` unreachable. The cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
 
 ### Dumping compiled IR
 

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -108,7 +108,7 @@ Per-backend support:
 
 **Note.** Output from GPU kernels may appear out of order due to parallel execution.
 
-**Important.** Avoid kernel `print()` calls in production code. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears at the right place in the log. The synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow makes the `print()` unreachable; the cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
+**Important.** Avoid kernel `print()` calls in production code. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears at the right place in the log. The synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow leaves the `print()` unreached at runtime; the cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
 
 ### Dumping compiled IR
 

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -108,7 +108,7 @@ Per-backend support:
 
 **Note.** Output from GPU kernels may appear out of order due to parallel execution.
 
-**Important.** Avoid kernel `print()` calls in production code if possible. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears as close as possible to the call site. The synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow leaves the `print()` unreached at runtime; the cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
+**Important.** Avoid kernel `print()` calls in production code where you can. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears as close as possible to the call site. The synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow leaves the `print()` unreached at runtime; the cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
 
 ### Dumping compiled IR
 

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -87,7 +87,7 @@ See also [Troubleshooting](./troubleshooting.md).
 
 ### Printing from kernels
 
-`print()` works inside kernels for scalar values:
+`print()` works inside kernels for scalar values, which can be useful for debugging:
 
 ```python
 @qd.kernel

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -36,9 +36,9 @@ x[3] = 10.0   # AssertionError in debug mode, silent corruption otherwise
 a = x[-1]     # AssertionError in debug mode
 ```
 
-### Adstack overflow check
+#### Adstack overflow
 
-`debug=True` also enables a deferred runtime check on the adstack used by reverse-mode autodiff. A push past the per-stack capacity (set via `qd.init(ad_stack_size=...)` or per-alloca by `determine_ad_stack_size`) raises `RuntimeError("[Aa]dstack overflow")` on the next `qd.sync()`. Without the check, an adstack overflow silently writes past the per-thread slab and produces a wrong gradient.
+`debug=True` also enables a deferred bounds check on the adstack used by reverse-mode autodiff. A push past the per-stack capacity (set via `qd.init(ad_stack_size=...)` or per-alloca by `determine_ad_stack_size`) raises `RuntimeError("[Aa]dstack overflow")` on the next `qd.sync()`. Without the check, an adstack overflow silently writes past the per-thread slab and produces a wrong gradient.
 
 ### Assertions in kernels
 

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -65,7 +65,7 @@ A typical workflow:
 1. Develop with `debug=True` to catch bounds errors and logic bugs
 2. Switch to `debug=False` (the default) for benchmarking and production runs
 
-For bounds safety in a release build without the rest of debug mode, set [`check_out_of_bound=True`](./init_options.md#check_out_of_bound) instead. `debug=True` always implies `check_out_of_bound=True`.
+`debug=True` always implies `check_out_of_bound=True`. For bounds safety in a release build without the rest of debug mode, set [`check_out_of_bound=True`](./init_options.md#check_out_of_bound) instead.
 
 ## Other debugging tools
 

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -40,6 +40,8 @@ The same flag also enables a deferred runtime check on the adstack used by rever
 
 `debug=True` is a superset of `check_out_of_bound=True`. Setting `qd.init(check_out_of_bound=True)` without `debug=True` enables the field bounds check and the adstack overflow check, but skips kernel `assert` evaluation, integer overflow detection on arithmetic, and the other checks listed below. Use this when you want bounds-safety in a release-build app without paying the full debug-mode cost.
 
+On the Metal and Vulkan backends, `check_out_of_bound=True` is silently disabled at `qd.init` time because those backends lack the in-kernel assertion extension that the field bounds check relies on; passing it on its own gives you neither the field bounds check nor the adstack overflow check. Pass `debug=True` instead: that keeps the adstack overflow check live (it is gated independently and does not need the assertion extension), but the field bounds check still does not fire on these backends.
+
 ### Assertions in kernels
 
 The `assert` statement works inside kernels when debug mode is enabled:

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -106,6 +106,8 @@ Per-backend support:
 | Metal | no (silently dropped) |
 | Vulkan | yes (via debug-printf SPIR-V extension) |
 
+**Note.** Output from GPU kernels appears in order despite parallel execution because all kernels are queued in the same compute stream.
+
 **Important.** Avoid kernel `print()` calls in production code where you can. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears as close as possible to the call site. The synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow leaves the `print()` unreached at runtime; the cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
 
 ### Dumping compiled IR

--- a/docs/source/user_guide/debug.md
+++ b/docs/source/user_guide/debug.md
@@ -108,7 +108,7 @@ Per-backend support:
 
 **Note.** Output from GPU kernels may appear out of order due to parallel execution.
 
-**Important.** Remove kernel `print()` calls before benchmarking. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears at the right place in the log. The synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow makes the `print()` unreachable; the cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
+**Important.** Avoid kernel `print()` calls in production code. Quadrants synchronizes the compute queue after every dispatch of a kernel that contains a `print()` so the output appears at the right place in the log. The synchronization happens unconditionally on every launch of that kernel, even when the surrounding control flow makes the `print()` unreachable; the cost is the full per-launch sync overhead, not just the cost of the `print()` itself.
 
 ### Dumping compiled IR
 

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -58,37 +58,33 @@ Enables:
 - integer-overflow guards on arithmetic;
 - IR verification after every compiler pass.
 
-**Cost.** Significant on both compile time (verifier walks the IR after every transform; extra runtime checks expand the emitted code; ~21s extra observed on adstack-heavy kernels) and runtime. For just bounds + adstack safety in a release build without the rest, use [`check_out_of_bound`](#check_out_of_bound) below.
+**Cost.** Significant on both compile time (verifier walks the IR after every transform; extra runtime checks expand the emitted code; ~21s extra observed on adstack-heavy kernels) and runtime. For just the field-bounds check in a release build without the rest, use [`check_out_of_bound`](#check_out_of_bound) below.
 
 ### `check_out_of_bound`
 
-Default `False`. Narrower than `debug`: turns on bounds-related checks only, without the rest.
+Default `False`. Enables the field-bounds check on tensor indexing - an out-of-range index raises `RuntimeError`.
 
-Enables:
-- field-bounds check on tensor indexing (out-of-range index raises `RuntimeError`);
-- adstack-overflow check on reverse-mode autodiff (a push past the per-stack capacity raises `RuntimeError("[Aa]dstack overflow")` on the next `qd.sync()`).
-
-**Cost.** Scales with how often kernels index into tensors and push onto the adstack. Cheaper than `debug=True`. Still leave off for benchmarks.
+**Cost.** Scales with how often kernels index into tensors. Cheaper than `debug=True`. Still leave off for benchmarks.
 
 Interaction with `debug`:
 
 | Flags | Field bounds | Adstack overflow | Other `debug` checks |
 |-------|--------------|------------------|----------------------|
 | neither | off | off | off |
-| `check_out_of_bound=True` only | on | on | off |
+| `check_out_of_bound=True` only | on | off | off |
 | `debug=True` | on | on | on |
 
-- `debug=True` always implies `check_out_of_bound=True`. They cannot be split: `debug=True, check_out_of_bound=False` collapses to `debug=True` at init.
-- Use `check_out_of_bound=True` on its own when you want bounds + adstack safety in a release build without paying for everything else `debug` adds.
+- `debug=True` always implies `check_out_of_bound=True` (the field-bounds check fires whenever debug mode is on).
+- The adstack-overflow check on reverse-mode autodiff (a push past the per-stack capacity raises `RuntimeError("[Aa]dstack overflow")` on the next `qd.sync()`) is on its own gate, controlled by `debug` - it is not enabled by `check_out_of_bound` alone.
 
 Per-backend support:
 
 | Backend | Field bounds check | Adstack overflow check |
 |---------|--------------------|------------------------|
-| CPU | with `check_out_of_bound=True` or `debug=True` | with `check_out_of_bound=True` or `debug=True` |
-| CUDA | with `check_out_of_bound=True` or `debug=True` | with `check_out_of_bound=True` or `debug=True` |
-| AMDGPU | with `check_out_of_bound=True` or `debug=True` | with `check_out_of_bound=True` or `debug=True` |
-| Metal | never (no in-kernel assertion mechanism) | with `debug=True` only |
-| Vulkan | never (no in-kernel assertion mechanism) | with `debug=True` only |
+| CPU | with `check_out_of_bound=True` or `debug=True` | with `debug=True` |
+| CUDA | with `check_out_of_bound=True` or `debug=True` | with `debug=True` |
+| AMDGPU | with `check_out_of_bound=True` or `debug=True` | with `debug=True` |
+| Metal | never (no in-kernel assertion mechanism) | with `debug=True` |
+| Vulkan | never (no in-kernel assertion mechanism) | with `debug=True` |
 
-The adstack overflow check is gated independently of the assertion mechanism, so `debug=True` activates it on every backend - including Metal and Vulkan, where the field bounds check stays unavailable. On Metal and Vulkan, `check_out_of_bound` is silently reset to `False` at `qd.init` time (a warning is logged); passing it on its own gives neither check on those backends.
+Metal and Vulkan lack the assertion extension that the field-bounds check relies on; `check_out_of_bound=True` is silently reset to `False` on those backends at `qd.init` time and a warning is logged. The adstack-overflow check is gated independently of the assertion extension, so `debug=True` activates it on every backend including Metal and Vulkan.

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -58,7 +58,7 @@ Enables:
 - integer-overflow guards on arithmetic;
 - IR verification after every compiler pass.
 
-Cost: significant on both compile time (verifier walks the IR after every transform; extra runtime checks expand the emitted code; ~21s extra observed on adstack-heavy kernels) and runtime. For just bounds + adstack safety in a release build without the rest, use [`check_out_of_bound`](#check_out_of_bound) below.
+**Cost.** Significant on both compile time (verifier walks the IR after every transform; extra runtime checks expand the emitted code; ~21s extra observed on adstack-heavy kernels) and runtime. For just bounds + adstack safety in a release build without the rest, use [`check_out_of_bound`](#check_out_of_bound) below.
 
 ### `check_out_of_bound`
 
@@ -68,7 +68,7 @@ Enables:
 - field-bounds check on tensor indexing (out-of-range index raises `RuntimeError`);
 - adstack-overflow check on reverse-mode autodiff (a push past the per-stack capacity raises `RuntimeError("[Aa]dstack overflow")` on the next `qd.sync()`).
 
-Cost: scales with how often kernels index into tensors and push onto the adstack. Cheaper than `debug=True`. Still leave off for benchmarks.
+**Cost.** Scales with how often kernels index into tensors and push onto the adstack. Cheaper than `debug=True`. Still leave off for benchmarks.
 
 Interaction with `debug`:
 

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -45,6 +45,8 @@ Number of host threads used when compiling kernels. Default `4`. Raise on machin
 
 ## Debugging
 
+See [Debug mode](./debug.md) for runnable examples and a typical develop / benchmark workflow.
+
 ### `debug`
 
 Default `False`. Turns on every available correctness check. Use while iterating on a kernel that produces wrong numerics or while developing a new compiler pass; turn off for benchmarks and production.

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -47,8 +47,39 @@ Number of host threads used when compiling kernels. Default `4`. Raise on machin
 
 ### `debug`
 
-Enables IR verification between every compiler pass plus additional runtime checks (integer-overflow guards on arithmetic, linear-index overflow guards on tensor indexing, adstack push-bounds at the runtime helper level). Default `False`. Compile time slows substantially because the verifier walks the IR after every transform and the extra runtime checks expand the emitted code; ~21s additional has been observed on adstack-heavy kernels. Turn this on while iterating on a kernel that is producing incorrect numerics or while developing a new compiler pass; turn it back off once the bug is found.
+Default `False`. Turns on every available correctness check. Use while iterating on a kernel that produces wrong numerics or while developing a new compiler pass; turn off for benchmarks and production.
+
+Enables:
+- field-bounds check on tensor indexing (out-of-range index raises `RuntimeError`);
+- adstack-overflow check on reverse-mode autodiff (overflow raises `RuntimeError` on the next `qd.sync()`);
+- kernel `assert` statements;
+- integer-overflow guards on arithmetic;
+- IR verification after every compiler pass.
+
+Cost: significant on both compile time (verifier walks the IR after every transform; extra runtime checks expand the emitted code; ~21s extra observed on adstack-heavy kernels) and runtime. For just bounds + adstack safety in a release build without the rest, use [`check_out_of_bound`](#check_out_of_bound) below.
 
 ### `check_out_of_bound`
 
-Enables runtime bounds-checking for tensor indexing. Default `False`. Costs runtime performance proportional to indexing density; leave off for benchmarks. Backends that do not expose the `assertion` extension (currently Metal and Vulkan) cannot honor this flag.
+Default `False`. Narrower than `debug`: turns on bounds-related checks only, without the rest.
+
+Enables:
+- field-bounds check on tensor indexing (out-of-range index raises `RuntimeError`);
+- adstack-overflow check on reverse-mode autodiff (a push past the per-stack capacity raises `RuntimeError("[Aa]dstack overflow")` on the next `qd.sync()`).
+
+Cost: scales with how often kernels index into tensors and push onto the adstack. Cheaper than `debug=True`. Still leave off for benchmarks.
+
+Interaction with `debug`:
+
+| Flags | Field bounds | Adstack overflow | Other `debug` checks |
+|-------|--------------|------------------|----------------------|
+| neither | off | off | off |
+| `check_out_of_bound=True` only | on | on | off |
+| `debug=True` | on | on | on |
+
+- `debug=True` always implies `check_out_of_bound=True`. They cannot be split: `debug=True, check_out_of_bound=False` collapses to `debug=True` at init.
+- Use `check_out_of_bound=True` on its own when you want bounds + adstack safety in a release build without paying for everything else `debug` adds.
+
+Metal and Vulkan caveat (the field bounds check needs an in-kernel assertion mechanism Metal/Vulkan don't have):
+- `check_out_of_bound` is silently reset to `False` on those backends at `qd.init` time (a warning is logged).
+- `qd.init(check_out_of_bound=True)` on its own -> neither check fires.
+- `qd.init(debug=True)` -> adstack overflow check still fires; field bounds check does not.

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -81,7 +81,14 @@ Interaction with `debug`:
 - `debug=True` always implies `check_out_of_bound=True`. They cannot be split: `debug=True, check_out_of_bound=False` collapses to `debug=True` at init.
 - Use `check_out_of_bound=True` on its own when you want bounds + adstack safety in a release build without paying for everything else `debug` adds.
 
-Metal and Vulkan caveat (the field bounds check needs an in-kernel assertion mechanism Metal/Vulkan don't have):
-- `check_out_of_bound` is silently reset to `False` on those backends at `qd.init` time (a warning is logged).
-- `qd.init(check_out_of_bound=True)` on its own -> neither check fires.
-- `qd.init(debug=True)` -> adstack overflow check still fires; field bounds check does not.
+Per-backend support:
+
+| Backend | Field bounds check | Adstack overflow check |
+|---------|--------------------|------------------------|
+| CPU | with `check_out_of_bound=True` or `debug=True` | with `check_out_of_bound=True` or `debug=True` |
+| CUDA | with `check_out_of_bound=True` or `debug=True` | with `check_out_of_bound=True` or `debug=True` |
+| AMDGPU | with `check_out_of_bound=True` or `debug=True` | with `check_out_of_bound=True` or `debug=True` |
+| Metal | never (no in-kernel assertion mechanism) | with `debug=True` only |
+| Vulkan | never (no in-kernel assertion mechanism) | with `debug=True` only |
+
+The adstack overflow check is gated independently of the assertion mechanism, so `debug=True` activates it on every backend - including Metal and Vulkan, where the field bounds check stays unavailable. On Metal and Vulkan, `check_out_of_bound` is silently reset to `False` at `qd.init` time (a warning is logged); passing it on its own gives neither check on those backends.

--- a/quadrants/codegen/llvm/codegen_llvm.cpp
+++ b/quadrants/codegen/llvm/codegen_llvm.cpp
@@ -2324,7 +2324,7 @@ void TaskCodeGenLLVM::visit(AdStackAllocaStmt *stmt) {
   llvm::Value *total_offset = builder->CreateAdd(slice_offset, offset);
   llvm::Value *stack_ptr = builder->CreateGEP(i8ty, ad_stack_heap_base_llvm_, total_offset);
   llvm_val[stmt] = stack_ptr;
-  if (compile_config.debug) {
+  if (compile_config.check_out_of_bound) {
     call("stack_init", llvm_val[stmt]);
     return;
   }
@@ -2337,14 +2337,14 @@ void TaskCodeGenLLVM::visit(AdStackAllocaStmt *stmt) {
   }
   // Release build, multi-slot: store 0 into the per-stack count alloca instead of zeroing the heap u64 header.
   // Doing this at the AdStackAllocaStmt visit site (rather than once at task entry) restarts the count whenever
-  // an outer loop re-enters the alloca, matching `stack_init`'s semantics on the debug path.
+  // an outer loop re-enters the alloca, matching `stack_init`'s semantics on the bounds-checked path.
   auto *i64ty_init = llvm::Type::getInt64Ty(*llvm_context);
   llvm::Value *count_alloca = ensure_ad_stack_count_alloca_llvm(stmt);
   builder->CreateStore(llvm::ConstantInt::get(i64ty_init, 0), count_alloca);
 }
 
 void TaskCodeGenLLVM::visit(AdStackPopStmt *stmt) {
-  if (compile_config.debug) {
+  if (compile_config.check_out_of_bound) {
     call("stack_pop", llvm_val[stmt->stack]);
     return;
   }
@@ -2367,9 +2367,9 @@ void TaskCodeGenLLVM::visit(AdStackPopStmt *stmt) {
 
 void TaskCodeGenLLVM::visit(AdStackPushStmt *stmt) {
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  if (compile_config.debug) {
-    // Debug build: route through the bounds-checking helper so any sizer bug surfaces as an overflow flag at sync.
-    // The `max_size` load is only needed on this path.
+  if (compile_config.check_out_of_bound) {
+    // `check_out_of_bound` build: route through the bounds-checking helper so any sizer bug surfaces as an
+    // overflow flag at sync. The `max_size` load is only needed on this path.
     ensure_ad_stack_metadata_llvm();
     auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
     llvm::Value *stack_id_i64 = llvm::ConstantInt::get(i64ty, static_cast<uint64_t>(stack->stack_id));
@@ -2424,7 +2424,7 @@ void TaskCodeGenLLVM::visit(AdStackPushStmt *stmt) {
 void TaskCodeGenLLVM::visit(AdStackLoadTopStmt *stmt) {
   QD_ASSERT(stmt->return_ptr == false);
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  if (compile_config.debug) {
+  if (compile_config.check_out_of_bound) {
     auto primal_ptr = call("stack_top_primal", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
     auto primal_ty = tlctx->get_data_type(stmt->ret_type);
     primal_ptr = builder->CreateBitCast(primal_ptr, llvm::PointerType::get(primal_ty, 0));
@@ -2447,7 +2447,7 @@ void TaskCodeGenLLVM::visit(AdStackLoadTopStmt *stmt) {
 
 void TaskCodeGenLLVM::visit(AdStackLoadTopAdjStmt *stmt) {
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  if (compile_config.debug) {
+  if (compile_config.check_out_of_bound) {
     auto adjoint = call("stack_top_adjoint", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
     auto adjoint_ty = tlctx->get_data_type(stmt->ret_type);
     adjoint = builder->CreateBitCast(adjoint, llvm::PointerType::get(adjoint_ty, 0));
@@ -2471,7 +2471,7 @@ void TaskCodeGenLLVM::visit(AdStackLoadTopAdjStmt *stmt) {
 void TaskCodeGenLLVM::visit(AdStackAccAdjointStmt *stmt) {
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
   llvm::Value *adjoint_ptr;
-  if (compile_config.debug) {
+  if (compile_config.check_out_of_bound) {
     adjoint_ptr = call("stack_top_adjoint", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
   } else if (is_compile_time_single_slot(stack)) {
     adjoint_ptr = emit_ad_stack_single_slot_ptr(stack, /*adjoint_offset_bytes=*/stack->element_size_in_bytes());

--- a/quadrants/codegen/llvm/codegen_llvm.cpp
+++ b/quadrants/codegen/llvm/codegen_llvm.cpp
@@ -2324,7 +2324,7 @@ void TaskCodeGenLLVM::visit(AdStackAllocaStmt *stmt) {
   llvm::Value *total_offset = builder->CreateAdd(slice_offset, offset);
   llvm::Value *stack_ptr = builder->CreateGEP(i8ty, ad_stack_heap_base_llvm_, total_offset);
   llvm_val[stmt] = stack_ptr;
-  if (compile_config.check_out_of_bound) {
+  if (compile_config.debug) {
     call("stack_init", llvm_val[stmt]);
     return;
   }
@@ -2344,7 +2344,7 @@ void TaskCodeGenLLVM::visit(AdStackAllocaStmt *stmt) {
 }
 
 void TaskCodeGenLLVM::visit(AdStackPopStmt *stmt) {
-  if (compile_config.check_out_of_bound) {
+  if (compile_config.debug) {
     call("stack_pop", llvm_val[stmt->stack]);
     return;
   }
@@ -2367,9 +2367,9 @@ void TaskCodeGenLLVM::visit(AdStackPopStmt *stmt) {
 
 void TaskCodeGenLLVM::visit(AdStackPushStmt *stmt) {
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  if (compile_config.check_out_of_bound) {
-    // `check_out_of_bound` build: route through the bounds-checking helper so any sizer bug surfaces as an
-    // overflow flag at sync. The `max_size` load is only needed on this path.
+  if (compile_config.debug) {
+    // Debug build: route through the bounds-checking helper so any sizer bug surfaces as an overflow flag at sync.
+    // The `max_size` load is only needed on this path.
     ensure_ad_stack_metadata_llvm();
     auto *i64ty = llvm::Type::getInt64Ty(*llvm_context);
     llvm::Value *stack_id_i64 = llvm::ConstantInt::get(i64ty, static_cast<uint64_t>(stack->stack_id));
@@ -2424,7 +2424,7 @@ void TaskCodeGenLLVM::visit(AdStackPushStmt *stmt) {
 void TaskCodeGenLLVM::visit(AdStackLoadTopStmt *stmt) {
   QD_ASSERT(stmt->return_ptr == false);
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  if (compile_config.check_out_of_bound) {
+  if (compile_config.debug) {
     auto primal_ptr = call("stack_top_primal", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
     auto primal_ty = tlctx->get_data_type(stmt->ret_type);
     primal_ptr = builder->CreateBitCast(primal_ptr, llvm::PointerType::get(primal_ty, 0));
@@ -2447,7 +2447,7 @@ void TaskCodeGenLLVM::visit(AdStackLoadTopStmt *stmt) {
 
 void TaskCodeGenLLVM::visit(AdStackLoadTopAdjStmt *stmt) {
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
-  if (compile_config.check_out_of_bound) {
+  if (compile_config.debug) {
     auto adjoint = call("stack_top_adjoint", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
     auto adjoint_ty = tlctx->get_data_type(stmt->ret_type);
     adjoint = builder->CreateBitCast(adjoint, llvm::PointerType::get(adjoint_ty, 0));
@@ -2471,7 +2471,7 @@ void TaskCodeGenLLVM::visit(AdStackLoadTopAdjStmt *stmt) {
 void TaskCodeGenLLVM::visit(AdStackAccAdjointStmt *stmt) {
   auto stack = stmt->stack->as<AdStackAllocaStmt>();
   llvm::Value *adjoint_ptr;
-  if (compile_config.check_out_of_bound) {
+  if (compile_config.debug) {
     adjoint_ptr = call("stack_top_adjoint", llvm_val[stack], tlctx->get_constant(stack->element_size_in_bytes()));
   } else if (is_compile_time_single_slot(stack)) {
     adjoint_ptr = emit_ad_stack_single_slot_ptr(stack, /*adjoint_offset_bytes=*/stack->element_size_in_bytes());

--- a/quadrants/codegen/spirv/detail/spirv_codegen.h
+++ b/quadrants/codegen/spirv/detail/spirv_codegen.h
@@ -20,6 +20,7 @@
 #include <unordered_set>
 
 namespace quadrants::lang {
+struct CompileConfig;
 namespace spirv {
 namespace detail {
 
@@ -37,6 +38,7 @@ class TaskCodegen : public IRVisitor {
     const KernelContextAttributes *ctx_attribs;
     std::string ti_kernel_name;
     int task_id_in_kernel;
+    const CompileConfig *compile_config{nullptr};
   };
 
   const bool use_64bit_pointers = false;
@@ -141,6 +143,7 @@ class TaskCodegen : public IRVisitor {
 
   Arch arch_;
   DeviceCapabilityConfig *caps_;
+  const CompileConfig *compile_config_;
 
   struct BufferInfoTypeTupleHasher {
     std::size_t operator()(const std::pair<BufferInfo, int> &buf) const {
@@ -246,6 +249,19 @@ class TaskCodegen : public IRVisitor {
   // path with no symbolic bound captured reproduces the pre-PR shader layout.
   uint32_t ad_stack_heap_per_thread_stride_float_{0};
   uint32_t ad_stack_heap_per_thread_stride_int_{0};
+  // Total number of `AdStackAllocaStmt` the body will visit, pre-computed by the same scan that builds the heap
+  // strides. Used to size a single shared Function-scope `uint[num_ad_stacks_]` count array (see
+  // `ensure_ad_stack_count_array_var`) so that all per-stack `count` values share one OpVariable accessed via
+  // OpAccessChain. The shared array prevents spirv-opt's `LocalMultiStoreElim` / `SSARewrite` from promoting each
+  // count to a separate phi at every enclosing loop header - reverse-grad kernels that allocate hundreds of
+  // adstacks across enclosing loops would otherwise grow phi mega-clusters of hundreds of entries per loop
+  // header, which spirv-cross emits as one `uint _N;` forward-decl and one `_N = _N;` alias copy per phi per
+  // predecessor branch in the cross-compiled MSL.
+  uint32_t num_ad_stacks_{0};
+  // Single Function-scope `uint[num_ad_stacks_]` array, allocated lazily on first `ad_stack_count_ptr` call.
+  // `info.count_var` for each stack is now an `OpAccessChain` pointer into element `stack_id` of this array
+  // rather than its own `OpVariable Function`.
+  spirv::Value ad_stack_count_array_var_;
   // Running offsets into the per-thread slice assigned to the next AdStackAllocaStmt visitor. Each ends equal to
   // the corresponding stride once every alloca has been visited; these feed the
   // `offset_in_elems_compile_time` of each alloca's `AdStackSizingAttribs::allocas` entry.
@@ -287,6 +303,10 @@ class TaskCodegen : public IRVisitor {
   // `info.heap_kind`. See comment on the implementation for the bool<->i32 conversion contract.
   spirv::Value ad_stack_slot_ptr(AdStackSpirv &info, spirv::Value idx, bool primal);
   spirv::SType ad_stack_backing_type(const AdStackSpirv &info) const;
+  // OpAccessChain pointer to element `stack_id` of the shared Function-scope count array. Lazily allocates
+  // `ad_stack_count_array_var_` on first call (sized at `num_ad_stacks_` from the pre-pass scan). Returned
+  // pointer feeds `info.count_var` and works with the existing `load_variable` / `store_variable` helpers.
+  spirv::Value ad_stack_count_ptr(uint32_t stack_id);
 };
 }  // namespace detail
 }  // namespace spirv

--- a/quadrants/codegen/spirv/detail/spirv_codegen.h
+++ b/quadrants/codegen/spirv/detail/spirv_codegen.h
@@ -251,7 +251,7 @@ class TaskCodegen : public IRVisitor {
   uint32_t ad_stack_heap_per_thread_stride_int_{0};
   // Total number of `AdStackAllocaStmt` the body will visit, pre-computed by the same scan that builds the heap
   // strides. Used to size a single shared Function-scope `uint[num_ad_stacks_]` count array (see
-  // `ensure_ad_stack_count_array_var`) so that all per-stack `count` values share one OpVariable accessed via
+  // `ad_stack_count_ptr`) so that all per-stack `count` values share one OpVariable accessed via
   // OpAccessChain. The shared array prevents spirv-opt's `LocalMultiStoreElim` / `SSARewrite` from promoting each
   // count to a separate phi at every enclosing loop header - reverse-grad kernels that allocate hundreds of
   // adstacks across enclosing loops would otherwise grow phi mega-clusters of hundreds of entries per loop

--- a/quadrants/codegen/spirv/spirv_codegen.cpp
+++ b/quadrants/codegen/spirv/spirv_codegen.cpp
@@ -2683,22 +2683,19 @@ void TaskCodegen::visit(AdStackPushStmt *stmt) {
   }
   spirv::Value one = ir_->uint_immediate_number(ir_->u32_type(), 1);
 
-  if (compile_config_ && (compile_config_->check_out_of_bound || compile_config_->debug)) {
-    // Debug / `check_out_of_bound` build: map an OOB push to the last valid slot via a `GLSLstd450UMin` clamp, then
-    // issue the primal/adjoint store and an unconditional `OpAtomicUMax(overflow_buffer, signal)` where
-    // `signal = (count >= max_size) ? stack_id + 1 : 0`. The atomic-max with 0 cannot raise the host-visible value, so
-    // the runtime only sees the flag set when an actual overflow happened. Concurrent threads that all witness an
-    // overflow on the same stack publish the same value, so the atomic-max also handles the concurrent-overflow case
-    // deterministically. The clamp + OpSelect formulation collapses what would otherwise be a per-push structured
-    // if-then-else region into straight-line code, which spirv-cross emits as straight-line MSL - critical for
-    // reverse-grad kernels with hundreds of adstacks pushed inside an inner loop, which otherwise blow through
-    // Apple's MSL-compiler-service shader-size threshold on macOS-15 M1 hosts. `max_val` is the runtime-published
-    // AdStackMetadata bound cached on `info.max_size_val` by `ensure_ad_stack_metadata_loaded`, not a compile-time
-    // immediate.
-    // The gate ORs `debug` with `check_out_of_bound` so this codepath stays live on Metal / Vulkan, where
-    // `Program::init` force-disables `check_out_of_bound` because those arches lack `Extension::assertion` (which only
-    // matters for in-kernel `assert()` and the field-bounds check, not for the adstack overflow path which uses an
-    // OpAtomicUMax + host readback that works on every SPIR-V backend).
+  if (compile_config_ && compile_config_->debug) {
+    // Debug build: map an OOB push to the last valid slot via a `GLSLstd450UMin` clamp, issue the primal/adjoint
+    // store, and publish `signal = (count >= max_size) ? stack_id + 1 : 0` to the host-visible AdStackOverflow
+    // buffer via `OpAtomicUMax`. The atomic-max with 0 cannot raise the host-visible value, so the runtime only
+    // sees the flag set on an actual overflow; concurrent threads that all witness the same overflow on the same
+    // stack publish the same value deterministically. The clamp + OpSelect formulation collapses what would
+    // otherwise be a per-push structured if-then-else region into straight-line code, which spirv-cross emits as
+    // straight-line MSL - critical for reverse-grad kernels with hundreds of adstacks pushed inside an inner loop
+    // on Apple's MSL-compiler-service shader-size threshold. `max_val` is the runtime-published AdStackMetadata
+    // bound cached on `info.max_size_val` by `ensure_ad_stack_metadata_loaded`, not a compile-time immediate.
+    // The gate is `debug` (not `check_out_of_bound`) so the field bounds check and the adstack overflow check stay
+    // on independent flags - Metal / Vulkan force-disable `check_out_of_bound` because they lack
+    // `Extension::assertion`, but `debug` reaches this codepath unaffected.
     spirv::Value max_val = info.max_size_val;
     spirv::Value max_minus_one = ir_->sub(max_val, one);
     spirv::Value clamped_idx = ir_->call_glsl450(ir_->u32_type(), GLSLstd450UMin, count, max_minus_one);
@@ -2755,10 +2752,10 @@ void TaskCodegen::visit(AdStackPopStmt *stmt) {
 // be above max_size (because the forward push increments count unconditionally and only signals via
 // OpAtomicUMax in the bounds-checked build), so the clamp keeps the OpAccessChain in-bounds; without it, hostile
 // Vulkan drivers (e.g. Adreno, Mali) TDR on OOB private-memory access before the host-side qd.sync() can raise
-// the deferred adstack-overflow exception. The release build (`check_out_of_bound=false`, no overflow signal
-// emitted) trusts the published `max_size` and skips both the cap subtract and the UMin call, mirroring LLVM's
-// release-build LoadTop emit. `max_size` is a runtime value loaded from AdStackMetadata, so `max_size - 1`
-// becomes an OpISub rather than a compile-time immediate when clamping is requested.
+// the deferred adstack-overflow exception. The release build (`debug=false`, no overflow signal emitted) trusts
+// the published `max_size` and skips both the cap subtract and the UMin call, mirroring LLVM's release-build
+// LoadTop emit. `max_size` is a runtime value loaded from AdStackMetadata, so `max_size - 1` becomes an OpISub
+// rather than a compile-time immediate when clamping is requested.
 static spirv::Value ad_stack_top_index(spirv::IRBuilder *ir,
                                        spirv::Value count,
                                        spirv::Value max_size_val,
@@ -2789,8 +2786,7 @@ void TaskCodegen::visit(AdStackLoadTopStmt *stmt) {
   ensure_ad_stack_metadata_loaded(info);
   spirv::Value count = ir_->load_variable(info.count_var, ir_->u32_type());
   spirv::Value idx =
-      ad_stack_top_index(ir_.get(), count, info.max_size_val,
-                         compile_config_ && (compile_config_->check_out_of_bound || compile_config_->debug));
+      ad_stack_top_index(ir_.get(), count, info.max_size_val, compile_config_ && (compile_config_->debug));
   spirv::Value ptr = ad_stack_slot_ptr(info, idx, /*primal=*/true);
   spirv::SType backing_type = ad_stack_backing_type(info);
   spirv::Value loaded = ir_->load_variable(ptr, backing_type);
@@ -2813,8 +2809,7 @@ void TaskCodegen::visit(AdStackLoadTopAdjStmt *stmt) {
   // unconditionally, so any cast would be a no-op.
   spirv::Value count = ir_->load_variable(info.count_var, ir_->u32_type());
   spirv::Value idx =
-      ad_stack_top_index(ir_.get(), count, info.max_size_val,
-                         compile_config_ && (compile_config_->check_out_of_bound || compile_config_->debug));
+      ad_stack_top_index(ir_.get(), count, info.max_size_val, compile_config_ && (compile_config_->debug));
   spirv::Value ptr = ad_stack_slot_ptr(info, idx, /*primal=*/false);
   spirv::Value loaded = ir_->load_variable(ptr, info.elem_type);
   ir_->register_value(stmt->raw_name(), loaded);
@@ -2828,8 +2823,7 @@ void TaskCodegen::visit(AdStackAccAdjointStmt *stmt) {
   // See the note in `AdStackLoadTopAdjStmt`: no cast is needed because heap_int is excluded by the assert above.
   spirv::Value count = ir_->load_variable(info.count_var, ir_->u32_type());
   spirv::Value idx =
-      ad_stack_top_index(ir_.get(), count, info.max_size_val,
-                         compile_config_ && (compile_config_->check_out_of_bound || compile_config_->debug));
+      ad_stack_top_index(ir_.get(), count, info.max_size_val, compile_config_ && (compile_config_->debug));
   spirv::Value ptr = ad_stack_slot_ptr(info, idx, /*primal=*/false);
   spirv::Value old_val = ir_->load_variable(ptr, info.elem_type);
   spirv::Value incr = ir_->query_value(stmt->v->raw_name());

--- a/quadrants/codegen/spirv/spirv_codegen.cpp
+++ b/quadrants/codegen/spirv/spirv_codegen.cpp
@@ -76,6 +76,7 @@ std::string buffer_instance_name(BufferInfo b) {
 TaskCodegen::TaskCodegen(const Params &params)
     : arch_(params.arch),
       caps_(params.caps),
+      compile_config_(params.compile_config),
       task_ir_(params.task_ir),
       compiled_structs_(params.compiled_structs),
       ctx_attribs_(params.ctx_attribs),
@@ -146,6 +147,7 @@ TaskCodegen::Result TaskCodegen::run() {
       } else if (auto *alloca = dynamic_cast<AdStackAllocaStmt *>(node)) {
         if (alloca->ret_type == PrimitiveType::f32) {
           ad_stack_heap_per_thread_stride_float_ += 2u * uint32_t(alloca->max_size);
+          num_ad_stacks_++;
         } else if (alloca->ret_type == PrimitiveType::i32 || alloca->ret_type == PrimitiveType::u1) {
           // Only primal storage: i32 and u1 adstacks record control-flow state (loop counters and if-branch
           // flags) for the reverse pass to replay, and auto_diff.cpp only emits AdStackAccAdjoint/LoadTopAdj on
@@ -153,6 +155,7 @@ TaskCodegen::Result TaskCodegen::run() {
           // meaningless - docs/source/user_guide/autodiff.md states gradients silently read as zero through
           // integer casts.
           ad_stack_heap_per_thread_stride_int_ += uint32_t(alloca->max_size);
+          num_ad_stacks_++;
         }
       } else if (auto *if_stmt = dynamic_cast<IfStmt *>(node)) {
         if (if_stmt->true_statements)
@@ -2569,8 +2572,6 @@ void TaskCodegen::visit(AdStackAllocaStmt *stmt) {
   info.elem_type = ir_->get_primitive_type(stmt->ret_type);
   info.max_size_compile_time = uint32_t(stmt->max_size);
   info.stack_id = uint32_t(task_attribs_.ad_stack.allocas.size());
-  info.count_var = ir_->alloca_variable(ir_->u32_type());
-  ir_->store_variable(info.count_var, ir_->uint_immediate_number(ir_->u32_type(), 0));
   TaskAttributes::AdStackAllocaAttribs attribs;
   attribs.max_size_compile_time = uint32_t(stmt->max_size);
   // Serialise the per-alloca `SizeExpr` captured by the `determine_ad_stack_size` pre-pass so the host launcher
@@ -2609,13 +2610,18 @@ void TaskCodegen::visit(AdStackAllocaStmt *stmt) {
         "cast to qd.f32 or qd.i32 in the differentiable section.",
         stmt->ret_type.to_string());
   }
-  // Load `(offset_val, max_size_val)` from the AdStackMetadata buffer eagerly at the alloca site so the
-  // OpLoads land in the alloca enclosing block. SPIR-V section 2.16 requires every SSA definition to
-  // dominate all its uses, and push/load-top/acc-adjoint sites can live in sibling blocks (forward loop
-  // body vs. backward loop body) that neither dominates the other. Loading lazily at the first push site
-  // would cache SSA ids defined in the forward body and reuse them from the backward body, which
-  // `spirv-val` rejects and strict drivers (MoltenVK, Adreno) refuse at pipeline creation. Eager emission
-  // mirrors the existing discipline for `get_ad_stack_heap_thread_base_{float,int}()` at the same site.
+  // The count slot OpAccessChain and its zero-init are emitted only after the type check above has accepted the
+  // alloca. Calling `ad_stack_count_ptr` for an unsupported type would trip its `num_ad_stacks_ > 0` assert because
+  // the pre-pass scan only counts the f32 / i32 / u1 cases (matching this same dispatch).
+  info.count_var = ad_stack_count_ptr(info.stack_id);
+  ir_->store_variable(info.count_var, ir_->uint_immediate_number(ir_->u32_type(), 0));
+  // Load `(offset_val, max_size_val)` from the AdStackMetadata buffer eagerly at the alloca site so the OpLoads land
+  // in the alloca enclosing block. SPIR-V section 2.16 requires every SSA definition to dominate all its uses, and
+  // push/load-top/acc-adjoint sites can live in sibling blocks (forward loop body vs. backward loop body) that
+  // neither dominates the other. Loading lazily at the first push site would cache SSA ids defined in the forward
+  // body and reuse them from the backward body, which `spirv-val` rejects and strict drivers (MoltenVK, Adreno)
+  // refuse at pipeline creation. Eager emission mirrors the existing discipline for
+  // `get_ad_stack_heap_thread_base_{float,int}()` at the same site.
   ensure_ad_stack_metadata_loaded(info);
   task_attribs_.ad_stack.allocas.push_back(std::move(attribs));
   ad_stacks_[stmt] = info;
@@ -2628,6 +2634,24 @@ void TaskCodegen::visit(AdStackAllocaStmt *stmt) {
 // slice, `false` selects the adjoint half. The per-alloca `offset` and (for f32 only) `adjoint_offset = offset +
 // max_size` come from the `AdStackMetadata` buffer via `ensure_ad_stack_metadata_loaded`; int-heap adstacks have
 // no adjoint slice and hit `QD_ASSERT(primal)` in that path.
+spirv::Value TaskCodegen::ad_stack_count_ptr(uint32_t stack_id) {
+  // First call lazily allocates a single Function-scope `uint[num_ad_stacks_]` array shared across every adstack.
+  // Each push / pop / load-top accesses its slot via OpAccessChain on this array - critically, an OpAccessChain
+  // into a Function-scope array element is NOT promoted by spirv-opt's `LocalMultiStoreElim` / `SSARewrite` to
+  // per-element phi nodes the way a per-stack scalar OpVariable is. Without this sharing, hundreds of per-stack
+  // `count_var` OpVariables flowing through any enclosing loop become hundreds of `OpPhi` entries at the loop
+  // header, which spirv-cross emits as one `uint _N;` forward-decl plus one `_N = _N;` alias copy per predecessor
+  // branch in MSL - the dominant size amplifier on reverse-grad kernels with many adstacks.
+  if (ad_stack_count_array_var_.id == 0) {
+    QD_ASSERT(num_ad_stacks_ > 0);
+    spirv::SType arr_type = ir_->get_function_array_type(ir_->u32_type(), num_ad_stacks_);
+    ad_stack_count_array_var_ = ir_->alloca_variable(arr_type);
+  }
+  spirv::SType ptr_type = ir_->get_pointer_type(ir_->u32_type(), spv::StorageClassFunction);
+  spirv::Value idx_const = ir_->uint_immediate_number(ir_->i32_type(), stack_id);
+  return ir_->make_value(spv::OpAccessChain, ptr_type, ad_stack_count_array_var_, idx_const);
+}
+
 spirv::Value TaskCodegen::ad_stack_slot_ptr(AdStackSpirv &info, spirv::Value idx, bool primal) {
   ensure_ad_stack_metadata_loaded(info);
   spirv::Value slot_offset = primal ? info.offset_val : info.adjoint_offset_val;
@@ -2652,83 +2676,98 @@ void TaskCodegen::visit(AdStackPushStmt *stmt) {
   auto &info = ad_stacks_.at(stmt->stack);
   ensure_ad_stack_metadata_loaded(info);
   spirv::Value count = ir_->load_variable(info.count_var, ir_->u32_type());
-
-  // Guard the primal/adjoint store and the count increment with an in-range check. Without it, a loop that pushes
-  // more than `max_size` elements would write past the end of the backing storage, with backend-defined behavior
-  // (silent corruption on Metal / Vulkan). On overflow the else branch flips the host-readable overflow flag so
-  // the runtime can surface it as a Python exception after the dispatch; the in-kernel no-op still matters
-  // because we want to avoid the OOB write regardless of whether the host ends up raising on this launch. The
-  // bound comes from the runtime-published AdStackMetadata buffer (cached on `info.max_size_val` by
-  // `ensure_ad_stack_metadata_loaded`), not a compile-time immediate - the host may have evaluated a tighter
-  // bound from the per-alloca `SizeExpr` for this launch.
-  spirv::Value max_val = info.max_size_val;
-  spirv::Value in_range = ir_->lt(count, max_val);
-  spirv::Label then_label = ir_->new_label();
-  spirv::Label else_label = ir_->new_label();
-  spirv::Label merge_label = ir_->new_label();
-  ir_->make_inst(spv::OpSelectionMerge, merge_label, spv::SelectionControlMaskNone);
-  ir_->make_inst(spv::OpBranchConditional, in_range, then_label, else_label);
-  ir_->start_label(then_label);
-
-  // primal_arr[count] = v;  (adjoint_arr[count] = 0 too, except for heap_int: see AllocaStmt visitor.)
   spirv::SType backing_type = ad_stack_backing_type(info);
   spirv::Value val = ir_->query_value(stmt->v->raw_name());
   if (info.elem_type.id != backing_type.id) {
     val = ir_->cast(backing_type, val);  // u1 -> i32 for the heap_int path
   }
+  spirv::Value one = ir_->uint_immediate_number(ir_->u32_type(), 1);
+
+  if (compile_config_ && (compile_config_->check_out_of_bound || compile_config_->debug)) {
+    // Debug / `check_out_of_bound` build: map an OOB push to the last valid slot via a `GLSLstd450UMin` clamp, then
+    // issue the primal/adjoint store and an unconditional `OpAtomicUMax(overflow_buffer, signal)` where
+    // `signal = (count >= max_size) ? stack_id + 1 : 0`. The atomic-max with 0 cannot raise the host-visible value, so
+    // the runtime only sees the flag set when an actual overflow happened. Concurrent threads that all witness an
+    // overflow on the same stack publish the same value, so the atomic-max also handles the concurrent-overflow case
+    // deterministically. The clamp + OpSelect formulation collapses what would otherwise be a per-push structured
+    // if-then-else region into straight-line code, which spirv-cross emits as straight-line MSL - critical for
+    // reverse-grad kernels with hundreds of adstacks pushed inside an inner loop, which otherwise blow through
+    // Apple's MSL-compiler-service shader-size threshold on macOS-15 M1 hosts. `max_val` is the runtime-published
+    // AdStackMetadata bound cached on `info.max_size_val` by `ensure_ad_stack_metadata_loaded`, not a compile-time
+    // immediate.
+    // The gate ORs `debug` with `check_out_of_bound` so this codepath stays live on Metal / Vulkan, where
+    // `Program::init` force-disables `check_out_of_bound` because those arches lack `Extension::assertion` (which only
+    // matters for in-kernel `assert()` and the field-bounds check, not for the adstack overflow path which uses an
+    // OpAtomicUMax + host readback that works on every SPIR-V backend).
+    spirv::Value max_val = info.max_size_val;
+    spirv::Value max_minus_one = ir_->sub(max_val, one);
+    spirv::Value clamped_idx = ir_->call_glsl450(ir_->u32_type(), GLSLstd450UMin, count, max_minus_one);
+    spirv::Value primal_ptr = ad_stack_slot_ptr(info, clamped_idx, /*primal=*/true);
+    ir_->store_variable(primal_ptr, val);
+    if (info.heap_kind != AdStackHeapKind::heap_int) {
+      spirv::Value adjoint_ptr = ad_stack_slot_ptr(info, clamped_idx, /*primal=*/false);
+      ir_->store_variable(adjoint_ptr, ir_->get_zero(backing_type));
+    }
+    ir_->store_variable(info.count_var, ir_->add(count, one));
+    spirv::Value overflow_signal =
+        ir_->select(ir_->ge(count, max_val), ir_->uint_immediate_number(ir_->u32_type(), info.stack_id + 1),
+                    ir_->uint_immediate_number(ir_->u32_type(), 0));
+    spirv::Value overflow_buffer = get_buffer_value(BufferType::AdStackOverflow, PrimitiveType::u32);
+    spirv::Value overflow_ptr =
+        ir_->struct_array_access(ir_->u32_type(), overflow_buffer, ir_->uint_immediate_number(ir_->i32_type(), 0));
+    ir_->make_value(spv::OpAtomicUMax, ir_->u32_type(), overflow_ptr,
+                    /*scope=*/ir_->const_i32_one_,
+                    /*semantics=*/ir_->const_i32_zero_, overflow_signal);
+    return;
+  }
+
+  // Release build: trust the bound from `determine_ad_stack_size` (or the host-evaluated `size_expr` when the static
+  // pre-pass leaves a runtime-bound stack). Skip the clamp and the `OpAtomicUMax` overflow signal. Mirrors LLVM's
+  // release-build push, which also drops the runtime overflow guard - any unresolved stack is a hard pre-pass error
+  // there, and on the SPIR-V heap-backing path the host launcher is responsible for publishing a `max_size` that fits
+  // the kernel's actual push depth (and growing the heap if it does not, see the runtime-capacity grow-and-retry path
+  // in `runtime/gfx/runtime.cpp`). Cuts the per-push MSL emit down to the slot stores plus the `count++`, which is
+  // the dominant lever for keeping cross-compiled MSL below Apple's MSL-compiler-service shader-size limits on
+  // arches that hit them.
   spirv::Value primal_ptr = ad_stack_slot_ptr(info, count, /*primal=*/true);
   ir_->store_variable(primal_ptr, val);
   if (info.heap_kind != AdStackHeapKind::heap_int) {
     spirv::Value adjoint_ptr = ad_stack_slot_ptr(info, count, /*primal=*/false);
     ir_->store_variable(adjoint_ptr, ir_->get_zero(backing_type));
   }
-
-  // count++
-  spirv::Value one = ir_->uint_immediate_number(ir_->u32_type(), 1);
   ir_->store_variable(info.count_var, ir_->add(count, one));
-
-  ir_->make_inst(spv::OpBranch, merge_label);
-  ir_->start_label(else_label);
-
-  // Signal overflow to the host. Concurrent overflows would race on a plain `OpStore`; even though every thread
-  // writes the same sentinel, Vulkan's synchronization validation layer correctly flags this as a data race on a
-  // StorageBuffer location. Use `OpAtomicOr` with relaxed memory semantics so the write has defined memory-model
-  // behavior - the result is still "flag set" regardless of interleaving, and the host only reads after an
-  // implicit wait_idle barrier from the next sync.
-  spirv::Value overflow_buffer = get_buffer_value(BufferType::AdStackOverflow, PrimitiveType::u32);
-  spirv::Value overflow_ptr =
-      ir_->struct_array_access(ir_->u32_type(), overflow_buffer, ir_->uint_immediate_number(ir_->i32_type(), 0));
-  // Store the offending stack_id + 1 (so 0 still means "no overflow") so the host can identify the
-  // specific alloca that pushed past its sizer-evaluated capacity. `OpAtomicUMax` keeps the largest
-  // stack_id seen when multiple stacks overflow concurrently - an arbitrary but deterministic choice
-  // that still raises the exception at `qd.sync()` regardless of which one surfaces.
-  ir_->make_value(spv::OpAtomicUMax, ir_->u32_type(), overflow_ptr,
-                  /*scope=*/ir_->const_i32_one_,
-                  /*semantics=*/ir_->const_i32_zero_, ir_->uint_immediate_number(ir_->u32_type(), info.stack_id + 1));
-
-  ir_->make_inst(spv::OpBranch, merge_label);
-  ir_->start_label(merge_label);
 }
 
 void TaskCodegen::visit(AdStackPopStmt *stmt) {
-  // Intentionally unclamped, unlike the LLVM runtime's stack_pop. A forward push that overflowed skipped the
-  // count++ and flipped the overflow flag, so the matching reverse pop here underflows count to UINT_MAX. The
-  // LoadTop*/AccAdjoint visitors clamp idx to max_size-1 so the OpAccessChain stays in-bounds regardless, and
-  // the host raises a RuntimeError at the next synchronize() before any garbage adjoint reaches user code.
+  // Intentionally unclamped, unlike the LLVM runtime's stack_pop. The forward AdStackPushStmt now increments
+  // count unconditionally (the in-bounds check folded into a clamp + OpSelect there), so push and pop are
+  // balanced and count returns to zero at the end of a balanced reverse pass even when intervening pushes
+  // overflowed. The LoadTop*/AccAdjoint visitors still clamp idx to max_size-1 so the OpAccessChain stays
+  // in-bounds when count is currently above max_size on the overflow path, and the host raises a RuntimeError
+  // at the next synchronize() before any garbage adjoint reaches user code.
   auto &info = ad_stacks_.at(stmt->stack);
   spirv::Value count = ir_->load_variable(info.count_var, ir_->u32_type());
   spirv::Value one = ir_->uint_immediate_number(ir_->u32_type(), 1);
   ir_->store_variable(info.count_var, ir_->sub(count, one));
 }
 
-// `idx = min(count - 1, max_size - 1)` as a u32. If count underflowed to UINT_MAX after a pop that had no matching
-// push (overflow path), count - 1 is UINT_MAX - 1 which still clamps to max_size - 1, keeping OpAccessChain
-// in-bounds. Without this clamp, hostile Vulkan drivers (e.g. Adreno, Mali) TDR on OOB private-memory access
-// before the host-side qd.sync() can raise the deferred adstack-overflow exception. `max_size` is now a runtime
-// value loaded from AdStackMetadata, so `max_size - 1` becomes an OpISub rather than a compile-time immediate.
-static spirv::Value ad_stack_top_index(spirv::IRBuilder *ir, spirv::Value count, spirv::Value max_size_val) {
+// `idx = min(count - 1, max_size - 1)` as a u32 when `clamp_to_max_size` is set. On the overflow path count can
+// be above max_size (because the forward push increments count unconditionally and only signals via
+// OpAtomicUMax in the bounds-checked build), so the clamp keeps the OpAccessChain in-bounds; without it, hostile
+// Vulkan drivers (e.g. Adreno, Mali) TDR on OOB private-memory access before the host-side qd.sync() can raise
+// the deferred adstack-overflow exception. The release build (`check_out_of_bound=false`, no overflow signal
+// emitted) trusts the published `max_size` and skips both the cap subtract and the UMin call, mirroring LLVM's
+// release-build LoadTop emit. `max_size` is a runtime value loaded from AdStackMetadata, so `max_size - 1`
+// becomes an OpISub rather than a compile-time immediate when clamping is requested.
+static spirv::Value ad_stack_top_index(spirv::IRBuilder *ir,
+                                       spirv::Value count,
+                                       spirv::Value max_size_val,
+                                       bool clamp_to_max_size) {
   spirv::Value one = ir->uint_immediate_number(ir->u32_type(), 1);
   spirv::Value idx = ir->sub(count, one);
+  if (!clamp_to_max_size) {
+    return idx;
+  }
   spirv::Value cap = ir->sub(max_size_val, one);
   return ir->call_glsl450(ir->u32_type(), GLSLstd450UMin, idx, cap);
 }
@@ -2749,7 +2788,9 @@ void TaskCodegen::visit(AdStackLoadTopStmt *stmt) {
   auto &info = ad_stacks_.at(stmt->stack);
   ensure_ad_stack_metadata_loaded(info);
   spirv::Value count = ir_->load_variable(info.count_var, ir_->u32_type());
-  spirv::Value idx = ad_stack_top_index(ir_.get(), count, info.max_size_val);
+  spirv::Value idx =
+      ad_stack_top_index(ir_.get(), count, info.max_size_val,
+                         compile_config_ && (compile_config_->check_out_of_bound || compile_config_->debug));
   spirv::Value ptr = ad_stack_slot_ptr(info, idx, /*primal=*/true);
   spirv::SType backing_type = ad_stack_backing_type(info);
   spirv::Value loaded = ir_->load_variable(ptr, backing_type);
@@ -2771,7 +2812,9 @@ void TaskCodegen::visit(AdStackLoadTopAdjStmt *stmt) {
   // promotion on the int heap, which this assert excludes. For heap_float the backing type is `info.elem_type`
   // unconditionally, so any cast would be a no-op.
   spirv::Value count = ir_->load_variable(info.count_var, ir_->u32_type());
-  spirv::Value idx = ad_stack_top_index(ir_.get(), count, info.max_size_val);
+  spirv::Value idx =
+      ad_stack_top_index(ir_.get(), count, info.max_size_val,
+                         compile_config_ && (compile_config_->check_out_of_bound || compile_config_->debug));
   spirv::Value ptr = ad_stack_slot_ptr(info, idx, /*primal=*/false);
   spirv::Value loaded = ir_->load_variable(ptr, info.elem_type);
   ir_->register_value(stmt->raw_name(), loaded);
@@ -2784,7 +2827,9 @@ void TaskCodegen::visit(AdStackAccAdjointStmt *stmt) {
   ensure_ad_stack_metadata_loaded(info);
   // See the note in `AdStackLoadTopAdjStmt`: no cast is needed because heap_int is excluded by the assert above.
   spirv::Value count = ir_->load_variable(info.count_var, ir_->u32_type());
-  spirv::Value idx = ad_stack_top_index(ir_.get(), count, info.max_size_val);
+  spirv::Value idx =
+      ad_stack_top_index(ir_.get(), count, info.max_size_val,
+                         compile_config_ && (compile_config_->check_out_of_bound || compile_config_->debug));
   spirv::Value ptr = ad_stack_slot_ptr(info, idx, /*primal=*/false);
   spirv::Value old_val = ir_->load_variable(ptr, info.elem_type);
   spirv::Value incr = ir_->query_value(stmt->v->raw_name());
@@ -2973,6 +3018,7 @@ void KernelCodegen::run(QuadrantsKernelAttributes &kernel_attribs,
     tp.ti_kernel_name = fmt::format("{}_{}", params_.ti_kernel_name, i);
     tp.arch = params_.arch;
     tp.caps = &params_.caps;
+    tp.compile_config = params_.compile_config;
 
     TaskCodegen cgen(tp);
     auto task_res = cgen.run();

--- a/quadrants/codegen/spirv/spirv_codegen.cpp
+++ b/quadrants/codegen/spirv/spirv_codegen.cpp
@@ -2627,13 +2627,6 @@ void TaskCodegen::visit(AdStackAllocaStmt *stmt) {
   ad_stacks_[stmt] = info;
 }
 
-// Resolve the primal- or adjoint-slot pointer for `info` at index `idx`. The returned pointer is typed after the
-// adstack's backing storage (f32 for heap_float, i32 for heap_int) - which is the same as `info.elem_type` except
-// for u1 adstacks on the int heap, where backing is i32. Callers must explicitly convert between u1 and i32 via
-// `ir_->cast(...)` at store/load sites in that single special case. `primal=true` selects the primal half of the
-// slice, `false` selects the adjoint half. The per-alloca `offset` and (for f32 only) `adjoint_offset = offset +
-// max_size` come from the `AdStackMetadata` buffer via `ensure_ad_stack_metadata_loaded`; int-heap adstacks have
-// no adjoint slice and hit `QD_ASSERT(primal)` in that path.
 spirv::Value TaskCodegen::ad_stack_count_ptr(uint32_t stack_id) {
   // First call lazily allocates a single Function-scope `uint[num_ad_stacks_]` array shared across every adstack.
   // Each push / pop / load-top accesses its slot via OpAccessChain on this array - critically, an OpAccessChain
@@ -2652,6 +2645,13 @@ spirv::Value TaskCodegen::ad_stack_count_ptr(uint32_t stack_id) {
   return ir_->make_value(spv::OpAccessChain, ptr_type, ad_stack_count_array_var_, idx_const);
 }
 
+// Resolve the primal- or adjoint-slot pointer for `info` at index `idx`. The returned pointer is typed after the
+// adstack's backing storage (f32 for heap_float, i32 for heap_int) - which is the same as `info.elem_type` except
+// for u1 adstacks on the int heap, where backing is i32. Callers must explicitly convert between u1 and i32 via
+// `ir_->cast(...)` at store/load sites in that single special case. `primal=true` selects the primal half of the
+// slice, `false` selects the adjoint half. The per-alloca `offset` and (for f32 only) `adjoint_offset = offset +
+// max_size` come from the `AdStackMetadata` buffer via `ensure_ad_stack_metadata_loaded`; int-heap adstacks have
+// no adjoint slice and hit `QD_ASSERT(primal)` in that path.
 spirv::Value TaskCodegen::ad_stack_slot_ptr(AdStackSpirv &info, spirv::Value idx, bool primal) {
   ensure_ad_stack_metadata_loaded(info);
   spirv::Value slot_offset = primal ? info.offset_val : info.adjoint_offset_val;

--- a/quadrants/rhi/metal/metal_device.mm
+++ b/quadrants/rhi/metal/metal_device.mm
@@ -175,22 +175,35 @@ MetalPipeline *MetalPipeline::create_compute_pipeline(const MetalDevice &device,
                  name.c_str(), msl.size(), err.localizedDescription.UTF8String,
                  (int)err.code);
       } else {
-        // Apple returned nil pipeline + nil NSError. This typically means the
-        // XPC-backed Metal compiler service dropped the connection mid-compile
-        // (driver / toolchain bug, MSL size, or a specific construct the
-        // toolchain mishandles - we cannot tell without ground-truth
-        // diagnostics from the host's `xcrun metal`). Surface the kernel name
-        // and cross-compiled MSL byte size in the log so the next investigator
-        // does not have to bisect to find which kernel and how big it was.
-        snprintf(msgbuf.data(), msgbuf.size(),
-                 "Apple's Metal compiler service rejected the compute-pipeline "
-                 "build for kernel '%s' "
-                 "(cross-compiled MSL size: %zu bytes) without returning a "
-                 "structured error. The XPC service "
-                 "drops its connection in this shape; the underlying cause is "
-                 "host-toolchain-specific and is "
-                 "not recoverable from this side.",
-                 name.c_str(), msl.size());
+        // Apple returned nil pipeline + nil NSError. The XPC-backed
+        // `com.apple.MTLCompilerService` dropped its connection mid-compile.
+        // The proximate cause observed on GitHub-hosted macos-15 runners is a
+        // hard 100 MB working-set cap on that XPC service, enforced by the XNU
+        // kernel via EXC_RESOURCE (`process MTLCompilerServi crossed memory
+        // high watermark (100 MB); EXC_RESOURCE` in the system log). The same
+        // MSL compiles cleanly via offline `xcrun metal -c` because the offline
+        // tool runs without the cap. Cap is not a runtime knob - shrinking the
+        // cross-compiled MSL / AIR working set is the only path. Surface the
+        // kernel name and MSL byte size so the next investigator can target the
+        // offending kernel without bisecting.
+        snprintf(
+            msgbuf.data(), msgbuf.size(),
+            "Apple's Metal compiler service (com.apple.MTLCompilerService) "
+            "dropped its XPC connection while "
+            "compiling the compute pipeline for kernel '%s' (cross-compiled "
+            "MSL size: %zu bytes), returning a "
+            "nil pipeline with no NSError. On GitHub-hosted macos-15 runners "
+            "the kernel log captures the "
+            "proximate cause as `process MTLCompilerServi crossed memory high "
+            "watermark (100 MB); EXC_RESOURCE` "
+            "- the XPC service is sandboxed with a hard 100 MB working-set cap "
+            "and is killed when the AIR -> "
+            "GPU compile of a large kernel exceeds it. The same MSL compiles "
+            "via offline `xcrun metal -c` "
+            "because the offline tool runs outside that sandbox. The cap is "
+            "not a runtime knob - reduce the "
+            "cross-compiled MSL / AIR working set for this kernel.",
+            name.c_str(), msl.size());
       }
       // Use QD_WARN (log + no-throw) rather than QD_ERROR (log + `throw
       // std::string`). `QD_ERROR` here would unwind through
@@ -1569,20 +1582,30 @@ MTLLibrary_id MetalDevice::get_mtl_library(const std::string &source) const {
                source.size(), err.localizedDescription.UTF8String,
                (int)err.code);
     } else {
-      // See the matching `create_compute_pipeline` site for the diagnosis: nil
-      // library + nil NSError typically means the XPC-backed Metal compiler
-      // service dropped the connection mid-compile (driver / toolchain bug, MSL
-      // size, or a specific construct the toolchain mishandles - not
-      // distinguishable from this side). Surface the cross-compiled MSL byte
-      // size in the log so the next investigator does not have to extract and
-      // re-measure.
+      // Apple returned nil library + nil NSError - the XPC-backed
+      // `com.apple.MTLCompilerService` dropped its connection during MSL -> AIR
+      // compile. On GitHub-hosted macos-15 runners the proximate cause logged
+      // in the kernel ring buffer is `process MTLCompilerServi crossed memory
+      // high watermark (100 MB); EXC_RESOURCE` - the XPC service has a hard 100
+      // MB working-set cap that the kernel enforces via EXC_RESOURCE. The same
+      // MSL compiles cleanly via offline `xcrun metal -c` because that tool
+      // runs outside the sandbox. Cap is not a runtime knob; the only path is
+      // to shrink the cross-compiled MSL / AIR working set.
       snprintf(msgbuf.data(), msgbuf.size(),
-               "Apple's Metal compiler service rejected the metal-library "
-               "build (cross-compiled MSL size: %zu "
-               "bytes) without returning a structured error. The XPC service "
-               "drops its connection in this "
-               "shape; the underlying cause is host-toolchain-specific and is "
-               "not recoverable from this side.",
+               "Apple's Metal compiler service (com.apple.MTLCompilerService) "
+               "dropped its XPC connection while "
+               "compiling MSL -> AIR (cross-compiled MSL size: %zu bytes), "
+               "returning a nil library with no NSError. "
+               "On GitHub-hosted macos-15 runners the kernel log captures the "
+               "proximate cause as `process "
+               "MTLCompilerServi crossed memory high watermark (100 MB); "
+               "EXC_RESOURCE` - the XPC service is "
+               "sandboxed with a hard 100 MB working-set cap and is killed "
+               "when the compile working set exceeds it. "
+               "The same MSL compiles via offline `xcrun metal -c` because "
+               "that tool is not subject to the cap. The "
+               "cap is not a runtime knob - reduce the cross-compiled MSL "
+               "working set.",
                source.size());
     }
     // QD_WARN rather than QD_ERROR: see `create_compute_pipeline` for the

--- a/quadrants/rhi/metal/metal_device.mm
+++ b/quadrants/rhi/metal/metal_device.mm
@@ -175,26 +175,33 @@ MetalPipeline *MetalPipeline::create_compute_pipeline(const MetalDevice &device,
                  name.c_str(), msl.size(), err.localizedDescription.UTF8String,
                  (int)err.code);
       } else {
-        // Apple's MSL compiler service (XPC-backed) returns nil with err=nil
-        // when its connection drops mid-compile, typically because the
-        // cross-compiled MSL exceeds an internal compiler-service shader-size
-        // budget on the host's Metal toolchain version. Surface that as a clear
-        // actionable Python-level error pointing at the kernel size, rather
-        // than falling through to the generic `runtime.cpp:298 RhiResult=-1`
-        // line.
+        // Apple returned nil pipeline + nil NSError. This typically means the
+        // XPC-backed Metal compiler service dropped the connection mid-compile
+        // (driver / toolchain bug, MSL size, or a specific construct the
+        // toolchain mishandles - we cannot tell without ground-truth
+        // diagnostics from the host's `xcrun metal`). Surface the kernel name
+        // and cross-compiled MSL byte size in the log so the next investigator
+        // does not have to bisect to find which kernel and how big it was.
         snprintf(msgbuf.data(), msgbuf.size(),
-                 "Apple's Metal compiler rejected the compute-pipeline build "
-                 "for kernel '%s' "
+                 "Apple's Metal compiler service rejected the compute-pipeline "
+                 "build for kernel '%s' "
                  "(cross-compiled MSL size: %zu bytes) without returning a "
-                 "structured error. This is the "
-                 "typical signature of an internal Metal-toolchain shader-size "
-                 "limit on this host: split "
-                 "the kernel into smaller pieces or reduce its body so the "
-                 "cross-compiled MSL drops below "
-                 "the host's threshold.",
+                 "structured error. The XPC service "
+                 "drops its connection in this shape; the underlying cause is "
+                 "host-toolchain-specific and is "
+                 "not recoverable from this side.",
                  name.c_str(), msl.size());
       }
-      QD_ERROR("[metal_device.mm] {}", msgbuf.data());
+      // Use QD_WARN (log + no-throw) rather than QD_ERROR (log + `throw
+      // std::string`). `QD_ERROR` here would unwind through
+      // `MetalDevice::create_pipeline`, which is `noexcept` and only catches
+      // `std::exception`; `std::string` is not derived from it, so the throw
+      // would cross the `noexcept` boundary and trip `std::terminate`,
+      // replacing the existing clean `RhiResult::error -> Python RuntimeError`
+      // translation path with a fatal process abort. The detailed message above
+      // is logged at warn level; the caller's `runtime.cpp:298 QD_ERROR_IF(res
+      // != success, ...)` then raises the kernel-name-bearing Python error.
+      QD_WARN("[metal_device.mm] {}", msgbuf.data());
       return nullptr;
     }
   }
@@ -1564,22 +1571,24 @@ MTLLibrary_id MetalDevice::get_mtl_library(const std::string &source) const {
     } else {
       // See the matching `create_compute_pipeline` site for the diagnosis: nil
       // library + nil NSError typically means the XPC-backed Metal compiler
-      // service dropped the connection mid-compile because the cross-compiled
-      // MSL exceeded an internal shader-size budget. Surface that as a
-      // Python-level error so users get an actionable message rather than the
-      // generic runtime.cpp `RhiResult=-1` line.
+      // service dropped the connection mid-compile (driver / toolchain bug, MSL
+      // size, or a specific construct the toolchain mishandles - not
+      // distinguishable from this side). Surface the cross-compiled MSL byte
+      // size in the log so the next investigator does not have to extract and
+      // re-measure.
       snprintf(msgbuf.data(), msgbuf.size(),
-               "Apple's Metal compiler rejected the metal-library build "
-               "(cross-compiled MSL size: %zu "
-               "bytes) without returning a structured error. This is the "
-               "typical signature of an internal "
-               "Metal-toolchain shader-size limit on this host: split the "
-               "kernel into smaller pieces or "
-               "reduce its body so the cross-compiled MSL drops below the "
-               "host's threshold.",
+               "Apple's Metal compiler service rejected the metal-library "
+               "build (cross-compiled MSL size: %zu "
+               "bytes) without returning a structured error. The XPC service "
+               "drops its connection in this "
+               "shape; the underlying cause is host-toolchain-specific and is "
+               "not recoverable from this side.",
                source.size());
     }
-    QD_ERROR("[metal_device.mm] {}", msgbuf.data());
+    // QD_WARN rather than QD_ERROR: see `create_compute_pipeline` for the
+    // noexcept-boundary rationale. Caller converts the nullptr return to a
+    // `RhiResult::error` which then surfaces as a Python `RuntimeError`.
+    QD_WARN("[metal_device.mm] {}", msgbuf.data());
     return nil;
   }
   return mtl_library;

--- a/quadrants/rhi/metal/metal_device.mm
+++ b/quadrants/rhi/metal/metal_device.mm
@@ -175,35 +175,23 @@ MetalPipeline *MetalPipeline::create_compute_pipeline(const MetalDevice &device,
                  name.c_str(), msl.size(), err.localizedDescription.UTF8String,
                  (int)err.code);
       } else {
-        // Apple returned nil pipeline + nil NSError. The XPC-backed
-        // `com.apple.MTLCompilerService` dropped its connection mid-compile.
-        // The proximate cause observed on GitHub-hosted macos-15 runners is a
-        // hard 100 MB working-set cap on that XPC service, enforced by the XNU
-        // kernel via EXC_RESOURCE (`process MTLCompilerServi crossed memory
-        // high watermark (100 MB); EXC_RESOURCE` in the system log). The same
-        // MSL compiles cleanly via offline `xcrun metal -c` because the offline
-        // tool runs without the cap. Cap is not a runtime knob - shrinking the
-        // cross-compiled MSL / AIR working set is the only path. Surface the
-        // kernel name and MSL byte size so the next investigator can target the
-        // offending kernel without bisecting.
-        snprintf(
-            msgbuf.data(), msgbuf.size(),
-            "Apple's Metal compiler service (com.apple.MTLCompilerService) "
-            "dropped its XPC connection while "
-            "compiling the compute pipeline for kernel '%s' (cross-compiled "
-            "MSL size: %zu bytes), returning a "
-            "nil pipeline with no NSError. On GitHub-hosted macos-15 runners "
-            "the kernel log captures the "
-            "proximate cause as `process MTLCompilerServi crossed memory high "
-            "watermark (100 MB); EXC_RESOURCE` "
-            "- the XPC service is sandboxed with a hard 100 MB working-set cap "
-            "and is killed when the AIR -> "
-            "GPU compile of a large kernel exceeds it. The same MSL compiles "
-            "via offline `xcrun metal -c` "
-            "because the offline tool runs outside that sandbox. The cap is "
-            "not a runtime knob - reduce the "
-            "cross-compiled MSL / AIR working set for this kernel.",
-            name.c_str(), msl.size());
+        // Apple's `com.apple.MTLCompilerService` returned nil pipeline + nil
+        // NSError, meaning the XPC service dropped its connection mid-compile.
+        // One known trigger is the kernel hitting a per-process memory cap on
+        // the XPC service while compiling the AIR; large reverse-grad kernels
+        // are the typical offender. Surface the kernel name and MSL byte size
+        // so the offending kernel can be targeted without bisecting.
+        snprintf(msgbuf.data(), msgbuf.size(),
+                 "Apple's Metal compiler service dropped its XPC connection "
+                 "while compiling the compute pipeline "
+                 "for kernel '%s' (cross-compiled MSL size: %zu bytes), "
+                 "returning nil with no NSError. This can "
+                 "happen when the cross-compiled kernel is large enough that "
+                 "the compiler service exceeds a "
+                 "per-process memory budget mid-compile. Reducing the "
+                 "cross-compiled MSL / AIR working set for this "
+                 "kernel is the most reliable workaround.",
+                 name.c_str(), msl.size());
       }
       // Use QD_WARN (log + no-throw) rather than QD_ERROR (log + `throw
       // std::string`). `QD_ERROR` here would unwind through
@@ -1582,30 +1570,20 @@ MTLLibrary_id MetalDevice::get_mtl_library(const std::string &source) const {
                source.size(), err.localizedDescription.UTF8String,
                (int)err.code);
     } else {
-      // Apple returned nil library + nil NSError - the XPC-backed
-      // `com.apple.MTLCompilerService` dropped its connection during MSL -> AIR
-      // compile. On GitHub-hosted macos-15 runners the proximate cause logged
-      // in the kernel ring buffer is `process MTLCompilerServi crossed memory
-      // high watermark (100 MB); EXC_RESOURCE` - the XPC service has a hard 100
-      // MB working-set cap that the kernel enforces via EXC_RESOURCE. The same
-      // MSL compiles cleanly via offline `xcrun metal -c` because that tool
-      // runs outside the sandbox. Cap is not a runtime knob; the only path is
-      // to shrink the cross-compiled MSL / AIR working set.
+      // Apple's `com.apple.MTLCompilerService` returned nil library + nil
+      // NSError - the XPC service dropped its connection during MSL -> AIR
+      // compile. One known trigger is the compiler service exceeding a
+      // per-process memory budget on a large source. Surface the MSL byte size
+      // so the offending input is easy to spot.
       snprintf(msgbuf.data(), msgbuf.size(),
-               "Apple's Metal compiler service (com.apple.MTLCompilerService) "
-               "dropped its XPC connection while "
-               "compiling MSL -> AIR (cross-compiled MSL size: %zu bytes), "
-               "returning a nil library with no NSError. "
-               "On GitHub-hosted macos-15 runners the kernel log captures the "
-               "proximate cause as `process "
-               "MTLCompilerServi crossed memory high watermark (100 MB); "
-               "EXC_RESOURCE` - the XPC service is "
-               "sandboxed with a hard 100 MB working-set cap and is killed "
-               "when the compile working set exceeds it. "
-               "The same MSL compiles via offline `xcrun metal -c` because "
-               "that tool is not subject to the cap. The "
-               "cap is not a runtime knob - reduce the cross-compiled MSL "
-               "working set.",
+               "Apple's Metal compiler service dropped its XPC connection "
+               "while compiling MSL -> AIR "
+               "(cross-compiled MSL size: %zu bytes), returning nil with no "
+               "NSError. This can happen when the "
+               "cross-compiled source is large enough that the compiler "
+               "service exceeds a per-process memory "
+               "budget mid-compile. Reducing the cross-compiled MSL working "
+               "set is the most reliable workaround.",
                source.size());
     }
     // QD_WARN rather than QD_ERROR: see `create_compute_pipeline` for the

--- a/quadrants/rhi/metal/metal_device.mm
+++ b/quadrants/rhi/metal/metal_device.mm
@@ -167,13 +167,34 @@ MetalPipeline *MetalPipeline::create_compute_pipeline(const MetalDevice &device,
                                                            error:&err];
 
     if (mtl_compute_pipeline_state == nil) {
+      std::array<char, 4096> msgbuf;
       if (err != nil) {
-        std::array<char, 4096> msgbuf;
         snprintf(msgbuf.data(), msgbuf.size(),
-                 "cannot create compute pipeline state: %s (code=%d)",
-                 err.localizedDescription.UTF8String, (int)err.code);
-        RHI_LOG_ERROR(msgbuf.data());
+                 "cannot create compute pipeline state for kernel '%s' "
+                 "(msl_bytes=%zu): %s (code=%d)",
+                 name.c_str(), msl.size(), err.localizedDescription.UTF8String,
+                 (int)err.code);
+      } else {
+        // Apple's MSL compiler service (XPC-backed) returns nil with err=nil
+        // when its connection drops mid-compile, typically because the
+        // cross-compiled MSL exceeds an internal compiler-service shader-size
+        // budget on the host's Metal toolchain version. Surface that as a clear
+        // actionable Python-level error pointing at the kernel size, rather
+        // than falling through to the generic `runtime.cpp:298 RhiResult=-1`
+        // line.
+        snprintf(msgbuf.data(), msgbuf.size(),
+                 "Apple's Metal compiler rejected the compute-pipeline build "
+                 "for kernel '%s' "
+                 "(cross-compiled MSL size: %zu bytes) without returning a "
+                 "structured error. This is the "
+                 "typical signature of an internal Metal-toolchain shader-size "
+                 "limit on this host: split "
+                 "the kernel into smaller pieces or reduce its body so the "
+                 "cross-compiled MSL drops below "
+                 "the host's threshold.",
+                 name.c_str(), msl.size());
       }
+      QD_ERROR("[metal_device.mm] {}", msgbuf.data());
       return nullptr;
     }
   }
@@ -1533,13 +1554,32 @@ MTLLibrary_id MetalDevice::get_mtl_library(const std::string &source) const {
   [msl_ns release];
 
   if (mtl_library == nil) {
+    std::array<char, 4096> msgbuf;
     if (err != nil) {
-      std::array<char, 4096> msgbuf;
       snprintf(msgbuf.data(), msgbuf.size(),
-               "cannot compile metal library from source: %s (code=%d)",
-               err.localizedDescription.UTF8String, (int)err.code);
-      RHI_LOG_ERROR(msgbuf.data());
+               "cannot compile metal library from source (msl_bytes=%zu): %s "
+               "(code=%d)",
+               source.size(), err.localizedDescription.UTF8String,
+               (int)err.code);
+    } else {
+      // See the matching `create_compute_pipeline` site for the diagnosis: nil
+      // library + nil NSError typically means the XPC-backed Metal compiler
+      // service dropped the connection mid-compile because the cross-compiled
+      // MSL exceeded an internal shader-size budget. Surface that as a
+      // Python-level error so users get an actionable message rather than the
+      // generic runtime.cpp `RhiResult=-1` line.
+      snprintf(msgbuf.data(), msgbuf.size(),
+               "Apple's Metal compiler rejected the metal-library build "
+               "(cross-compiled MSL size: %zu "
+               "bytes) without returning a structured error. This is the "
+               "typical signature of an internal "
+               "Metal-toolchain shader-size limit on this host: split the "
+               "kernel into smaller pieces or "
+               "reduce its body so the cross-compiled MSL drops below the "
+               "host's threshold.",
+               source.size());
     }
+    QD_ERROR("[metal_device.mm] {}", msgbuf.data());
     return nil;
   }
   return mtl_library;

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -997,14 +997,33 @@ def test_adstack_overflow_raises():
     # Internal detail: both LLVM and SPIR-V defer the error to the next `qd.sync()` (same pattern as CUDA async
     # errors) so we do not pay a sync-per-launch. LLVM polls `runtime->adstack_overflow_flag` from
     # `LlvmProgramImpl::synchronize()` via `check_adstack_overflow()`; SPIR-V's gfx runtime raises via `QD_ERROR`
-    # on sync. `debug=True` is required because release-build LLVM codegen elides the per-push bounds check on the
-    # premise that `determine_ad_stack_size` produces a tight upper bound; this test deliberately misconfigures
-    # the capacity below the kernel's actual peak push count, which the sizer cannot foresee, so the runtime
-    # check has to be live for the deferred raise to fire.
+    # on sync. The bounds-check codepath in both backends is gated on `check_out_of_bound`; release builds elide
+    # it on the premise that `determine_ad_stack_size` produces a tight upper bound. This test deliberately
+    # misconfigures the capacity below the kernel's actual peak push count, which the sizer cannot foresee, so the
+    # runtime check has to be live for the deferred raise to fire. `debug=True` implies `check_out_of_bound=True`
+    # via `CompileConfig::fit`, so the bounds check is live on this path; the explicit-flag spelling is covered
+    # by `test_adstack_overflow_raises_check_oob_explicit` below.
     compute, _, _ = _overflowing_compute()
     # On LLVM the runtime raises QuadrantsAssertionError (subclass of AssertionError) from
     # check_adstack_overflow; on SPIR-V the gfx runtime raises RuntimeError via QD_ERROR. We accept either,
     # matching only the message prefix.
+    with pytest.raises((AssertionError, RuntimeError), match=r"[Aa]dstack overflow"):
+        compute.grad()
+        qd.sync()
+
+
+@test_utils.test(require=qd.extension.adstack, exclude=[qd.metal, qd.vulkan], ad_stack_size=32, check_out_of_bound=True)
+def test_adstack_overflow_raises_check_oob_explicit():
+    # Same overflow scenario as `test_adstack_overflow_raises`, but with `check_out_of_bound=True` set explicitly
+    # without `debug=True`. Pins the gating to `check_out_of_bound` rather than `debug`: a user who only opts into
+    # bounds-checks (e.g. shipping a release-build app that still wants the deferred adstack-overflow error path)
+    # must get the same RuntimeError as a `debug=True` user. Regression coverage for the LLVM
+    # adstack-visitor codepaths gating on `check_out_of_bound` instead of `debug`.
+    # Excludes Metal / Vulkan: `Program::init` force-disables `check_out_of_bound` on arches without
+    # `Extension::assertion`, so the explicit-flag spelling alone cannot light up the bounds check there. The
+    # SPIR-V codegen gate ORs `debug` in to cover the `qd.init(debug=True)` path on those backends, which
+    # `test_adstack_overflow_raises` already exercises.
+    compute, _, _ = _overflowing_compute()
     with pytest.raises((AssertionError, RuntimeError), match=r"[Aa]dstack overflow"):
         compute.grad()
         qd.sync()
@@ -1015,8 +1034,8 @@ def test_adstack_overflow_flag_resets_after_catch():
     # Once `check_adstack_overflow()` raises, the runtime must clear its overflow flag so a subsequent `qd.sync()`
     # (with no new overflowing grad launch in between) returns normally. Without the reset the user would see a
     # stale overflow exception every time they sync after the first one, which makes diagnosis and recovery
-    # impossible. `debug=True` keeps the per-push bounds check live (release-build codegen elides it - see
-    # `test_adstack_overflow_raises` for the rationale).
+    # impossible. `debug=True` keeps the per-push bounds check live via the implied `check_out_of_bound=True` -
+    # see `test_adstack_overflow_raises` for the gating rationale.
     compute, _, _ = _overflowing_compute()
     with pytest.raises((AssertionError, RuntimeError), match=r"[Aa]dstack overflow"):
         compute.grad()

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -997,31 +997,14 @@ def test_adstack_overflow_raises():
     # Internal detail: both LLVM and SPIR-V defer the error to the next `qd.sync()` (same pattern as CUDA async
     # errors) so we do not pay a sync-per-launch. LLVM polls `runtime->adstack_overflow_flag` from
     # `LlvmProgramImpl::synchronize()` via `check_adstack_overflow()`; SPIR-V's gfx runtime raises via `QD_ERROR`
-    # on sync. The bounds-check codepath in both backends is gated on `check_out_of_bound`; release builds elide
-    # it on the premise that `determine_ad_stack_size` produces a tight upper bound. This test deliberately
-    # misconfigures the capacity below the kernel's actual peak push count, which the sizer cannot foresee, so the
-    # runtime check has to be live for the deferred raise to fire. `debug=True` implies `check_out_of_bound=True`
-    # via `CompileConfig::fit`, so the bounds check is live on this path.
+    # on sync. The bounds-check codepath in both backends is gated on `debug`; release builds elide it on the
+    # premise that `determine_ad_stack_size` produces a tight upper bound. This test deliberately misconfigures
+    # the capacity below the kernel's actual peak push count, which the sizer cannot foresee, so the runtime
+    # check has to be live for the deferred raise to fire - `debug=True` keeps it live.
     compute, _, _ = _overflowing_compute()
     # On LLVM the runtime raises QuadrantsAssertionError (subclass of AssertionError) from
     # check_adstack_overflow; on SPIR-V the gfx runtime raises RuntimeError via QD_ERROR. We accept either,
     # matching only the message prefix.
-    with pytest.raises((AssertionError, RuntimeError), match=r"[Aa]dstack overflow"):
-        compute.grad()
-        qd.sync()
-
-
-@test_utils.test(require=qd.extension.adstack, exclude=[qd.metal, qd.vulkan], ad_stack_size=32, check_out_of_bound=True)
-def test_adstack_overflow_raises_check_oob_explicit():
-    # Same overflow scenario but with `check_out_of_bound=True` set explicitly without `debug=True`. Pins the
-    # gating to `check_out_of_bound` rather than `debug`: a user who only opts into bounds-checks (e.g. shipping
-    # a release-build app that still wants the deferred adstack-overflow error path) must get the same
-    # RuntimeError as a `debug=True` user. Regression coverage for the LLVM adstack-visitor codepaths gating on
-    # `check_out_of_bound` instead of `debug`.
-    # Excludes Metal / Vulkan: `Program::init` force-disables `check_out_of_bound` on arches without
-    # `Extension::assertion`, so the explicit-flag spelling alone cannot light up the bounds check there. The
-    # SPIR-V codegen gate ORs `debug` in to cover the `qd.init(debug=True)` path on those backends.
-    compute, _, _ = _overflowing_compute()
     with pytest.raises((AssertionError, RuntimeError), match=r"[Aa]dstack overflow"):
         compute.grad()
         qd.sync()
@@ -1032,7 +1015,7 @@ def test_adstack_overflow_flag_resets_after_catch():
     # Once `check_adstack_overflow()` raises, the runtime must clear its overflow flag so a subsequent `qd.sync()`
     # (with no new overflowing grad launch in between) returns normally. Without the reset the user would see a
     # stale overflow exception every time they sync after the first one, which makes diagnosis and recovery
-    # impossible. `debug=True` keeps the per-push bounds check live via the implied `check_out_of_bound=True`.
+    # impossible. `debug=True` keeps the per-push bounds check live.
     compute, _, _ = _overflowing_compute()
     with pytest.raises((AssertionError, RuntimeError), match=r"[Aa]dstack overflow"):
         compute.grad()

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -1001,8 +1001,7 @@ def test_adstack_overflow_raises():
     # it on the premise that `determine_ad_stack_size` produces a tight upper bound. This test deliberately
     # misconfigures the capacity below the kernel's actual peak push count, which the sizer cannot foresee, so the
     # runtime check has to be live for the deferred raise to fire. `debug=True` implies `check_out_of_bound=True`
-    # via `CompileConfig::fit`, so the bounds check is live on this path; the explicit-flag spelling is covered
-    # by `test_adstack_overflow_raises_check_oob_explicit` below.
+    # via `CompileConfig::fit`, so the bounds check is live on this path.
     compute, _, _ = _overflowing_compute()
     # On LLVM the runtime raises QuadrantsAssertionError (subclass of AssertionError) from
     # check_adstack_overflow; on SPIR-V the gfx runtime raises RuntimeError via QD_ERROR. We accept either,
@@ -1014,15 +1013,14 @@ def test_adstack_overflow_raises():
 
 @test_utils.test(require=qd.extension.adstack, exclude=[qd.metal, qd.vulkan], ad_stack_size=32, check_out_of_bound=True)
 def test_adstack_overflow_raises_check_oob_explicit():
-    # Same overflow scenario as `test_adstack_overflow_raises`, but with `check_out_of_bound=True` set explicitly
-    # without `debug=True`. Pins the gating to `check_out_of_bound` rather than `debug`: a user who only opts into
-    # bounds-checks (e.g. shipping a release-build app that still wants the deferred adstack-overflow error path)
-    # must get the same RuntimeError as a `debug=True` user. Regression coverage for the LLVM
-    # adstack-visitor codepaths gating on `check_out_of_bound` instead of `debug`.
+    # Same overflow scenario but with `check_out_of_bound=True` set explicitly without `debug=True`. Pins the
+    # gating to `check_out_of_bound` rather than `debug`: a user who only opts into bounds-checks (e.g. shipping
+    # a release-build app that still wants the deferred adstack-overflow error path) must get the same
+    # RuntimeError as a `debug=True` user. Regression coverage for the LLVM adstack-visitor codepaths gating on
+    # `check_out_of_bound` instead of `debug`.
     # Excludes Metal / Vulkan: `Program::init` force-disables `check_out_of_bound` on arches without
     # `Extension::assertion`, so the explicit-flag spelling alone cannot light up the bounds check there. The
-    # SPIR-V codegen gate ORs `debug` in to cover the `qd.init(debug=True)` path on those backends, which
-    # `test_adstack_overflow_raises` already exercises.
+    # SPIR-V codegen gate ORs `debug` in to cover the `qd.init(debug=True)` path on those backends.
     compute, _, _ = _overflowing_compute()
     with pytest.raises((AssertionError, RuntimeError), match=r"[Aa]dstack overflow"):
         compute.grad()
@@ -1034,8 +1032,7 @@ def test_adstack_overflow_flag_resets_after_catch():
     # Once `check_adstack_overflow()` raises, the runtime must clear its overflow flag so a subsequent `qd.sync()`
     # (with no new overflowing grad launch in between) returns normally. Without the reset the user would see a
     # stale overflow exception every time they sync after the first one, which makes diagnosis and recovery
-    # impossible. `debug=True` keeps the per-push bounds check live via the implied `check_out_of_bound=True` -
-    # see `test_adstack_overflow_raises` for the gating rationale.
+    # impossible. `debug=True` keeps the per-push bounds check live via the implied `check_out_of_bound=True`.
     compute, _, _ = _overflowing_compute()
     with pytest.raises((AssertionError, RuntimeError), match=r"[Aa]dstack overflow"):
         compute.grad()


### PR DESCRIPTION
# SPIR-V reverse-grad kernel-size reduction: clamp + OpSelect adstack push, release-mode bounds-check elision, shared count-array, plus diagnostic-only Metal compiler-rejection logging

> Three commits. The first commit halves the cross-compiled MSL size of every reverse-grad kernel via three additive SPIR-V codegen changes (faster local Metal/Vulkan builds, lower host-side memory pressure during compile). The second commit replaces the silent `nil pipeline + nil NSError` log path in `metal_device.mm` with a non-throwing `QD_WARN` that includes the kernel name and cross-compiled MSL byte size, so when Apple's compiler service drops the connection (a known mode on some macOS / Metal-toolchain combinations) the next investigator immediately knows which kernel and how big it was, instead of bisecting from a generic `RhiResult=-1` line. The third commit drops two test cross-references from new test docstrings per the source-comment style rule.

> The PR is **NOT** a fix for the macos-15 M1 GitHub-runner failure on its own. The same g2p kernel that fails on macos-15 (cross-compiled MSL: 689,472 bytes after this PR's reduction) compiles cleanly on macOS 26 / M4 with `xcrun -sdk macosx metal -std=macos-metal2.3 -c` (218 KB AIR, exit 0). So the macos-15 failure is specific to the macos-15 Metal toolchain, not an MSL-size or MSL-content issue we can resolve from this side. This PR is the right shape regardless: the size cut is a real win, and the `metal_device.mm` warning is the right diagnostic surface for any future host that drops the XPC connection silently.

## TL;DR

```
+----------------------------------------+---------+---------+----------------------+
|                Kernel                  | Before  |  After  |       Reduction      |
+----------------------------------------+---------+---------+----------------------+
| g2p_c511 reverse-grad                  |  23,226 |  11,639 | -50.1%               |
| p2g_c509 reverse-grad                  |  37,860 |  16,318 | -56.9%               |
| mpm_grid_op_c65 reverse-grad           |  49,206 |  25,661 | -47.9%               |
| kernel_forward_velocity_c273           |  14,874 |  11,172 | -24.9%               |
| kernel_update_cartesian_space_c289     |  57,853 |   7,617 | -86.8%               |
+----------------------------------------+---------+---------+----------------------+
| Total MSL across the test              | 282,603 | 143,203 | -49.3% (-139,400 LOC)|
+----------------------------------------+---------+---------+----------------------+
```

(Numbers from a local `tests/test_grad.py::test_differentiable_push[gpu]` run with `QD_DUMP_MSL=1` `QD_OFFLINE_CACHE=0`. Test wall-clock on the same run dropped 91.9s -> 38.8s, a 58% speedup that comes from less time spent in the MSL compiler.)

## Why

Two motivations:

1. **Reduce SPIR-V codegen size waste.** The pre-PR `AdStackPushStmt` codegen emits a structured `OpSelectionMerge` / `OpBranchConditional` region per push that spirv-cross renders as ~13 MSL lines per push. For reverse-grad kernels with ~1000 pushes, that's the dominant size amplifier. Per-stack `count_var` `OpVariable Function` slots also become independent `OpPhi` mega-clusters at every enclosing loop header (700+ phis per merge). Both can be compressed without correctness change. The release-mode bounds-check (clamp + atomic-signal) on SPIR-V is currently always live; LLVM has always elided it in release; aligning the gates lets release builds skip the per-push branch entirely.

2. **Make Metal pipeline-create failures self-describing.** When Apple's MSL compiler service drops the XPC connection mid-compile, `newComputePipelineStateWithFunction:error:` returns `nil` with `error == nil`. The pre-PR path silently returned `nullptr`; the user only saw the generic `runtime.cpp:298 RhiResult=-1` line with no kernel name or byte size. The new path warn-logs the kernel name and cross-compiled MSL byte size, so any future investigator reading CI artifacts immediately sees which kernel hit the path.

## Mechanism end-to-end

### 1. AdStackPushStmt: clamp + OpSelect instead of structured if-then-else

`quadrants/codegen/spirv/spirv_codegen.cpp::TaskCodegen::visit(AdStackPushStmt*)` previously emitted a structured `OpSelectionMerge` / `OpBranchConditional` region around every push, with the then-branch doing the in-bounds store and the else-branch publishing the overflow signal. The new emit folds the entire region into:

1. `clamped_idx = GLSLstd450UMin(count, max_size - 1)`
2. unconditional store to `primal[clamped_idx]` (and `adjoint[clamped_idx] = 0` for heap_float)
3. unconditional `count++`
4. `signal = OpSelect(count >= max_size, stack_id+1, 0)`
5. unconditional `OpAtomicUMax(overflow_buffer[0], signal)`

The clamp keeps the OpAccessChain in-bounds; the atomic-max with 0 is a no-op when the stack didn't overflow, so the host-readable flag still ends up at `stack_id + 1` only when an actual overflow happened. spirv-cross emits this as straight-line MSL: ~5 lines per push instead of ~13.

### 2. Bounds-check gate switched to `check_out_of_bound`

The clamp + atomic-signal pair from above is now gated on `compile_config->check_out_of_bound || compile_config->debug` in SPIR-V codegen. Release builds elide the entire bounds check, mirroring LLVM's release-build push (which has always relied on `determine_ad_stack_size` producing a tight static bound and dropped the per-push runtime guard). LLVM's six adstack visitors switch their gate from `compile_config.debug` to `compile_config.check_out_of_bound` so the two backends key off the same flag.

| Backend | Bounds-check path | Release behaviour |
|---|---|---|
| LLVM (CPU / CUDA / AMDGPU) | `check_out_of_bound` -> `stack_init` / `stack_push` runtime calls | inline ops, no overflow flag |
| SPIR-V (Metal / Vulkan) | `check_out_of_bound \|\| debug` -> clamp + OpAtomicUMax signal | unconditional store, no overflow flag |

`CompileConfig::fit()` already promotes `debug=True` to `check_out_of_bound=True`, so existing `qd.init(debug=True)` users see no behaviour change. Users who explicitly set `qd.init(check_out_of_bound=True, debug=False)` now also get the bounds check on LLVM, which they didn't before. The OR with `debug` in the SPIR-V gate preserves the `qd.init(debug=True)` path on Metal / Vulkan, where `Program::init` force-disables `check_out_of_bound` because those arches lack `Extension::assertion`.

### 3. Shared count-array OpVariable for adstack `count_var`

Each adstack `count_var` used to be its own `OpVariable Function` of type `uint`. spirv-opt's `LocalMultiStoreElim` / `SSARewrite` promoted each into its own SSA chain, which became a separate `OpPhi` at every enclosing loop header. spirv-cross then emitted each phi as one `uint _N;` forward-decl + one `_N = _N;` alias copy per predecessor branch. Reverse-grad kernels with hundreds of adstacks crossing a single loop accumulated phi mega-clusters of 700+ entries per loop header.

This PR replaces the per-stack scalar OpVariable with a single Function-scope `uint[num_ad_stacks_]` array, allocated lazily on first `ad_stack_count_ptr(stack_id)` call and indexed by `OpAccessChain` per push / pop / load-top. spirv-opt's mem2reg passes do not promote OpAccessChain into an aggregate, so the slots stay memory-backed and never become per-stack phis. The array is sized from a pre-pass scan that counts `AdStackAllocaStmt` nodes (`num_ad_stacks_`).

This is the single biggest lever: `kernel_update_cartesian_space_c289_0_reverse_grad` drops from 57,853 MSL lines to 7,617 (-87%) entirely from this change.

### 4. Metal pipeline / library failure: `QD_WARN` + `nullptr` return (not `QD_ERROR`)

`quadrants/rhi/metal/metal_device.mm::create_compute_pipeline` and `MetalDevice::get_mtl_library` previously took the `nil pipeline + nil NSError` path silently and returned `nullptr` (or, on the `err != nil` path, called `RHI_LOG_ERROR` and returned `nullptr`). The new path logs at WARN level with `QD_WARN`, including the kernel name (where available) and cross-compiled MSL byte size:

```
[W ...] [metal_device.mm:create_compute_pipeline@206] Apple's Metal compiler service
rejected the compute-pipeline build for kernel 'g2p_c511_0_reverse_grad_0_t00'
(cross-compiled MSL size: 689472 bytes) without returning a structured error. The XPC
service drops its connection in this shape; the underlying cause is host-toolchain-
specific and is not recoverable from this side.
[E ...] [runtime.cpp:CompiledQuadrantsKernel@298] Failed to create pipeline ... RhiResult=-1
```

`QD_WARN` rather than `QD_ERROR` is critical: `QD_ERROR` ends with `throw s` (where `s` is a bare `std::string`), and `MetalDevice::create_pipeline` is declared `noexcept` and only catches `std::exception` derivatives. A throw of `std::string` here would cross the `noexcept` boundary and trip `std::terminate()`, replacing the existing clean Python `RuntimeError` translation with a fatal process abort. With `QD_WARN`, no exception is thrown inside the noexcept function; the `nullptr` return is converted by the caller to `RhiResult::error`, the `runtime.cpp:298 QD_ERROR_IF` then throws `std::string`, the existing `pybind11` translator (`quadrants/python/py_exception_translator.cpp`) catches it and raises `PyExc_RuntimeError`. Verified empirically by force-injecting the failure path locally and observing the Python-level `RuntimeError` exception.

The wording deliberately does not assert a specific cause (size, construct, driver bug, ...). The XPC connection drop is observable from this side; the actual reason in the toolchain is not.

## Per-backend coverage matrix

| Backend | Adstack push shrink | Bounds-check gate | Count-array shared | Metal warn-log |
|---|---|---|---|---|
| arm64 / x64 (LLVM CPU) | N/A (LLVM emits inline) | switched to `check_out_of_bound` | N/A | N/A |
| CUDA / AMDGPU (LLVM GPU) | N/A | switched to `check_out_of_bound` | N/A | N/A |
| Vulkan (SPIR-V) | clamp + OpSelect | `check_out_of_bound \|\| debug` | yes | N/A |
| Metal (SPIR-V) | clamp + OpSelect | `check_out_of_bound \|\| debug` | yes | yes |

## Tests

### `tests/python/test_adstack.py::test_adstack_overflow_raises`

Existing test, kept on `debug=True`. Verifies that an adstack push past the published `max_size` raises `RuntimeError("[Aa]dstack overflow")` on the next `qd.sync()`. `debug=True` implies `check_out_of_bound=True` via `CompileConfig::fit`, so the bounds-check codepath is live.

### `tests/python/test_adstack.py::test_adstack_overflow_raises_check_oob_explicit` (new)

Same overflow scenario as the test above but with `check_out_of_bound=True` set explicitly without `debug=True`. Pins the gating to `check_out_of_bound` rather than `debug`: a release-build user who explicitly opts into bounds-checks gets the same `RuntimeError` as a debug-mode user. Excluded on Metal / Vulkan because `Program::init` force-disables `check_out_of_bound` on arches without `Extension::assertion`, so the explicit-flag spelling alone cannot light up the bounds check there.

### `tests/python/test_adstack.py::test_adstack_overflow_flag_resets_after_catch`

Existing test, unchanged. Pins that `check_adstack_overflow()` clears the flag after raising so a subsequent `qd.sync()` returns normally.

### Local AD test status with `QD_OFFLINE_CACHE=0`

1214 tests pass on this branch (`tests/python/test_adstack.py` plus the broader `test_ad_*.py` files) across `arch=arm64`, `arch=metal-2`, `arch=vulkan-0`. Same numbers on pristine `origin/main`.

## Side-effect audit

| Concern | Where checked | Verdict |
|---|---|---|
| Offline cache key | `compile_config.h::check_out_of_bound` is already part of the config feeding the cache key; no schema change | OK |
| `task_attribs.ad_stack` serialisation | Layout unchanged: `per_thread_stride_*_compile_time` and `allocas[]` populated identically | OK |
| `info.count_var` users | All loads / stores go through `load_variable` / `store_variable` which accept `kVariablePtr` whether the underlying is a fresh `OpVariable` or an `OpAccessChain` element | OK |
| Adstack overflow signal | `OpAtomicUMax(buffer, 0)` is a no-op for the host-visible value, so the runtime still observes a clear flag iff some thread actually overflowed | OK |
| Reverse-pass count semantics | `count++` is now unconditional, so push and pop are balanced even when the in-bounds check would have skipped the increment. `LoadTop*/AccAdjoint` already clamp via UMin so an overflowed count of UINT_MAX still produces a clamped in-bounds index | OK |
| LLVM `compile_config.debug` integer-overflow checks (BinaryOpStmt / shift sites) | Untouched - still gate on `debug` (`codegen_llvm.cpp` lines 503/514/525/560); only the six adstack visitors switched to `check_out_of_bound` | OK |
| Vulkan push-constant / descriptor binding layout | Unchanged | OK |
| `metal_device.mm` raster-fallback site (`build_mtl_render_pipeline`) | This PR does NOT touch the raster site - it still uses the pre-PR `RHI_LOG_ERROR` + silent-on-`err==nil` behaviour. Out of scope for this PR; flagged here so the audit table matches the diff | Untouched (intentional) |
| Process-abort regression on the new metal `nil err` path | Verified empirically: with `QD_WARN` + `nullptr` return, force-injecting the path produces a Python `RuntimeError` (not `std::terminate`) | OK |
