### PR TITLE
[Bug] Fix: promote Ndarray to AnyArray in build_Name for flattened struct fields

### DIFF
--- a/python/quadrants/lang/ast/ast_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformer.py
@@ -86,6 +86,10 @@ class ASTTransformer(Builder):
         if not pruning.enforcing and not ctx.expanding_dataclass_call_parameters and node.id.startswith("__qd_"):
             ctx.global_context.pruning.mark_used(ctx.func.func_id, node.id)
         node.violates_pure, node.ptr, node.violates_pure_reason = ctx.get_var_by_name(node.id)
+        # Flattened struct fields (``__qd_foo__qd_bar``) injected by ``populate_global_vars_from_dataclass`` are raw
+        # ``Ndarray`` instances.  ``build_Attribute`` already promotes these via ``_promote_ndarray_if_declared`` but
+        # the flattened-name path bypasses ``build_Attribute`` entirely, so we must promote here too.
+        node.ptr = ASTTransformer._promote_ndarray_if_declared(ctx, node.ptr)
         if isinstance(node, (ast.stmt, ast.expr)) and isinstance(node.ptr, Expr):
             node.ptr.dbg_info = _qd_core.DebugInfo(ctx.get_pos_info(node))
             node.ptr.ptr.set_dbg_info(node.ptr.dbg_info)

--- a/tests/python/test_frozen_dc_dispatch_cache.py
+++ b/tests/python/test_frozen_dc_dispatch_cache.py
@@ -325,3 +325,43 @@ def test_frozen_dc_kernel_correct_after_reset():
     a2 = qd.ndarray(qd.i32, shape=(4,))
     fill(State(a=a2), 20)
     np.testing.assert_array_equal(a2.to_numpy(), [20, 20, 20, 20])
+
+
+# ---------------------------------------------------------------------------
+# Regression: qd.grouped() on flattened struct ndarray field after field→ndarray switch.
+# ---------------------------------------------------------------------------
+
+
+@test_utils.test(arch=qd.cpu)
+def test_grouped_on_struct_ndarray_after_field_to_ndarray_switch():
+    """Frozen-dataclass struct fields resolved via the flattened-name path (build_Name) must be promoted to AnyArray
+    just like the build_Attribute path does.  Without the fix in build_Name, qd.grouped() on a struct ndarray field
+    raises TypeError after a field→ndarray backend switch because the raw ScalarNdarray is not recognized by
+    begin_frontend_struct_for.
+    """
+
+    @dataclasses.dataclass(frozen=True)
+    class Info:
+        weights: qd.Tensor
+
+    @qd.kernel
+    def sum_via_grouped(info: qd.template(), out: qd.types.ndarray()):
+        for I in qd.grouped(info.weights):
+            out[0] += info.weights[I]
+
+    # Cycle 1: field backend
+    w1 = qd.field(qd.f32, shape=(4,))
+    w1.fill(1.0)
+    o1 = qd.ndarray(qd.f32, shape=(1,))
+    sum_via_grouped(Info(weights=qd.Tensor(w1)), o1)
+    np.testing.assert_allclose(o1.to_numpy(), [4.0])
+
+    qd.reset()
+    qd.init(arch=qd.cpu)
+
+    # Cycle 2: ndarray backend — this is the case that failed before the fix.
+    w2 = qd.ndarray(qd.f32, shape=(4,))
+    w2.fill(2.0)
+    o2 = qd.ndarray(qd.f32, shape=(1,))
+    sum_via_grouped(Info(weights=qd.Tensor(w2)), o2)
+    np.testing.assert_allclose(o2.to_numpy(), [8.0])

--- a/tests/python/test_tensor_annotation.py
+++ b/tests/python/test_tensor_annotation.py
@@ -96,6 +96,21 @@ def test_tensor_accepts_field():
     np.testing.assert_array_equal(a.to_numpy(), [0, 10, 20, 30])
 
 
+@test_utils.test(arch=qd.cpu)
+def test_tensor_accepts_raw_field():
+    """A kernel parameter annotated ``qd.Tensor`` also accepts a raw ``qd.field()`` (not wrapped in ``qd.Tensor``).
+    The raw Field falls through to the template path internally."""
+    a = qd.field(qd.i32, shape=(4,))
+
+    @qd.kernel
+    def fill(x: qd.Tensor):
+        for i in range(4):
+            x[i] = i * 10
+
+    fill(a)
+    np.testing.assert_array_equal(a.to_numpy(), [0, 10, 20, 30])
+
+
 # ----------------------------------------------------------------------------
 # Cross-call dispatch: same kernel object, both backends, separate cache entries
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
populate_global_vars_from_dataclass stores raw unwrapped Ndarray instances in global_vars under flattened names (__qd_foo__qd_bar). These resolve via build_Name, which—unlike build_Attribute—was missing the _promote_ndarray_if_declared call. This caused qd.grouped() and struct-for loops to receive raw ScalarNdarray objects instead of AnyArray proxies, triggering a TypeError in begin_frontend_struct_for.

The bug is only observable after a field→ndarray backend switch (gs.destroy() + gs.init()) because in field-only mode the raw values are Field subclasses that pass the isinstance check directly.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
