### PR TITLE
[DONOTMERGE][Perf] Skip _recursive_set_args for all-Field frozen dataclass structs

### DIFF
--- a/python/quadrants/lang/_func_base.py
+++ b/python/quadrants/lang/_func_base.py
@@ -143,6 +143,15 @@ def _get_frozen_dc_unwrapped(v: Any, fields_dict: dict) -> dict[str, Any]:
         object.__setattr__(v, "_qd_dc_unwrapped", unwrapped)
     except AttributeError:
         pass
+    # Cache whether ALL unwrapped values are Fields (zero launch-context slots).  This is a property of the instance
+    # alone — independent of which kernel or field-subset is active — so a simple boolean suffices and survives
+    # qd.reset() harmlessly (the boolean remains valid as long as the instance is alive).
+    if getattr(v, "_qd_all_field", None) is None:
+        _all_field = all(not isinstance(fv, Ndarray) for fv in unwrapped.values())
+        try:
+            object.__setattr__(v, "_qd_all_field", _all_field)
+        except (AttributeError, TypeError):
+            pass
     return unwrapped
 
 

--- a/python/quadrants/lang/kernel.py
+++ b/python/quadrants/lang/kernel.py
@@ -491,6 +491,8 @@ class Kernel(FuncBase):
                     template_num += 1
                     i_out += 1
                     continue
+                if getattr(val, "_qd_all_field", False):
+                    continue
                 if self.graph_do_while_arg is not None and self.arg_metas[i_in].name == self.graph_do_while_arg:
                     self._graph_do_while_cpp_arg_id = i_out - template_num
                 num_args_, is_launch_ctx_cacheable_ = self._recursive_set_args(


### PR DESCRIPTION
Cache a _qd_all_field boolean on frozen dataclass instances indicating whether all unwrapped field values are Fields (not Ndarrays).  This is a property of the instance alone — independent of which kernel or field-subset is active — so it survives qd.reset() harmlessly.

In kernel.py, skip _recursive_set_args entirely for args where _qd_all_field is True, eliminating even function-call overhead.

On the anymal_uniform_kinematic benchmark (field backend), this eliminates a -11% regression caused by struct-class annotations replacing qd.template() in kernel signatures.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
