### PR TITLE
[CI] Add CI check that PR changes have test coverage

### DIFF
--- a/.github/workflows/check_test_coverage.yml
+++ b/.github/workflows/check_test_coverage.yml
@@ -1,0 +1,110 @@
+name: Check test coverage for changes
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+jobs:
+  check-test-coverage:
+    name: Check test coverage for changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Wait for builds to finish (dead-reckoning), to save AI cost if someone pushes many commits in a row
+        run: sleep 1800
+
+      - name: Collect diffs and file lists
+        id: changed
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          MERGE_BASE=$(git merge-base "origin/$BASE_REF" HEAD)
+
+          # Diff of source-only files (excluding tests/, benchmarks/, docs/, scripts/, misc/)
+          git diff "$MERGE_BASE...HEAD" \
+            -- '*.py' '*.cpp' '*.h' '*.hpp' '*.c' '*.cc' \
+            ':!tests/' ':!benchmarks/' ':!docs/' ':!scripts/' ':!misc/' \
+            > /tmp/source_diff.patch
+
+          # List of ALL changed files in the PR (including tests)
+          git diff --name-only "$MERGE_BASE...HEAD" > /tmp/all_changed_files.txt
+
+          # List of changed test files only
+          git diff --name-only "$MERGE_BASE...HEAD" -- 'tests/' > /tmp/changed_test_files.txt
+
+          if [ ! -s /tmp/source_diff.patch ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No source files changed (only tests/docs/scripts/etc)."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Source diff: $(wc -l < /tmp/source_diff.patch) lines"
+            echo "All changed files: $(wc -l < /tmp/all_changed_files.txt)"
+            echo "Changed test files: $(wc -l < /tmp/changed_test_files.txt)"
+          fi
+
+      - name: Install Cursor CLI
+        if: steps.changed.outputs.skip != 'true'
+        run: |
+          curl https://cursor.com/install -fsS | bash
+          echo "$HOME/.cursor/bin" >> $GITHUB_PATH
+
+      - name: Check test coverage with Cursor agent
+        if: steps.changed.outputs.skip != 'true'
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_KEY_HUGH }}
+        run: |
+          RESULT=$(agent -p "$(cat <<'PROMPT'
+          You are checking whether code changes in a PR have adequate test coverage.
+
+          Inputs:
+          - /tmp/source_diff.patch — unified diff of NON-TEST source files changed in this PR (.py, .cpp, .h, etc., excluding tests/)
+          - /tmp/all_changed_files.txt — list of ALL files changed in this PR
+          - /tmp/changed_test_files.txt — list of test files changed/added in this PR
+
+          Your task:
+          1. Read the source diff to understand what functional code was added or modified.
+          2. Read the changed test files list to see what tests were added or modified in this PR.
+          3. For each meaningful source change (new function, new class, new method, changed behavior, new module), determine whether there is a corresponding test — either:
+             a. An existing test file in the repo (under tests/) that already covers that code, OR
+             b. A new/modified test file in this PR that covers that code.
+          4. Use the repo structure to find existing tests. The repo layout is:
+             - Python source: python/quadrants/
+             - Python tests: tests/python/
+             - C++ source: quadrants/ (subdirs: codegen, ir, runtime, transforms, etc.)
+             - C++ tests: tests/cpp/ (mirrors the source subdirs)
+             Test files are typically named test_<feature>.py or test_<feature>.cpp.
+
+          What to flag:
+          - New public functions/methods/classes with no test coverage at all
+          - New modules/files with no corresponding test file
+          - Significant behavior changes (new branches, new error handling) with no test for the new behavior
+
+          What NOT to flag:
+          - Pure refactors that don't change behavior (renames, moves, reformatting)
+          - Changes to internal/private helpers that are indirectly tested through public API tests
+          - Trivial changes (imports, type hints, comments, docstrings, logging)
+          - Config files, build files, CI files
+          - Changes to test infrastructure itself (conftest.py, test utilities)
+          - Bug fixes where the fix is obviously correct and narrow
+
+          Be pragmatic. Not every line needs a test. Focus on substantial untested additions.
+          Do NOT modify any files.
+          Stop after finding 5 violations.
+
+          If there are NO violations, your final output must start with the word PASS.
+          If there ARE violations, your final output must start with the word FAIL, followed by a list of violations (up to 5) in the format: <filepath>:<function_or_class>: <what is untested>
+          PROMPT
+          )" --model claude-4.6-opus-high-thinking --mode ask --output-format text --trust)
+
+          echo "$RESULT"
+          if echo "$RESULT" | grep -qE "^FAIL([[:space:]]|$)"; then
+            exit 1
+          fi

--- a/.github/workflows/check_test_coverage.yml
+++ b/.github/workflows/check_test_coverage.yml
@@ -30,7 +30,7 @@ jobs:
 
           # Diff of source-only files (excluding tests/, benchmarks/, docs/, scripts/, misc/)
           git diff "$MERGE_BASE...HEAD" \
-            -- '*.py' '*.cpp' '*.h' '*.hpp' '*.c' '*.cc' \
+            -- '*.py' '*.cpp' '*.h' '*.hpp' '*.c' '*.cc' '*.cu' \
             ':!tests/' ':!benchmarks/' ':!docs/' ':!scripts/' ':!misc/' \
             > /tmp/source_diff.patch
 

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -140,3 +140,13 @@ The check runs only on lines changed in the PR and reports up to 3 violations. T
 ### Deleted comments check (`check_deleted_comments.yml`)
 
 Uses an AI agent to check that comments and docstrings have not been unnecessarily deleted. Reports up to 10 violations. This check is delayed by 30 minutes, to avoid running repeatedly if multiple commits pushed with a short delay between each.
+
+### Test coverage check (`check_test_coverage.yml`)
+
+Uses an AI agent to verify that new or modified source code in a PR has corresponding test coverage. The agent examines the diff of non-test source files and cross-references them against test files in the repo (existing or added in the PR). It flags up to 5 violations such as:
+
+- New public functions, methods, or classes with no test coverage
+- New modules with no corresponding test file
+- Significant behavior changes with no test for the new behavior
+
+The check is pragmatic: it does not flag pure refactors, trivial changes (imports, type hints, comments), private helpers tested indirectly through public API tests, or narrow bug fixes. This check is delayed by 30 minutes, to avoid running repeatedly if multiple commits pushed with a short delay between each.

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -143,10 +143,4 @@ Uses an AI agent to check that comments and docstrings have not been unnecessari
 
 ### Test coverage check (`check_test_coverage.yml`)
 
-Uses an AI agent to verify that new or modified source code in a PR has corresponding test coverage. The agent examines the diff of non-test source files and cross-references them against test files in the repo (existing or added in the PR). It flags up to 5 violations such as:
-
-- New public functions, methods, or classes with no test coverage
-- New modules with no corresponding test file
-- Significant behavior changes with no test for the new behavior
-
-The check is pragmatic: it does not flag pure refactors, trivial changes (imports, type hints, comments), private helpers tested indirectly through public API tests, or narrow bug fixes. This check is delayed by 30 minutes, to avoid running repeatedly if multiple commits pushed with a short delay between each.
+Uses an AI agent to verify that new or modified source code in a PR has corresponding test coverage. The agent examines the diff of non-test source files and cross-references them against test files in the repo (existing or added in the PR). It flags up to 5 violations. This check is delayed by 30 minutes, to avoid running repeatedly if multiple commits pushed with a short delay between each.


### PR DESCRIPTION
Uses Cursor agent (same pattern as check_wrapping and check_deleted_comments) to verify that new/modified source code has corresponding tests.

Issue: #

### Brief Summary

Sanity checking:
- simple dummy test, failed correctly https://github.com/Genesis-Embodied-AI/hugh-test-github-actions/actions/runs/25166668183/job/73774562217?pr=16
- forked @alanray-tech 's BufferView PR. Passed ok https://github.com/Genesis-Embodied-AI/quadrants/actions/runs/25166391210/job/73773593058?pr=593
- forked @duburcqa precise change. Passed ok https://github.com/Genesis-Embodied-AI/quadrants/actions/runs/25166933747/job/73775489370
- my own zero-copy PR failed https://github.com/Genesis-Embodied-AI/quadrants/actions/runs/25166897505/job/73775360928

So:
- shows that it can sometimes fail branches (the simple test + my own branch)
- shows that it doesnt just needlessly flag stuff (which would get annoying...)

copilot:summary

### Walkthrough

copilot:walkthrough
