### PR TITLE
[Misc] Forward copy= through qd.Tensor, add copy=None option

### DIFF
--- a/docs/source/user_guide/interop.md
+++ b/docs/source/user_guide/interop.md
@@ -79,12 +79,13 @@ Quadrants' zero-copy interop has been designed with **PyTorch as the first-class
 ```python
 f = qd.field(qd.f32, shape=(1024,))
 
-view  = f.to_torch(copy=False)  # zero-copy view: aliases f's memory
+view  = f.to_torch(copy=False)  # zero-copy view: aliases f's memory, or ValueError
+auto  = f.to_torch(copy=None)   # zero-copy if possible, otherwise copy
 clone = f.to_torch(copy=True)   # independent copy (default)
-auto  = f.to_torch()            # same as copy=True
+plain = f.to_torch()            # same as copy=True
 ```
 
-When using `copy=False`, modifications via the view are visible to subsequent Quadrants kernel reads, and vice-versa. The view stays valid until the underlying storage is reallocated -- typically on `qd.init()` or `qd.reset()`, after which a fresh call to `to_torch(copy=False)` / `to_numpy(copy=False)` returns a new view.
+When using `copy=False` or `copy=None` (when zero-copy succeeds), modifications via the view are visible to subsequent Quadrants kernel reads, and vice-versa. The view stays valid until the underlying storage is reallocated -- typically on `qd.init()` or `qd.reset()`, after which a fresh call to `to_torch(copy=False)` / `to_numpy(copy=False)` returns a new view.
 
 ### When zero-copy is available
 
@@ -105,9 +106,10 @@ On **NumPy >= 2.1**, `to_numpy(copy=False)` returns a **writable** array (via a 
 | Value | Behaviour |
 |---|---|
 | `True` (default) | Independent copy via kernel. |
+| `None` | Zero-copy view via DLPack when available, otherwise falls back to a copy silently. |
 | `False` | Zero-copy view via DLPack, or `ValueError` if zero-copy is unsupported for this backend/dtype. |
 
-The default `copy=True` always returns a buffer that is safe to mutate without affecting the field/ndarray.
+The default `copy=True` always returns a buffer that is safe to mutate without affecting the field/ndarray. Use `copy=None` when you want zero-copy as a best-effort optimisation without having to handle exceptions — it gives you a view when possible and a safe copy otherwise.
 
 ### Examples
 
@@ -304,8 +306,9 @@ print(x.grad[0])  # 4.0
 |--------|-------------|-------------------|---------------------|
 | `to_numpy()` / `from_numpy()` (default) | yes | yes | yes |
 | `to_torch()` / `from_torch()` (default) | yes | yes | yes |
+| `to_numpy(copy=None)` / `to_torch(copy=None)` | no when possible, yes otherwise | yes | yes |
 | `to_numpy(copy=False)` / `to_torch(copy=False)` | no (DLPack view) | yes | yes |
 | `to_dlpack()` | no (raw capsule) | yes | yes |
 | Direct pass-through | no | no | yes (as kernel arg) |
 
-The `copy` parameter is supported on `to_numpy()` and `to_torch()` for `ScalarField`, `MatrixField` (and `VectorField`), `StructField`, and all `Ndarray` types. See [Zero-copy interop via DLPack](#zero-copy-interop-via-dlpack) for the support matrix and lifetime rules.
+The `copy` parameter is supported on `to_numpy()` and `to_torch()` for `ScalarField`, `MatrixField` (and `VectorField`), `StructField`, `qd.Tensor`, and all `Ndarray` types. See [Zero-copy interop via DLPack](#zero-copy-interop-via-dlpack) for the support matrix and lifetime rules.

--- a/docs/source/user_guide/tensor.md
+++ b/docs/source/user_guide/tensor.md
@@ -168,6 +168,10 @@ clone = a.to_torch(copy=True)    # independent copy (default)
 | `True` (default) | Independent copy via kernel. Safe to mutate freely. |
 | `False` | Zero-copy DLPack view, or `ValueError` if unsupported for this backend/dtype. |
 
+`copy=False` avoids both the buffer allocation and the copy kernel entirely — the returned numpy array or torch tensor points directly at Quadrants' existing memory. For a large tensor this eliminates a potentially expensive memcpy and a device-side kernel launch. Writes through the view are immediately visible to subsequent Quadrants kernels (and vice versa), removing the need for `to_torch` → modify → `from_torch` round-trips.
+
+The tradeoff is lifetime coupling: the view is invalidated on `qd.reset()` or `qd.init()`, and on GPU you must be mindful of stream synchronisation when both frameworks write to the same buffer.
+
 This works identically on both backends. For the full support matrix (which backends/dtypes qualify, lifetime caveats, Metal synchronisation) see [`interop`](interop.md#zero-copy-interop-via-dlpack).
 
 Gradient buffers behave identically: `a.grad.to_numpy()` returns the canonical view of the gradient.

--- a/docs/source/user_guide/tensor.md
+++ b/docs/source/user_guide/tensor.md
@@ -151,6 +151,25 @@ a.from_torch(out)
 
 The exact same surface is available on both backends — switching `qd.tensor(..., backend=qd.Backend.FIELD/NDARRAY)` does not require any other code change at the call site.
 
+### Zero-copy with `copy=False`
+
+`to_numpy()` and `to_torch()` accept a keyword-only `copy` argument:
+
+```python
+a = qd.tensor(qd.f32, shape=(1024,))
+a.fill(1.0)
+
+view  = a.to_torch(copy=False)   # zero-copy: aliases a's memory
+clone = a.to_torch(copy=True)    # independent copy (default)
+```
+
+| Value | Behaviour |
+|---|---|
+| `True` (default) | Independent copy via kernel. Safe to mutate freely. |
+| `False` | Zero-copy DLPack view, or `ValueError` if unsupported for this backend/dtype. |
+
+This works identically on both backends. For the full support matrix (which backends/dtypes qualify, lifetime caveats, Metal synchronisation) see [`interop`](interop.md#zero-copy-interop-via-dlpack).
+
 Gradient buffers behave identically: `a.grad.to_numpy()` returns the canonical view of the gradient.
 
 ## Annotating kernel arguments: `qd.Tensor`

--- a/docs/source/user_guide/tensor.md
+++ b/docs/source/user_guide/tensor.md
@@ -159,18 +159,22 @@ The exact same surface is available on both backends — switching `qd.tensor(..
 a = qd.tensor(qd.f32, shape=(1024,))
 a.fill(1.0)
 
-view  = a.to_torch(copy=False)   # zero-copy: aliases a's memory
+view  = a.to_torch(copy=False)   # zero-copy: aliases a's memory, or ValueError
+auto  = a.to_torch(copy=None)    # zero-copy if possible, otherwise copy
 clone = a.to_torch(copy=True)    # independent copy (default)
 ```
 
 | Value | Behaviour |
 |---|---|
 | `True` (default) | Independent copy via kernel. Safe to mutate freely. |
+| `None` | Zero-copy when available, otherwise falls back to a copy silently. |
 | `False` | Zero-copy DLPack view, or `ValueError` if unsupported for this backend/dtype. |
 
-`copy=False` avoids both the buffer allocation and the copy kernel entirely — the returned numpy array or torch tensor points directly at Quadrants' existing memory. For a large tensor this eliminates a potentially expensive memcpy and a device-side kernel launch. Writes through the view are immediately visible to subsequent Quadrants kernels (and vice versa), removing the need for `to_torch` → modify → `from_torch` round-trips.
+`copy=False` and `copy=None` avoid both the buffer allocation and the copy kernel when zero-copy is available — the returned numpy array or torch tensor points directly at Quadrants' existing memory. For a large tensor this eliminates a potentially expensive memcpy and a device-side kernel launch. Writes through the view are immediately visible to subsequent Quadrants kernels (and vice versa), removing the need for `to_torch` → modify → `from_torch` round-trips.
 
-The tradeoff is lifetime coupling: the view is invalidated on `qd.reset()` or `qd.init()`, and on GPU you must be mindful of stream synchronisation when both frameworks write to the same buffer.
+The difference between `False` and `None`: `copy=False` raises `ValueError` when zero-copy is not supported (e.g. unsupported dtype or GPU-to-numpy), while `copy=None` silently falls back to a kernel copy in those cases. Use `copy=None` when you want zero-copy as a best-effort optimisation without having to handle exceptions.
+
+The tradeoff of zero-copy is lifetime coupling: the view is invalidated on `qd.reset()` or `qd.init()`, and on GPU you must be mindful of stream synchronisation when both frameworks write to the same buffer.
 
 This works identically on both backends. For the full support matrix (which backends/dtypes qualify, lifetime caveats, Metal synchronisation) see [`interop`](interop.md#zero-copy-interop-via-dlpack).
 

--- a/python/quadrants/_tensor_wrapper.py
+++ b/python/quadrants/_tensor_wrapper.py
@@ -190,13 +190,19 @@ class Tensor:
     # ------------------------------------------------------------------
 
     def to_numpy(self, dtype: typing.Any = None, *, copy: typing.Optional[bool] = True) -> typing.Any:
-        return self._impl.to_numpy(dtype=dtype, copy=copy)
+        kw: dict[str, typing.Any] = {"copy": copy}
+        if dtype is not None:
+            kw["dtype"] = dtype
+        return self._impl.to_numpy(**kw)
 
     def from_numpy(self, arr: typing.Any) -> None:
         self._impl.from_numpy(arr)
 
     def to_torch(self, device: typing.Any = None, *, copy: typing.Optional[bool] = True) -> typing.Any:
-        return self._impl.to_torch(device=device, copy=copy)
+        kw: dict[str, typing.Any] = {"copy": copy}
+        if device is not None:
+            kw["device"] = device
+        return self._impl.to_torch(**kw)
 
     def from_torch(self, arr: typing.Any) -> None:
         self._impl.from_torch(arr)

--- a/python/quadrants/_tensor_wrapper.py
+++ b/python/quadrants/_tensor_wrapper.py
@@ -189,18 +189,14 @@ class Tensor:
     # Interop forwards (layout-aware on both impls already)
     # ------------------------------------------------------------------
 
-    def to_numpy(self, dtype: typing.Any = None) -> typing.Any:
-        if dtype is None:
-            return self._impl.to_numpy()
-        return self._impl.to_numpy(dtype=dtype)
+    def to_numpy(self, dtype: typing.Any = None, *, copy: bool = True) -> typing.Any:
+        return self._impl.to_numpy(dtype=dtype, copy=copy)
 
     def from_numpy(self, arr: typing.Any) -> None:
         self._impl.from_numpy(arr)
 
-    def to_torch(self, device: typing.Any = None) -> typing.Any:
-        if device is None:
-            return self._impl.to_torch()
-        return self._impl.to_torch(device=device)
+    def to_torch(self, device: typing.Any = None, *, copy: bool = True) -> typing.Any:
+        return self._impl.to_torch(device=device, copy=copy)
 
     def from_torch(self, arr: typing.Any) -> None:
         self._impl.from_torch(arr)

--- a/python/quadrants/_tensor_wrapper.py
+++ b/python/quadrants/_tensor_wrapper.py
@@ -189,13 +189,13 @@ class Tensor:
     # Interop forwards (layout-aware on both impls already)
     # ------------------------------------------------------------------
 
-    def to_numpy(self, dtype: typing.Any = None, *, copy: bool = True) -> typing.Any:
+    def to_numpy(self, dtype: typing.Any = None, *, copy: typing.Optional[bool] = True) -> typing.Any:
         return self._impl.to_numpy(dtype=dtype, copy=copy)
 
     def from_numpy(self, arr: typing.Any) -> None:
         self._impl.from_numpy(arr)
 
-    def to_torch(self, device: typing.Any = None, *, copy: bool = True) -> typing.Any:
+    def to_torch(self, device: typing.Any = None, *, copy: typing.Optional[bool] = True) -> typing.Any:
         return self._impl.to_torch(device=device, copy=copy)
 
     def from_torch(self, arr: typing.Any) -> None:

--- a/python/quadrants/lang/_ndarray.py
+++ b/python/quadrants/lang/_ndarray.py
@@ -477,18 +477,22 @@ class ScalarNdarray(Ndarray):
 
         Args:
             dtype: Optional numpy dtype to cast the result to. ``None`` keeps the native ndarray dtype.
-            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise.
         """
-        if copy is False:
+        if copy is not True:
             from quadrants.lang.field import (  # pylint: disable=C0415
                 _try_zerocopy_numpy,
             )
 
-            arr = _try_zerocopy_numpy(self, copy=False, is_ndarray=True)
+            arr = _try_zerocopy_numpy(self, copy=copy, is_ndarray=True)
             if arr is not None:
                 if dtype is not None and arr.dtype != dtype:
-                    raise ValueError(f"copy=False is incompatible with dtype conversion ({arr.dtype} -> {dtype})")
-                return arr
+                    if copy is False:
+                        raise ValueError(f"copy=False is incompatible with dtype conversion ({arr.dtype} -> {dtype})")
+                    # copy=None: fall through to the copy path for dtype conversion
+                else:
+                    return arr
 
         arr = self._ndarray_to_numpy()
         if dtype is not None and arr.dtype != dtype:
@@ -508,14 +512,17 @@ class ScalarNdarray(Ndarray):
         view just like ``to_numpy()`` does.
 
         Args:
-            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise.
         """
-        if copy is False:
+        if copy is not True:
             from quadrants.lang.field import (  # pylint: disable=C0415
                 _try_zerocopy_torch,
             )
 
-            return _try_zerocopy_torch(self, copy=copy, device=device, is_ndarray=True)
+            result = _try_zerocopy_torch(self, copy=copy, device=device, is_ndarray=True)
+            if result is not None:
+                return result
 
         import torch  # pylint: disable=C0415
 

--- a/python/quadrants/lang/field.py
+++ b/python/quadrants/lang/field.py
@@ -204,12 +204,15 @@ def _can_zerocopy_field(field: "Field", *, is_scalar: bool = False, is_ndarray: 
 def _try_zerocopy_torch(field: "Field", *, copy, device=None, is_scalar: bool = False, is_ndarray: bool = False):
     """Try to return a zero-copy torch tensor via DLPack.
 
-    Only called when ``copy is False``. Returns the tensor on success. Raises ``ValueError`` when zero-copy is not
-    available. Does NOT call ``torch.mps.synchronize()`` -- the caller is expected to handle MPS sync for the copy=True
-    (kernel-copy) path instead.
+    Returns the tensor on success. When ``copy is False``, raises ``ValueError`` if zero-copy is not available. When
+    ``copy is None``, returns ``None`` if zero-copy is not available (allowing the caller to fall back to a copy). Does
+    NOT call ``torch.mps.synchronize()`` -- the caller is expected to handle MPS sync for the copy=True (kernel-copy)
+    path instead.
     """
     if not _can_zerocopy_field(field, is_scalar=is_scalar, is_ndarray=is_ndarray):
-        raise ValueError(f"Zero-copy not available for arch={impl.current_cfg().arch.name}, dtype={field.dtype}")
+        if copy is False:
+            raise ValueError(f"Zero-copy not available for arch={impl.current_cfg().arch.name}, dtype={field.dtype}")
+        return None
 
     import torch  # pylint: disable=C0415
     import torch.utils.dlpack  # pylint: disable=C0415
@@ -217,7 +220,9 @@ def _try_zerocopy_torch(field: "Field", *, copy, device=None, is_scalar: bool = 
     try:
         tc = torch.utils.dlpack.from_dlpack(field.to_dlpack())
     except RuntimeError as e:
-        raise ValueError(f"Zero-copy not available: {e}") from None
+        if copy is False:
+            raise ValueError(f"Zero-copy not available: {e}") from None
+        return None
     if impl.current_cfg().arch == _ARCH_METAL:
         impl.get_runtime().sync()
 
@@ -228,9 +233,11 @@ def _try_zerocopy_torch(field: "Field", *, copy, device=None, is_scalar: bool = 
             requested.index is not None and tc.device.index is not None and tc.device.index != requested.index
         )
         if type_mismatch or index_mismatch:
-            raise ValueError(
-                f"copy=False is incompatible with device transfer (data on {tc.device}, requested {device})"
-            )
+            if copy is False:
+                raise ValueError(
+                    f"copy=False is incompatible with device transfer (data on {tc.device}, requested {device})"
+                )
+            return None
 
     return tc
 
@@ -431,7 +438,8 @@ class Field:
         """Converts `self` to a numpy array.
 
         Args:
-            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise.
 
         Returns:
             numpy.ndarray: The result numpy array.
@@ -444,7 +452,8 @@ class Field:
 
         Args:
             device (torch.device, optional): The desired device of returned tensor.
-            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise.
 
         Returns:
             torch.tensor: The result torch tensor.
@@ -604,14 +613,17 @@ class ScalarField(Field):
 
         Args:
             dtype: Optional target numpy dtype.
-            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise.
         """
-        if copy is False:
-            arr = _try_zerocopy_numpy(self, copy=False, is_scalar=True)
+        if copy is not True:
+            arr = _try_zerocopy_numpy(self, copy=copy, is_scalar=True)
             if arr is not None:
                 if dtype is not None and arr.dtype != dtype:
-                    raise ValueError(f"copy=False is incompatible with dtype conversion ({arr.dtype} -> {dtype})")
-                return arr
+                    if copy is False:
+                        raise ValueError(f"copy=False is incompatible with dtype conversion ({arr.dtype} -> {dtype})")
+                else:
+                    return arr
 
         if self.parent()._snode.ptr.type == _qd_core.SNodeType.dynamic:
             warn(
@@ -634,10 +646,13 @@ class ScalarField(Field):
 
         Args:
             device: Optional torch device for the returned tensor.
-            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise.
         """
-        if copy is False:
-            return _try_zerocopy_torch(self, copy=copy, device=device, is_scalar=True)
+        if copy is not True:
+            result = _try_zerocopy_torch(self, copy=copy, device=device, is_scalar=True)
+            if result is not None:
+                return result
 
         import torch  # pylint: disable=C0415
 

--- a/python/quadrants/lang/matrix.py
+++ b/python/quadrants/lang/matrix.py
@@ -1429,21 +1429,24 @@ class MatrixField(Field):
                 keep_dims=False, the resulting numpy array should skip the matrix dims with size 1. For example, a 4x1
                 or 1x4 matrix field with 5x6x7 elements results in an array of shape 5x6x7x4.
             dtype (DataType, optional): The desired data type of returned numpy array.
-            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise.
 
         Returns:
             numpy.ndarray: The result NumPy array.
         """
-        if copy is False:
-            arr = _try_zerocopy_numpy(self, copy=False)
+        if copy is not True:
+            arr = _try_zerocopy_numpy(self, copy=copy)
             if arr is not None:
                 as_vector = self.m == 1 and not keep_dims
                 expected = self.shape + ((self.n,) if as_vector else (self.n, self.m))
                 if arr.shape != expected:
                     arr = arr.reshape(expected)
                 if dtype is not None and arr.dtype != dtype:
-                    raise ValueError(f"copy=False is incompatible with dtype conversion ({arr.dtype} -> {dtype})")
-                return arr
+                    if copy is False:
+                        raise ValueError(f"copy=False is incompatible with dtype conversion ({arr.dtype} -> {dtype})")
+                else:
+                    return arr
 
         if dtype is None:
             dtype = to_numpy_type(self.dtype)
@@ -1463,18 +1466,20 @@ class MatrixField(Field):
             device (torch.device, optional): The desired device of returned tensor.
             keep_dims (bool, optional): Whether to keep the dimension after conversion.
                 See :meth:`~quadrants.lang.field.MatrixField.to_numpy` for more detailed explanation.
-            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise.
 
         Returns:
             torch.tensor: The result torch tensor.
         """
-        if copy is False:
+        if copy is not True:
             tc = _try_zerocopy_torch(self, copy=copy, device=device)
-            as_vector = self.m == 1 and not keep_dims
-            expected = self.shape + ((self.n,) if as_vector else (self.n, self.m))
-            if tc.shape != expected:
-                tc = tc.reshape(expected)
-            return tc
+            if tc is not None:
+                as_vector = self.m == 1 and not keep_dims
+                expected = self.shape + ((self.n,) if as_vector else (self.n, self.m))
+                if tc.shape != expected:
+                    tc = tc.reshape(expected)
+                return tc
 
         import torch  # pylint: disable=C0415
 
@@ -1859,7 +1864,8 @@ class MatrixNdarray(Ndarray):
         """Converts this ndarray to a ``numpy.ndarray``.
 
         Args:
-            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise.
 
         Example::
 
@@ -1871,12 +1877,14 @@ class MatrixNdarray(Ndarray):
              [[[0. 0.]
                [0. 0.]]]]
         """
-        if copy is False:
-            arr = _try_zerocopy_numpy(self, copy=False, is_ndarray=True)
+        if copy is not True:
+            arr = _try_zerocopy_numpy(self, copy=copy, is_ndarray=True)
             if arr is not None:
                 if dtype is not None and arr.dtype != dtype:
-                    raise ValueError(f"copy=False is incompatible with dtype conversion ({arr.dtype} -> {dtype})")
-                return arr
+                    if copy is False:
+                        raise ValueError(f"copy=False is incompatible with dtype conversion ({arr.dtype} -> {dtype})")
+                else:
+                    return arr
         arr = self._ndarray_matrix_to_numpy(as_vector=0)
         if dtype is not None and arr.dtype != dtype:
             arr = arr.astype(dtype)
@@ -1901,10 +1909,13 @@ class MatrixNdarray(Ndarray):
         Mirrors :meth:`MatrixField.to_torch`.
 
         Args:
-            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise.
         """
-        if copy is False:
-            return _try_zerocopy_torch(self, copy=copy, device=device, is_ndarray=True)
+        if copy is not True:
+            result = _try_zerocopy_torch(self, copy=copy, device=device, is_ndarray=True)
+            if result is not None:
+                return result
         return self._ndarray_matrix_to_torch(as_vector=0, device=device)
 
     @python_scope
@@ -2004,7 +2015,8 @@ class VectorNdarray(Ndarray):
         """Converts this vector ndarray to a ``numpy.ndarray``.
 
         Args:
-            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise.
 
         Example::
 
@@ -2016,12 +2028,14 @@ class VectorNdarray(Ndarray):
                    [[0., 0., 0.],
                     [0., 0., 0.]]], dtype=float32)
         """
-        if copy is False:
-            arr = _try_zerocopy_numpy(self, copy=False, is_ndarray=True)
+        if copy is not True:
+            arr = _try_zerocopy_numpy(self, copy=copy, is_ndarray=True)
             if arr is not None:
                 if dtype is not None and arr.dtype != dtype:
-                    raise ValueError(f"copy=False is incompatible with dtype conversion ({arr.dtype} -> {dtype})")
-                return arr
+                    if copy is False:
+                        raise ValueError(f"copy=False is incompatible with dtype conversion ({arr.dtype} -> {dtype})")
+                else:
+                    return arr
         arr = self._ndarray_matrix_to_numpy(as_vector=1)
         if dtype is not None and arr.dtype != dtype:
             arr = arr.astype(dtype)
@@ -2049,10 +2063,13 @@ class VectorNdarray(Ndarray):
         Mirrors :meth:`MatrixField.to_torch` on the vector code path.
 
         Args:
-            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns an independent copy, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise.
         """
-        if copy is False:
-            return _try_zerocopy_torch(self, copy=copy, device=device, is_ndarray=True)
+        if copy is not True:
+            result = _try_zerocopy_torch(self, copy=copy, device=device, is_ndarray=True)
+            if result is not None:
+                return result
         return self._ndarray_matrix_to_torch(as_vector=1, device=device)
 
     @python_scope

--- a/python/quadrants/lang/struct.py
+++ b/python/quadrants/lang/struct.py
@@ -555,7 +555,8 @@ class StructField(Field):
         The dictionary may be nested when converting nested structs.
 
         Args:
-            copy: ``True`` (default) returns independent copies, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns independent copies, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise (per member).
 
         Returns:
             Dict[str, Union[numpy.ndarray, Dict]]: The result NumPy array.
@@ -570,7 +571,8 @@ class StructField(Field):
 
         Args:
             device (torch.device, optional): The desired device of returned tensor.
-            copy: ``True`` (default) returns independent copies, ``False`` requires zero-copy or raises.
+            copy: ``True`` (default) returns independent copies, ``False`` requires zero-copy or raises,
+                ``None`` uses zero-copy when available and falls back to a copy otherwise (per member).
 
         Returns:
             Dict[str, Union[torch.Tensor, Dict]]: The result

--- a/tests/python/test_tensor_wrapper_surface.py
+++ b/tests/python/test_tensor_wrapper_surface.py
@@ -369,3 +369,49 @@ def test_to_torch_copy_false(backend):
     np.testing.assert_array_equal(out.numpy(), src)
     out[0] = 999.0
     assert t.to_numpy(copy=True)[0] == 999.0
+
+
+# ----------------------------------------------------------------------
+# copy=None (best-effort zero-copy)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_to_numpy_copy_none_zerocopy_when_available(backend):
+    """copy=None returns a zero-copy view on CPU with a supported dtype."""
+    t = qd.tensor(qd.f32, shape=(4,), backend=backend)
+    src = np.arange(4, dtype=np.float32)
+    t.from_numpy(src)
+    arr = t.to_numpy(copy=None)
+    np.testing.assert_array_equal(arr, src)
+    arr[0] = 999.0
+    assert t.to_numpy(copy=True)[0] == 999.0
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_to_numpy_copy_none_with_dtype_falls_back(backend):
+    """copy=None with dtype conversion silently falls back to a copy."""
+    t = qd.tensor(qd.f32, shape=(4,), backend=backend)
+    src = np.arange(4, dtype=np.float32)
+    t.from_numpy(src)
+    arr = t.to_numpy(dtype=np.float64, copy=None)
+    assert arr.dtype == np.float64
+    np.testing.assert_array_equal(arr, src.astype(np.float64))
+    arr[0] = 999.0
+    np.testing.assert_array_equal(t.to_numpy(), src)
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_to_torch_copy_none_zerocopy_when_available(backend):
+    """copy=None returns a zero-copy torch tensor on CPU with a supported dtype."""
+    torch = pytest.importorskip("torch")
+    t = qd.tensor(qd.f32, shape=(4,), backend=backend)
+    src = np.arange(4, dtype=np.float32)
+    t.from_numpy(src)
+    out = t.to_torch(copy=None)
+    np.testing.assert_array_equal(out.numpy(), src)
+    out[0] = 999.0
+    assert t.to_numpy(copy=True)[0] == 999.0

--- a/tests/python/test_tensor_wrapper_surface.py
+++ b/tests/python/test_tensor_wrapper_surface.py
@@ -320,10 +320,14 @@ def test_to_numpy_copy_true(backend):
     np.testing.assert_array_equal(t.to_numpy(), src)
 
 
+@pytest.mark.needs_torch
 @pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
 @test_utils.test(arch=qd.cpu)
 def test_to_numpy_copy_false(backend):
-    """copy=False returns a zero-copy view (CPU backend supports this)."""
+    """copy=False returns a zero-copy view (CPU backend supports this).
+
+    Marked needs_torch because Field.to_numpy(copy=False) uses DLPack which requires torch.
+    """
     t = qd.tensor(qd.f32, shape=(4,), backend=backend)
     src = np.arange(4, dtype=np.float32)
     t.from_numpy(src)
@@ -333,6 +337,7 @@ def test_to_numpy_copy_false(backend):
     assert t.to_numpy(copy=True)[0] == 999.0
 
 
+@pytest.mark.needs_torch
 @pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
 @test_utils.test(arch=qd.cpu)
 def test_to_numpy_copy_false_with_dtype_raises(backend):
@@ -343,6 +348,7 @@ def test_to_numpy_copy_false_with_dtype_raises(backend):
         t.to_numpy(dtype=np.float64, copy=False)
 
 
+@pytest.mark.needs_torch
 @pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
 @test_utils.test(arch=qd.cpu)
 def test_to_torch_copy_true(backend):
@@ -357,6 +363,7 @@ def test_to_torch_copy_true(backend):
     np.testing.assert_array_equal(t.to_numpy(), src)
 
 
+@pytest.mark.needs_torch
 @pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
 @test_utils.test(arch=qd.cpu)
 def test_to_torch_copy_false(backend):
@@ -378,8 +385,20 @@ def test_to_torch_copy_false(backend):
 
 @pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
 @test_utils.test(arch=qd.cpu)
+def test_to_numpy_copy_none_returns_correct_data(backend):
+    """copy=None never raises and returns correct data regardless of whether zero-copy is available."""
+    t = qd.tensor(qd.f32, shape=(4,), backend=backend)
+    src = np.arange(4, dtype=np.float32)
+    t.from_numpy(src)
+    arr = t.to_numpy(copy=None)
+    np.testing.assert_array_equal(arr, src)
+
+
+@pytest.mark.needs_torch
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
 def test_to_numpy_copy_none_zerocopy_when_available(backend):
-    """copy=None returns a zero-copy view on CPU with a supported dtype."""
+    """copy=None returns a zero-copy view on CPU with torch installed and a supported dtype."""
     t = qd.tensor(qd.f32, shape=(4,), backend=backend)
     src = np.arange(4, dtype=np.float32)
     t.from_numpy(src)
@@ -403,6 +422,7 @@ def test_to_numpy_copy_none_with_dtype_falls_back(backend):
     np.testing.assert_array_equal(t.to_numpy(), src)
 
 
+@pytest.mark.needs_torch
 @pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
 @test_utils.test(arch=qd.cpu)
 def test_to_torch_copy_none_zerocopy_when_available(backend):

--- a/tests/python/test_tensor_wrapper_surface.py
+++ b/tests/python/test_tensor_wrapper_surface.py
@@ -435,3 +435,80 @@ def test_to_torch_copy_none_zerocopy_when_available(backend):
     np.testing.assert_array_equal(out.numpy(), src)
     out[0] = 999.0
     assert t.to_numpy(copy=True)[0] == 999.0
+
+
+# ----------------------------------------------------------------------
+# copy=None on Matrix / Vector types
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_matrix_to_numpy_copy_none(backend):
+    """copy=None on MatrixField / MatrixNdarray returns correct data without raising."""
+    t = qd.Matrix.tensor(2, 2, qd.f32, shape=(3,), backend=backend)
+    src = np.arange(12, dtype=np.float32).reshape(3, 2, 2)
+    t.from_numpy(src)
+    arr = t.to_numpy(copy=None)
+    np.testing.assert_array_equal(arr, src)
+
+
+@pytest.mark.needs_torch
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_matrix_to_torch_copy_none(backend):
+    """copy=None on MatrixField / MatrixNdarray returns correct torch tensor."""
+    torch = pytest.importorskip("torch")
+    t = qd.Matrix.tensor(2, 2, qd.f32, shape=(3,), backend=backend)
+    src = np.arange(12, dtype=np.float32).reshape(3, 2, 2)
+    t.from_numpy(src)
+    out = t.to_torch(copy=None)
+    np.testing.assert_array_equal(out.numpy(), src)
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_matrix_to_numpy_copy_none_dtype_fallback(backend):
+    """copy=None with dtype on MatrixField / MatrixNdarray silently falls back."""
+    t = qd.Matrix.tensor(2, 2, qd.f32, shape=(3,), backend=backend)
+    src = np.arange(12, dtype=np.float32).reshape(3, 2, 2)
+    t.from_numpy(src)
+    arr = t.to_numpy(dtype=np.float64, copy=None)
+    assert arr.dtype == np.float64
+    np.testing.assert_array_equal(arr, src.astype(np.float64))
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_vector_to_numpy_copy_none(backend):
+    """copy=None on VectorField / VectorNdarray returns correct data without raising."""
+    t = qd.Vector.tensor(3, qd.f32, shape=(4,), backend=backend)
+    src = np.arange(12, dtype=np.float32).reshape(4, 3)
+    t.from_numpy(src)
+    arr = t.to_numpy(copy=None)
+    np.testing.assert_array_equal(arr, src)
+
+
+@pytest.mark.needs_torch
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_vector_to_torch_copy_none(backend):
+    """copy=None on VectorField / VectorNdarray returns correct torch tensor."""
+    torch = pytest.importorskip("torch")
+    t = qd.Vector.tensor(3, qd.f32, shape=(4,), backend=backend)
+    src = np.arange(12, dtype=np.float32).reshape(4, 3)
+    t.from_numpy(src)
+    out = t.to_torch(copy=None)
+    np.testing.assert_array_equal(out.numpy(), src)
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_vector_to_numpy_copy_none_dtype_fallback(backend):
+    """copy=None with dtype on VectorField / VectorNdarray silently falls back."""
+    t = qd.Vector.tensor(3, qd.f32, shape=(4,), backend=backend)
+    src = np.arange(12, dtype=np.float32).reshape(4, 3)
+    t.from_numpy(src)
+    arr = t.to_numpy(dtype=np.float64, copy=None)
+    assert arr.dtype == np.float64
+    np.testing.assert_array_equal(arr, src.astype(np.float64))

--- a/tests/python/test_tensor_wrapper_surface.py
+++ b/tests/python/test_tensor_wrapper_surface.py
@@ -300,3 +300,72 @@ def test_wrap_picks_matrix_tensor(backend):
         a = qd.Matrix.ndarray(2, 2, qd.f32, shape=(3,))
     t = qd.wrap(a)
     assert isinstance(t, qd.MatrixTensor)
+
+
+# ----------------------------------------------------------------------
+# copy= kwarg on to_numpy / to_torch
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_to_numpy_copy_true(backend):
+    """copy=True (default) returns an independent array."""
+    t = qd.tensor(qd.f32, shape=(4,), backend=backend)
+    src = np.arange(4, dtype=np.float32)
+    t.from_numpy(src)
+    arr = t.to_numpy(copy=True)
+    np.testing.assert_array_equal(arr, src)
+    arr[0] = 999.0
+    np.testing.assert_array_equal(t.to_numpy(), src)
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_to_numpy_copy_false(backend):
+    """copy=False returns a zero-copy view (CPU backend supports this)."""
+    t = qd.tensor(qd.f32, shape=(4,), backend=backend)
+    src = np.arange(4, dtype=np.float32)
+    t.from_numpy(src)
+    arr = t.to_numpy(copy=False)
+    np.testing.assert_array_equal(arr, src)
+    arr[0] = 999.0
+    assert t.to_numpy(copy=True)[0] == 999.0
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_to_numpy_copy_false_with_dtype_raises(backend):
+    """copy=False combined with dtype conversion must raise."""
+    t = qd.tensor(qd.f32, shape=(4,), backend=backend)
+    t.from_numpy(np.ones(4, dtype=np.float32))
+    with pytest.raises(ValueError, match="copy=False"):
+        t.to_numpy(dtype=np.float64, copy=False)
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_to_torch_copy_true(backend):
+    """copy=True (default) returns an independent torch tensor."""
+    torch = pytest.importorskip("torch")
+    t = qd.tensor(qd.f32, shape=(4,), backend=backend)
+    src = np.arange(4, dtype=np.float32)
+    t.from_numpy(src)
+    out = t.to_torch(copy=True)
+    np.testing.assert_array_equal(out.numpy(), src)
+    out[0] = 999.0
+    np.testing.assert_array_equal(t.to_numpy(), src)
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=BACKEND_IDS)
+@test_utils.test(arch=qd.cpu)
+def test_to_torch_copy_false(backend):
+    """copy=False returns a zero-copy torch tensor (CPU backend)."""
+    torch = pytest.importorskip("torch")
+    t = qd.tensor(qd.f32, shape=(4,), backend=backend)
+    src = np.arange(4, dtype=np.float32)
+    t.from_numpy(src)
+    out = t.to_torch(copy=False)
+    np.testing.assert_array_equal(out.numpy(), src)
+    out[0] = 999.0
+    assert t.to_numpy(copy=True)[0] == 999.0


### PR DESCRIPTION
The underlying field and ndarray impls already support copy=False for zero-copy interop. Wire it through the Tensor wrapper so users don't have to drop down to _unwrap().

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
