### PR TITLE
[FEATURE] Support external Metal command queue via qd.init

### DIFF
--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -31,6 +31,7 @@ parallelization
 :titlesonly:
 
 interop
+metal_shared_queue
 ```
 
 ```{toctree}

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -64,6 +64,14 @@ Forces every adstack in the program to exactly `N` slots and bypasses the launch
 
 Cutoff (in bytes) below which the gate-passing-count sizing path described in [Memory footprint](./autodiff.md#memory-footprint) is skipped in favour of the eager `dispatched_threads * stride` heap. Default `100 MiB`. The sparse path saves memory on kernels of the shape `for i in range(...): if field[i] cmp literal: <adstack work>` but pays a per-launch reducer dispatch; below the threshold that overhead outweighs the savings. Set to `0` to always use the sparse path; lower it if the default still skips kernels you want shrunk. No effect when `ad_stack_experimental_enabled=False` or when the kernel has no such gate.
 
+## Apple Metal
+
+### `external_metal_command_queue`
+
+An `MTLCommandQueue*` pointer (as an integer) to use instead of creating a new Metal command queue. Default `0` (create a new queue). When non-zero, Quadrants dispatches all GPU work on the provided queue, which enables GPU-side ordering with other frameworks that share the same queue (most notably PyTorch MPS).
+
+See [Shared Metal command queue](./metal_shared_queue.md) for the full setup guide, including how to extract the queue pointer from PyTorch and the synchronisation implications.
+
 ## Debugging
 
 See [Debug mode](./debug.md) for runnable examples and a typical develop / benchmark workflow.

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -70,6 +70,10 @@ Cutoff (in bytes) below which the gate-passing-count sizing path described in [M
 
 An `MTLCommandQueue*` pointer (as an integer) to use instead of creating a new Metal command queue. Default `0` (create a new queue). When non-zero, Quadrants dispatches all GPU work on the provided queue, which enables GPU-side ordering with other frameworks that share the same queue (most notably PyTorch MPS).
 
+### `external_metal_command_queue_is_torch_queue`
+
+Default `False`. Set to `True` when the `external_metal_command_queue` is PyTorch MPS's command queue. This tells Quadrants that both frameworks share the same Metal queue, so the explicit `qd.sync()` / `torch.mps.synchronize()` calls at `to_torch` / `from_torch` interop points can be skipped. When `False` (or when no external queue is set), the interop syncs are preserved.
+
 See [Shared Metal command queue](./metal_shared_queue.md) for the full setup guide, including how to extract the queue pointer from PyTorch and the synchronisation implications.
 
 ## Debugging

--- a/docs/source/user_guide/interop.md
+++ b/docs/source/user_guide/interop.md
@@ -178,6 +178,8 @@ my_kernel(f)                     # now safe
 
 This is intentional: forcing a sync on every Quadrants kernel that touches a previously-zerocopied field would be very expensive in workloads that batch many torch ops and many kernels back-to-back. If you mutate fields from torch and then read them from a Quadrants kernel on Metal, call `torch.mps.synchronize()` once between the torch ops and the kernels.
 
+**Shared command queue.** The synchronisation overhead above can be eliminated entirely by passing PyTorch MPS's `MTLCommandQueue` to Quadrants at init time via `external_metal_command_queue`. When both frameworks share the same queue, Metal guarantees command buffer ordering automatically. See [Shared Metal command queue](./metal_shared_queue.md) for the setup guide.
+
 ### Lifetime caveats
 
 A zero-copy view becomes invalid when the underlying Quadrants storage is freed. This happens on `qd.reset()` and `qd.init()`. Holding a `copy=False` tensor across either is undefined behaviour:

--- a/docs/source/user_guide/interop.md
+++ b/docs/source/user_guide/interop.md
@@ -180,7 +180,7 @@ my_kernel(f)                     # now safe
 
 This is intentional: forcing a sync on every Quadrants kernel that touches a previously-zerocopied field would be very expensive in workloads that batch many torch ops and many kernels back-to-back. If you mutate fields from torch and then read them from a Quadrants kernel on Metal, call `torch.mps.synchronize()` once between the torch ops and the kernels.
 
-**Shared command queue.** The synchronisation overhead above can be eliminated entirely by passing PyTorch MPS's `MTLCommandQueue` to Quadrants at init time via `external_metal_command_queue`. When both frameworks share the same queue, Metal guarantees command buffer ordering automatically. See [Shared Metal command queue](./metal_shared_queue.md) for the setup guide.
+**Shared command queue.** The synchronisation overhead above can be eliminated entirely by passing PyTorch MPS's `MTLCommandQueue` to Quadrants at init time via `external_metal_command_queue`. Quadrants provides `quadrants.interop.get_mps_command_queue()` to extract the queue pointer at runtime. When both frameworks share the same queue, Metal guarantees command buffer ordering automatically. See [Shared Metal command queue](./metal_shared_queue.md) for the setup guide.
 
 ### Lifetime caveats
 

--- a/docs/source/user_guide/metal_shared_queue.md
+++ b/docs/source/user_guide/metal_shared_queue.md
@@ -98,7 +98,7 @@ qd.init(arch=qd.metal, external_metal_command_queue=queue_ptr)
 
 ## Lifetime and ownership
 
-The caller (your application) owns the command queue. Quadrants retains it for the duration of the runtime and does **not** release it on `qd.reset()`. You must keep PyTorch (and its MPS backend) alive for as long as the Quadrants runtime is active.
+The caller (your application) owns the command queue. Quadrants borrows the pointer without retaining it, so the caller must keep the queue alive for the lifetime of the Quadrants runtime. In practice this means keeping PyTorch (and its MPS backend) alive for as long as `qd.init()` is active.
 
 ## Fallback
 

--- a/docs/source/user_guide/metal_shared_queue.md
+++ b/docs/source/user_guide/metal_shared_queue.md
@@ -94,7 +94,7 @@ qd.init(arch=qd.metal, external_metal_command_queue=queue_ptr)
 | `f.to_torch(copy=False)` | `qd.sync()` called internally | no sync needed |
 | `f.to_torch(copy=True)` | `qd.sync()` + `torch.mps.synchronize()` | no sync needed |
 | Quadrants kernel after torch write | manual `torch.mps.synchronize()` required | automatic (same queue) |
-| `f.to_numpy()` | `qd.sync()` (always needed for CPU readback) | `qd.sync()` (still needed) |
+| `f.to_numpy()` | `qd.sync()` (always needed for CPU readback) | `qd.sync()` (still needed — the kernel-copy path is Quadrants-internal, not routed through MPS) |
 
 ## Lifetime and ownership
 

--- a/docs/source/user_guide/metal_shared_queue.md
+++ b/docs/source/user_guide/metal_shared_queue.md
@@ -7,9 +7,12 @@ The `external_metal_command_queue` option lets you pass PyTorch's command queue 
 ## Quick start
 
 ```python
+import torch
 import quadrants as qd
+from quadrants.interop import get_mps_command_queue
 
-queue_ptr = get_mps_command_queue()   # see below
+torch.zeros(1, device="mps")  # ensure MPS is initialised
+queue_ptr = get_mps_command_queue()
 qd.init(
     arch=qd.metal,
     external_metal_command_queue=queue_ptr,
@@ -32,56 +35,15 @@ You can still call `qd.sync()` when you need to read results back to the CPU (e.
 
 ## Extracting PyTorch's MTLCommandQueue
 
-PyTorch does not expose its MPS command queue through a public Python API. The following helper extracts it at runtime using `ctypes` and the Objective-C runtime, with no build-time PyTorch dependency:
+PyTorch does not expose its MPS command queue through a public Python API. Quadrants provides a built-in helper that extracts it at runtime using `ctypes` and the Objective-C runtime:
 
 ```python
-import ctypes
-import os
-import torch
+from quadrants.interop import get_mps_command_queue
 
-
-def get_mps_command_queue() -> int:
-    """Return PyTorch MPS's MTLCommandQueue* as a Python int."""
-    # Ensure MPS is initialised
-    torch.zeros(1, device="mps")
-
-    torch_lib = os.path.join(
-        os.path.dirname(torch.__file__), "lib", "libtorch_cpu.dylib"
-    )
-    handle = ctypes.CDLL(torch_lib)._handle
-
-    libdl = ctypes.CDLL(None)
-    dlsym = libdl.dlsym
-    dlsym.restype = ctypes.c_void_p
-    dlsym.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
-
-    # at::mps::getDefaultMPSStream() -> MPSStream*
-    func_addr = dlsym(handle, b"_ZN2at3mps19getDefaultMPSStreamEv")
-    assert func_addr, "Cannot find getDefaultMPSStream — check PyTorch version"
-    stream_ptr = ctypes.CFUNCTYPE(ctypes.c_void_p)(func_addr)()
-
-    # MPSStream::commandBuffer() -> id<MTLCommandBuffer>
-    cb_addr = dlsym(handle, b"_ZN2at3mps9MPSStream13commandBufferEv")
-    assert cb_addr, "Cannot find MPSStream::commandBuffer"
-    cb_ptr = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p)(cb_addr)(
-        stream_ptr
-    )
-
-    # [commandBuffer commandQueue] via ObjC runtime
-    objc = ctypes.CDLL("/usr/lib/libobjc.A.dylib")
-    sel_reg = objc.sel_registerName
-    sel_reg.restype = ctypes.c_void_p
-    sel_reg.argtypes = [ctypes.c_char_p]
-    msg_send = objc.objc_msgSend
-    msg_send.restype = ctypes.c_void_p
-    msg_send.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-
-    queue_ptr = msg_send(cb_ptr, sel_reg(b"commandQueue"))
-    assert queue_ptr, "Failed to extract MTLCommandQueue"
-    return queue_ptr
+queue_ptr = get_mps_command_queue()  # returns int (raw pointer), or 0 on failure
 ```
 
-The C++ symbol `_ZN2at3mps19getDefaultMPSStreamEv` has been stable since PyTorch 1.13.
+The function returns the `MTLCommandQueue*` as a Python `int`. It returns `0` if extraction fails (e.g. non-macOS platform, PyTorch not installed, or unsupported PyTorch build). The underlying C++ symbol (`_ZN2at3mps19getDefaultMPSStreamEv`) has been stable since PyTorch 1.13.
 
 ## Init ordering
 
@@ -92,6 +54,8 @@ import torch
 torch.zeros(1, device="mps")        # trigger MPS init
 
 import quadrants as qd
+from quadrants.interop import get_mps_command_queue
+
 queue_ptr = get_mps_command_queue()
 qd.init(
     arch=qd.metal,
@@ -115,17 +79,17 @@ The caller (your application) owns the command queue. Quadrants borrows the poin
 
 ## Fallback
 
-If extracting the queue fails (e.g. on an older PyTorch version or a non-Apple system), fall back to the default separate-queue path:
+`get_mps_command_queue()` returns `0` on failure (non-macOS, missing PyTorch, unsupported build) rather than raising. You can use this to fall back to the default separate-queue path:
 
 ```python
-try:
-    queue_ptr = get_mps_command_queue()
-except (AssertionError, OSError):
-    queue_ptr = 0   # 0 means "create a new queue" (the default)
+from quadrants.interop import get_mps_command_queue
 
+queue_ptr = get_mps_command_queue()
 qd.init(
     arch=qd.metal,
-    external_metal_command_queue=queue_ptr,
+    external_metal_command_queue=queue_ptr or None,
     external_metal_command_queue_is_torch_queue=queue_ptr != 0,
 )
 ```
+
+When `external_metal_command_queue` is `0` (or omitted), Quadrants creates its own queue and the explicit sync path is used as before.

--- a/docs/source/user_guide/metal_shared_queue.md
+++ b/docs/source/user_guide/metal_shared_queue.md
@@ -10,10 +10,19 @@ The `external_metal_command_queue` option lets you pass PyTorch's command queue 
 import quadrants as qd
 
 queue_ptr = get_mps_command_queue()   # see below
-qd.init(arch=qd.metal, external_metal_command_queue=queue_ptr)
+qd.init(
+    arch=qd.metal,
+    external_metal_command_queue=queue_ptr,
+    external_metal_command_queue_is_torch_queue=True,
+)
 ```
 
-Once initialised this way:
+Two flags work together:
+
+- `external_metal_command_queue` — the raw `MTLCommandQueue*` pointer. Quadrants dispatches all GPU work on this queue instead of creating its own.
+- `external_metal_command_queue_is_torch_queue` — set to `True` when the queue comes from PyTorch MPS. This tells Quadrants that PyTorch shares the same queue, so the explicit interop syncs can be safely skipped. Defaults to `False`, which preserves the sync calls even when an external queue is provided (useful when the external queue belongs to a non-PyTorch framework).
+
+Once initialised with both flags:
 
 - `to_torch(copy=False)` no longer calls `qd.sync()` internally.
 - `to_torch(copy=True)` no longer calls `torch.mps.synchronize()` after the copy.
@@ -84,7 +93,11 @@ torch.zeros(1, device="mps")        # trigger MPS init
 
 import quadrants as qd
 queue_ptr = get_mps_command_queue()
-qd.init(arch=qd.metal, external_metal_command_queue=queue_ptr)
+qd.init(
+    arch=qd.metal,
+    external_metal_command_queue=queue_ptr,
+    external_metal_command_queue_is_torch_queue=True,
+)
 ```
 
 ## What changes with a shared queue
@@ -110,5 +123,9 @@ try:
 except (AssertionError, OSError):
     queue_ptr = 0   # 0 means "create a new queue" (the default)
 
-qd.init(arch=qd.metal, external_metal_command_queue=queue_ptr)
+qd.init(
+    arch=qd.metal,
+    external_metal_command_queue=queue_ptr,
+    external_metal_command_queue_is_torch_queue=queue_ptr != 0,
+)
 ```

--- a/docs/source/user_guide/metal_shared_queue.md
+++ b/docs/source/user_guide/metal_shared_queue.md
@@ -1,0 +1,114 @@
+# Shared Metal command queue (PyTorch MPS)
+
+On Apple Silicon, Quadrants and PyTorch MPS both dispatch GPU work via Metal. By default each framework creates its own `MTLCommandQueue`, which means there is no GPU-level ordering between them. Every zero-copy interop point therefore requires explicit CPU-side synchronisation (`qd.sync()` and `torch.mps.synchronize()`) to guarantee data visibility.
+
+The `external_metal_command_queue` option lets you pass PyTorch's command queue to Quadrants so that both frameworks share a single queue. Metal processes command buffers in commit order within a queue, so GPU-side ordering is automatic and the per-interop sync overhead is eliminated.
+
+## Quick start
+
+```python
+import quadrants as qd
+
+queue_ptr = get_mps_command_queue()   # see below
+qd.init(arch=qd.metal, external_metal_command_queue=queue_ptr)
+```
+
+Once initialised this way:
+
+- `to_torch(copy=False)` no longer calls `qd.sync()` internally.
+- `to_torch(copy=True)` no longer calls `torch.mps.synchronize()` after the copy.
+- GPU work submitted by Quadrants and by PyTorch executes in the order it was committed — no manual sync needed between the two.
+
+You can still call `qd.sync()` when you need to read results back to the CPU (e.g. `to_numpy()`); what changes is that you no longer need *both* `qd.sync()` and `torch.mps.synchronize()` at every framework boundary.
+
+## Extracting PyTorch's MTLCommandQueue
+
+PyTorch does not expose its MPS command queue through a public Python API. The following helper extracts it at runtime using `ctypes` and the Objective-C runtime, with no build-time PyTorch dependency:
+
+```python
+import ctypes
+import os
+import torch
+
+
+def get_mps_command_queue() -> int:
+    """Return PyTorch MPS's MTLCommandQueue* as a Python int."""
+    # Ensure MPS is initialised
+    torch.zeros(1, device="mps")
+
+    torch_lib = os.path.join(
+        os.path.dirname(torch.__file__), "lib", "libtorch_cpu.dylib"
+    )
+    handle = ctypes.CDLL(torch_lib)._handle
+
+    libdl = ctypes.CDLL(None)
+    dlsym = libdl.dlsym
+    dlsym.restype = ctypes.c_void_p
+    dlsym.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+
+    # at::mps::getDefaultMPSStream() -> MPSStream*
+    func_addr = dlsym(handle, b"_ZN2at3mps19getDefaultMPSStreamEv")
+    assert func_addr, "Cannot find getDefaultMPSStream — check PyTorch version"
+    stream_ptr = ctypes.CFUNCTYPE(ctypes.c_void_p)(func_addr)()
+
+    # MPSStream::commandBuffer() -> id<MTLCommandBuffer>
+    cb_addr = dlsym(handle, b"_ZN2at3mps9MPSStream13commandBufferEv")
+    assert cb_addr, "Cannot find MPSStream::commandBuffer"
+    cb_ptr = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p)(cb_addr)(
+        stream_ptr
+    )
+
+    # [commandBuffer commandQueue] via ObjC runtime
+    objc = ctypes.CDLL("/usr/lib/libobjc.A.dylib")
+    sel_reg = objc.sel_registerName
+    sel_reg.restype = ctypes.c_void_p
+    sel_reg.argtypes = [ctypes.c_char_p]
+    msg_send = objc.objc_msgSend
+    msg_send.restype = ctypes.c_void_p
+    msg_send.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+    queue_ptr = msg_send(cb_ptr, sel_reg(b"commandQueue"))
+    assert queue_ptr, "Failed to extract MTLCommandQueue"
+    return queue_ptr
+```
+
+The C++ symbol `_ZN2at3mps19getDefaultMPSStreamEv` has been stable since PyTorch 1.13.
+
+## Init ordering
+
+PyTorch MPS must be initialised **before** `qd.init()` so that the command queue exists when Quadrants starts:
+
+```python
+import torch
+torch.zeros(1, device="mps")        # trigger MPS init
+
+import quadrants as qd
+queue_ptr = get_mps_command_queue()
+qd.init(arch=qd.metal, external_metal_command_queue=queue_ptr)
+```
+
+## What changes with a shared queue
+
+| Scenario | Separate queues (default) | Shared queue |
+|----------|--------------------------|--------------|
+| `f.to_torch(copy=False)` | `qd.sync()` called internally | no sync needed |
+| `f.to_torch(copy=True)` | `qd.sync()` + `torch.mps.synchronize()` | no sync needed |
+| Quadrants kernel after torch write | manual `torch.mps.synchronize()` required | automatic (same queue) |
+| `f.to_numpy()` | `qd.sync()` (always needed for CPU readback) | `qd.sync()` (still needed) |
+
+## Lifetime and ownership
+
+The caller (your application) owns the command queue. Quadrants retains it for the duration of the runtime and does **not** release it on `qd.reset()`. You must keep PyTorch (and its MPS backend) alive for as long as the Quadrants runtime is active.
+
+## Fallback
+
+If extracting the queue fails (e.g. on an older PyTorch version or a non-Apple system), fall back to the default separate-queue path:
+
+```python
+try:
+    queue_ptr = get_mps_command_queue()
+except (AssertionError, OSError):
+    queue_ptr = 0   # 0 means "create a new queue" (the default)
+
+qd.init(arch=qd.metal, external_metal_command_queue=queue_ptr)
+```

--- a/docs/source/user_guide/metal_shared_queue.md
+++ b/docs/source/user_guide/metal_shared_queue.md
@@ -7,11 +7,9 @@ The `external_metal_command_queue` option lets you pass PyTorch's command queue 
 ## Quick start
 
 ```python
-import torch
 import quadrants as qd
 from quadrants.interop import get_mps_command_queue
 
-torch.zeros(1, device="mps")  # ensure MPS is initialised
 queue_ptr = get_mps_command_queue()
 qd.init(
     arch=qd.metal,
@@ -43,20 +41,17 @@ from quadrants.interop import get_mps_command_queue
 queue_ptr = get_mps_command_queue()  # returns int (raw pointer), or 0 on failure
 ```
 
-The function returns the `MTLCommandQueue*` as a Python `int`. It returns `0` if extraction fails (e.g. non-macOS platform, PyTorch not installed, or unsupported PyTorch build). The underlying C++ symbol (`_ZN2at3mps19getDefaultMPSStreamEv`) has been stable since PyTorch 1.13.
+The function initialises PyTorch MPS if needed, then returns the `MTLCommandQueue*` as a Python `int`. It returns `0` if extraction fails (e.g. non-macOS platform, PyTorch not installed, MPS not available, or unsupported PyTorch build). The underlying C++ symbol (`_ZN2at3mps19getDefaultMPSStreamEv`) has been stable since PyTorch 1.13.
 
 ## Init ordering
 
-PyTorch MPS must be initialised **before** `qd.init()` so that the command queue exists when Quadrants starts:
+`get_mps_command_queue()` handles PyTorch MPS initialisation internally, so you can call it before `qd.init()` without any manual setup:
 
 ```python
-import torch
-torch.zeros(1, device="mps")        # trigger MPS init
-
 import quadrants as qd
 from quadrants.interop import get_mps_command_queue
 
-queue_ptr = get_mps_command_queue()
+queue_ptr = get_mps_command_queue()  # initialises MPS if needed
 qd.init(
     arch=qd.metal,
     external_metal_command_queue=queue_ptr,

--- a/python/quadrants/__init__.py
+++ b/python/quadrants/__init__.py
@@ -19,7 +19,7 @@ from quadrants import (
     ad,
     algorithms,
     experimental,
-    interop,
+    interop,  # noqa: F401
     linalg,
     math,
     sparse,

--- a/python/quadrants/__init__.py
+++ b/python/quadrants/__init__.py
@@ -19,6 +19,7 @@ from quadrants import (
     ad,
     algorithms,
     experimental,
+    interop,
     linalg,
     math,
     sparse,

--- a/python/quadrants/interop/__init__.py
+++ b/python/quadrants/interop/__init__.py
@@ -1,0 +1,9 @@
+"""Cross-framework interop utilities for Quadrants.
+
+This module provides helpers for integrating Quadrants with other GPU frameworks (e.g. PyTorch MPS) at the
+command-queue level, enabling zero-overhead shared-queue execution without explicit synchronisation.
+"""
+
+from quadrants.interop._torch_mps import get_mps_command_queue
+
+__all__ = ["get_mps_command_queue"]

--- a/python/quadrants/interop/_torch_mps.py
+++ b/python/quadrants/interop/_torch_mps.py
@@ -36,6 +36,12 @@ def get_mps_command_queue() -> int:
     if torch.__file__ is None:
         return 0
 
+    if not hasattr(torch.backends, "mps") or not torch.backends.mps.is_available():
+        return 0
+
+    # Ensure MPS runtime is initialised (creates the device and default stream).
+    torch.zeros(1, device="mps")
+
     try:
         torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib", "libtorch_cpu.dylib")
         handle = ctypes.CDLL(torch_lib)._handle

--- a/python/quadrants/interop/_torch_mps.py
+++ b/python/quadrants/interop/_torch_mps.py
@@ -1,0 +1,69 @@
+"""Extract PyTorch MPS's Metal command queue for shared-queue interop with Quadrants.
+
+Usage::
+
+    import quadrants as qd
+    from quadrants.interop import get_mps_command_queue
+
+    queue = get_mps_command_queue()
+    qd.init(arch=qd.metal, external_metal_command_queue=queue, external_metal_command_queue_is_torch_queue=True)
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import sys
+
+
+def get_mps_command_queue() -> int:
+    """Extract PyTorch MPS's ``MTLCommandQueue*`` as a raw pointer (Python int).
+
+    Returns the pointer value on success, or 0 if extraction fails (e.g. PyTorch not installed, non-macOS platform,
+    or unsupported PyTorch build).
+
+    The returned pointer is borrowed — it remains valid for the lifetime of the PyTorch MPS runtime (i.e. until process
+    exit or an explicit ``torch._C._mps_emptyCache()``).
+    """
+    if sys.platform != "darwin":
+        return 0
+
+    try:
+        import torch  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        return 0
+
+    if torch.__file__ is None:
+        return 0
+
+    try:
+        torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib", "libtorch_cpu.dylib")
+        handle = ctypes.CDLL(torch_lib)._handle
+
+        libdl = ctypes.CDLL(None)
+        dlsym = libdl.dlsym
+        dlsym.restype = ctypes.c_void_p
+        dlsym.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+
+        stream_fn = dlsym(handle, b"_ZN2at3mps19getDefaultMPSStreamEv")
+        if not stream_fn:
+            return 0
+        stream_ptr = ctypes.CFUNCTYPE(ctypes.c_void_p)(stream_fn)()
+
+        cb_fn = dlsym(handle, b"_ZN2at3mps9MPSStream13commandBufferEv")
+        if not cb_fn:
+            return 0
+        cb_ptr = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p)(cb_fn)(stream_ptr)
+
+        objc = ctypes.CDLL("/usr/lib/libobjc.A.dylib")
+        sel_reg = objc.sel_registerName
+        sel_reg.restype = ctypes.c_void_p
+        sel_reg.argtypes = [ctypes.c_char_p]
+        msg_send = objc.objc_msgSend
+        msg_send.restype = ctypes.c_void_p
+        msg_send.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+        queue_ptr = msg_send(cb_ptr, sel_reg(b"commandQueue"))
+        return queue_ptr or 0
+    except (OSError, AttributeError):
+        return 0

--- a/python/quadrants/lang/_func_base.py
+++ b/python/quadrants/lang/_func_base.py
@@ -102,10 +102,20 @@ _is_cpython = sys.implementation.name == "cpython"
 
 _frozen_dc_plans: dict[tuple[int, type, str], tuple[set[str], tuple[tuple[str, str, Any], ...]]] = {}
 
+_frozen_dc_plans_hook_registered = False
+
+
+def _ensure_frozen_dc_plans_reset_hook():
+    global _frozen_dc_plans_hook_registered
+    if not _frozen_dc_plans_hook_registered:
+        impl.on_reset(_frozen_dc_plans.clear)
+        _frozen_dc_plans_hook_registered = True
+
 
 def _get_frozen_dc_plan(
     used_params: set[str], struct_cls: type, basename: str, fields_dict: dict
 ) -> tuple[tuple[str, str, Any], ...]:
+    _ensure_frozen_dc_plans_reset_hook()
     key = (id(used_params), struct_cls, basename)
     entry = _frozen_dc_plans.get(key)
     # Guard against id() reuse: after the original set is garbage-collected, a new set can be allocated at the same

--- a/python/quadrants/lang/_metal_interop.py
+++ b/python/quadrants/lang/_metal_interop.py
@@ -1,0 +1,66 @@
+"""Metal interop synchronisation helpers.
+
+When Quadrants and PyTorch MPS use separate Metal command queues, explicit CPU-side syncs
+(``qd.sync()`` and ``torch.mps.synchronize()``) are needed at every interop point to guarantee
+data visibility.  When both frameworks share a single command queue (via
+``external_metal_command_queue`` + ``external_metal_command_queue_is_torch_queue``), Metal's
+sequential command buffer ordering makes these syncs unnecessary.
+
+This module caches the "do we need interop sync?" decision and exposes it to ``field.py``
+and other consumers.  The cache is lazily populated on first access and invalidated on
+``qd.reset()`` via the ``impl.on_reset`` hook.
+"""
+
+from __future__ import annotations
+
+from quadrants._lib.core import quadrants_python as _qd_core
+from quadrants.lang import impl
+
+_ARCH_METAL = _qd_core.Arch.metal
+
+_metal_needs_interop_sync_cached: bool | None = None
+
+
+def _recompute_metal_interop_sync() -> None:
+    """Recompute and cache the Metal interop sync flag from the current config."""
+    global _metal_needs_interop_sync_cached
+    cfg = impl.current_cfg()
+    _metal_needs_interop_sync_cached = cfg.arch == _ARCH_METAL and not (
+        cfg.external_metal_command_queue and cfg.external_metal_command_queue_is_torch_queue
+    )
+
+
+def _clear_metal_interop_cache() -> None:
+    """Invalidate the cached flag.  Registered as a reset hook."""
+    global _metal_needs_interop_sync_cached
+    _metal_needs_interop_sync_cached = None
+
+
+_metal_interop_hook_registered = False
+
+
+def metal_needs_interop_sync() -> bool:
+    """Return True when explicit sync is needed between Quadrants and PyTorch MPS (separate Metal queues)."""
+    global _metal_interop_hook_registered
+    if not _metal_interop_hook_registered:
+        impl.on_reset(_clear_metal_interop_cache)
+        _metal_interop_hook_registered = True
+    if _metal_needs_interop_sync_cached is None:
+        _recompute_metal_interop_sync()
+    return _metal_needs_interop_sync_cached  # type: ignore[return-value]
+
+
+def mps_sync_if_metal() -> None:
+    """Call ``torch.mps.synchronize()`` when running on the Metal backend with separate command queues.
+
+    When Quadrants and PyTorch MPS use separate Metal command queues, ``qd.sync()`` only guarantees Quadrants writes are
+    complete. A subsequent ``.clone()`` or kernel copy is queued on the MPS stream and may execute *after* the next
+    Quadrants kernel overwrites the source buffer. We must also synchronize MPS after the copy.
+
+    When a shared command queue is configured (``external_metal_command_queue != 0``), Metal's sequential command buffer
+    semantics guarantee ordering automatically and no sync is needed.
+    """
+    if metal_needs_interop_sync():
+        import torch  # pylint: disable=C0415
+
+        torch.mps.synchronize()

--- a/python/quadrants/lang/_metal_interop.py
+++ b/python/quadrants/lang/_metal_interop.py
@@ -1,14 +1,12 @@
 """Metal interop synchronisation helpers.
 
-When Quadrants and PyTorch MPS use separate Metal command queues, explicit CPU-side syncs
-(``qd.sync()`` and ``torch.mps.synchronize()``) are needed at every interop point to guarantee
-data visibility.  When both frameworks share a single command queue (via
-``external_metal_command_queue`` + ``external_metal_command_queue_is_torch_queue``), Metal's
+When Quadrants and PyTorch MPS use separate Metal command queues, explicit CPU-side syncs (``qd.sync()`` and
+``torch.mps.synchronize()``) are needed at every interop point to guarantee data visibility.  When both frameworks share
+a single command queue (via ``external_metal_command_queue`` + ``external_metal_command_queue_is_torch_queue``), Metal's
 sequential command buffer ordering makes these syncs unnecessary.
 
-This module caches the "do we need interop sync?" decision and exposes it to ``field.py``
-and other consumers.  The cache is lazily populated on first access and invalidated on
-``qd.reset()`` via the ``impl.on_reset`` hook.
+This module caches the "do we need interop sync?" decision and exposes it to ``field.py`` and other consumers.  The
+cache is lazily populated on first access and invalidated on ``qd.reset()`` via the ``impl.on_reset`` hook.
 """
 
 from __future__ import annotations

--- a/python/quadrants/lang/_ndarray.py
+++ b/python/quadrants/lang/_ndarray.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from quadrants._lib import core as _qd_core
 from quadrants.lang import _ndarray_pickle, impl
+from quadrants.lang._metal_interop import mps_sync_if_metal
 
 # Cache enum value at module level for fast lookup in hot paths
 _arch_metal = _qd_core.Arch.metal
@@ -289,9 +290,7 @@ class Ndarray:
         layout_is_aos = 1
         ndarray_matrix_to_ext_arr(self, out, layout_is_aos, as_vector)
         impl.get_runtime().sync()
-        from quadrants.lang.field import _mps_sync_if_metal  # pylint: disable=C0415
-
-        _mps_sync_if_metal()
+        mps_sync_if_metal()
         return out
 
     @python_scope
@@ -527,9 +526,7 @@ class ScalarNdarray(Ndarray):
 
         ndarray_to_ext_arr(self, out)
         impl.get_runtime().sync()
-        from quadrants.lang.field import _mps_sync_if_metal  # pylint: disable=C0415
-
-        _mps_sync_if_metal()
+        mps_sync_if_metal()
         return out
 
     @python_scope

--- a/python/quadrants/lang/field.py
+++ b/python/quadrants/lang/field.py
@@ -218,7 +218,7 @@ def _try_zerocopy_torch(field: "Field", *, copy, device=None, is_scalar: bool = 
         tc = torch.utils.dlpack.from_dlpack(field.to_dlpack())
     except RuntimeError as e:
         raise ValueError(f"Zero-copy not available: {e}") from None
-    if impl.current_cfg().arch == _ARCH_METAL:
+    if impl.current_cfg().arch == _ARCH_METAL and not impl.current_cfg().external_metal_command_queue:
         impl.get_runtime().sync()
 
     if device is not None:
@@ -236,14 +236,16 @@ def _try_zerocopy_torch(field: "Field", *, copy, device=None, is_scalar: bool = 
 
 
 def _mps_sync_if_metal():
-    """Call ``torch.mps.synchronize()`` when running on the Metal backend, no-op otherwise.
+    """Call ``torch.mps.synchronize()`` when running on the Metal backend with separate command queues.
 
-    Quadrants and PyTorch MPS use separate Metal command queues, so ``qd.sync()`` only guarantees Quadrants writes are
+    When Quadrants and PyTorch MPS use separate Metal command queues, ``qd.sync()`` only guarantees Quadrants writes are
     complete. A subsequent ``.clone()`` or kernel copy is queued on the MPS stream and may execute *after* the next
     Quadrants kernel overwrites the source buffer. We must also synchronize MPS after the copy.
+
+    When a shared command queue is configured (``external_metal_command_queue != 0``), Metal's sequential command buffer
+    semantics guarantee ordering automatically and no sync is needed.
     """
-    # FIXME: DLPack may return old values on Apple Metal if sync is not systematically called manually.
-    if impl.current_cfg().arch == _ARCH_METAL:
+    if impl.current_cfg().arch == _ARCH_METAL and not impl.current_cfg().external_metal_command_queue:
         import torch  # pylint: disable=C0415
 
         torch.mps.synchronize()

--- a/python/quadrants/lang/field.py
+++ b/python/quadrants/lang/field.py
@@ -9,6 +9,7 @@ from quadrants._lib import core as _qd_core
 from quadrants._lib.core.quadrants_python import DataTypeCxx
 from quadrants._logging import warn
 from quadrants.lang import impl
+from quadrants.lang._metal_interop import metal_needs_interop_sync, mps_sync_if_metal
 from quadrants.lang.exception import QuadrantsSyntaxError
 from quadrants.lang.util import (
     in_python_scope,
@@ -144,39 +145,6 @@ _ARCH_CPU = frozenset({_qd_core.Arch.x64, _qd_core.Arch.arm64})
 
 _DLPACK_SUPPORTED_DTYPES = frozenset({f32, f64, i32, i64, u1})
 
-# Cached flag: True when Metal is active with separate command queues (sync needed at interop points).
-# Set by _recompute_metal_interop_sync() after qd.init(); cleared by impl.reset() via _clear_metal_interop_cache().
-_metal_needs_interop_sync_cached: bool | None = None
-
-
-def _recompute_metal_interop_sync() -> None:
-    """Recompute and cache the Metal interop sync flag from the current config."""
-    global _metal_needs_interop_sync_cached
-    cfg = impl.current_cfg()
-    _metal_needs_interop_sync_cached = cfg.arch == _ARCH_METAL and not (
-        cfg.external_metal_command_queue and cfg.external_metal_command_queue_is_torch_queue
-    )
-
-
-def _clear_metal_interop_cache() -> None:
-    """Invalidate the cached flag. Registered as a reset hook."""
-    global _metal_needs_interop_sync_cached
-    _metal_needs_interop_sync_cached = None
-
-
-_metal_interop_hook_registered = False
-
-
-def _metal_needs_interop_sync() -> bool:
-    """Return True when explicit sync is needed between Quadrants and PyTorch MPS (separate Metal queues)."""
-    global _metal_interop_hook_registered
-    if not _metal_interop_hook_registered:
-        impl.on_reset(_clear_metal_interop_cache)
-        _metal_interop_hook_registered = True
-    if _metal_needs_interop_sync_cached is None:
-        _recompute_metal_interop_sync()
-    return _metal_needs_interop_sync_cached  # type: ignore[return-value]
-
 
 def _compute_torch_mps_supports_dlpack_bytes_offset() -> bool:
     try:
@@ -251,7 +219,7 @@ def _try_zerocopy_torch(field: "Field", *, copy, device=None, is_scalar: bool = 
         tc = torch.utils.dlpack.from_dlpack(field.to_dlpack())
     except RuntimeError as e:
         raise ValueError(f"Zero-copy not available: {e}") from None
-    if _metal_needs_interop_sync():
+    if metal_needs_interop_sync():
         impl.get_runtime().sync()
 
     if device is not None:
@@ -266,22 +234,6 @@ def _try_zerocopy_torch(field: "Field", *, copy, device=None, is_scalar: bool = 
             )
 
     return tc
-
-
-def _mps_sync_if_metal():
-    """Call ``torch.mps.synchronize()`` when running on the Metal backend with separate command queues.
-
-    When Quadrants and PyTorch MPS use separate Metal command queues, ``qd.sync()`` only guarantees Quadrants writes are
-    complete. A subsequent ``.clone()`` or kernel copy is queued on the MPS stream and may execute *after* the next
-    Quadrants kernel overwrites the source buffer. We must also synchronize MPS after the copy.
-
-    When a shared command queue is configured (``external_metal_command_queue != 0``), Metal's sequential command buffer
-    semantics guarantee ordering automatically and no sync is needed.
-    """
-    if _metal_needs_interop_sync():
-        import torch  # pylint: disable=C0415
-
-        torch.mps.synchronize()
 
 
 class _DLPackV1Adapter:
@@ -681,7 +633,7 @@ class ScalarField(Field):
 
         tensor_to_ext_arr(self, arr)
         quadrants.lang.runtime_ops.sync()  # type: ignore  # TODO: can we remove .runtime_ops here?
-        _mps_sync_if_metal()
+        mps_sync_if_metal()
         return arr
 
     @python_scope

--- a/python/quadrants/lang/field.py
+++ b/python/quadrants/lang/field.py
@@ -144,6 +144,37 @@ _ARCH_CPU = frozenset({_qd_core.Arch.x64, _qd_core.Arch.arm64})
 
 _DLPACK_SUPPORTED_DTYPES = frozenset({f32, f64, i32, i64, u1})
 
+# Cached flag: True when Metal is active with separate command queues (sync needed at interop points).
+# Set by _recompute_metal_interop_sync() after qd.init(); cleared by impl.reset() via _clear_metal_interop_cache().
+_metal_needs_interop_sync_cached: bool | None = None
+
+
+def _recompute_metal_interop_sync() -> None:
+    """Recompute and cache the Metal interop sync flag from the current config."""
+    global _metal_needs_interop_sync_cached
+    cfg = impl.current_cfg()
+    _metal_needs_interop_sync_cached = cfg.arch == _ARCH_METAL and not cfg.external_metal_command_queue
+
+
+def _clear_metal_interop_cache() -> None:
+    """Invalidate the cached flag. Registered as a reset hook."""
+    global _metal_needs_interop_sync_cached
+    _metal_needs_interop_sync_cached = None
+
+
+_metal_interop_hook_registered = False
+
+
+def _metal_needs_interop_sync() -> bool:
+    """Return True when explicit sync is needed between Quadrants and PyTorch MPS (separate Metal queues)."""
+    global _metal_interop_hook_registered
+    if not _metal_interop_hook_registered:
+        impl.on_reset(_clear_metal_interop_cache)
+        _metal_interop_hook_registered = True
+    if _metal_needs_interop_sync_cached is None:
+        _recompute_metal_interop_sync()
+    return _metal_needs_interop_sync_cached  # type: ignore[return-value]
+
 
 def _compute_torch_mps_supports_dlpack_bytes_offset() -> bool:
     try:
@@ -218,7 +249,7 @@ def _try_zerocopy_torch(field: "Field", *, copy, device=None, is_scalar: bool = 
         tc = torch.utils.dlpack.from_dlpack(field.to_dlpack())
     except RuntimeError as e:
         raise ValueError(f"Zero-copy not available: {e}") from None
-    if impl.current_cfg().arch == _ARCH_METAL and not impl.current_cfg().external_metal_command_queue:
+    if _metal_needs_interop_sync():
         impl.get_runtime().sync()
 
     if device is not None:
@@ -245,7 +276,7 @@ def _mps_sync_if_metal():
     When a shared command queue is configured (``external_metal_command_queue != 0``), Metal's sequential command buffer
     semantics guarantee ordering automatically and no sync is needed.
     """
-    if impl.current_cfg().arch == _ARCH_METAL and not impl.current_cfg().external_metal_command_queue:
+    if _metal_needs_interop_sync():
         import torch  # pylint: disable=C0415
 
         torch.mps.synchronize()

--- a/python/quadrants/lang/field.py
+++ b/python/quadrants/lang/field.py
@@ -153,7 +153,9 @@ def _recompute_metal_interop_sync() -> None:
     """Recompute and cache the Metal interop sync flag from the current config."""
     global _metal_needs_interop_sync_cached
     cfg = impl.current_cfg()
-    _metal_needs_interop_sync_cached = cfg.arch == _ARCH_METAL and not cfg.external_metal_command_queue
+    _metal_needs_interop_sync_cached = cfg.arch == _ARCH_METAL and not (
+        cfg.external_metal_command_queue and cfg.external_metal_command_queue_is_torch_queue
+    )
 
 
 def _clear_metal_interop_cache() -> None:

--- a/python/quadrants/lang/impl.py
+++ b/python/quadrants/lang/impl.py
@@ -586,6 +586,15 @@ def get_runtime() -> PyQuadrants:
     return pyquadrants
 
 
+_reset_hooks: list[callable] = []
+
+
+def on_reset(hook: callable) -> None:
+    """Register a callback to be invoked on ``reset()``.  Subscribers use this
+    to invalidate module-level caches without ``impl.py`` knowing about them."""
+    _reset_hooks.append(hook)
+
+
 def reset():
     global pyquadrants
     old_ndarrays = pyquadrants.ndarrays
@@ -600,6 +609,9 @@ def reset():
     from quadrants.lang._func_base import _frozen_dc_plans  # pylint: disable=C0415
 
     _frozen_dc_plans.clear()
+
+    for hook in _reset_hooks:
+        hook()
 
 
 @quadrants_scope

--- a/python/quadrants/lang/impl.py
+++ b/python/quadrants/lang/impl.py
@@ -2,7 +2,7 @@ import numbers
 import threading
 import weakref
 from types import FunctionType, MethodType
-from typing import TYPE_CHECKING, Any, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence
 
 import numpy as np
 
@@ -586,12 +586,11 @@ def get_runtime() -> PyQuadrants:
     return pyquadrants
 
 
-_reset_hooks: list[callable] = []
+_reset_hooks: list[Callable[[], None]] = []
 
 
-def on_reset(hook: callable) -> None:
-    """Register a callback to be invoked on ``reset()``.  Subscribers use this
-    to invalidate module-level caches without ``impl.py`` knowing about them."""
+def on_reset(hook: Callable[[], None]) -> None:
+    """Register a callback to be invoked on ``reset()``.  Invalidates module-level caches without coupling."""
     _reset_hooks.append(hook)
 
 

--- a/python/quadrants/lang/impl.py
+++ b/python/quadrants/lang/impl.py
@@ -606,9 +606,6 @@ def reset():
     for k in old_kernels:
         k.reset()
     _qd_core.reset_default_compile_config()
-    from quadrants.lang._func_base import _frozen_dc_plans  # pylint: disable=C0415
-
-    _frozen_dc_plans.clear()
 
     for hook in _reset_hooks:
         hook()

--- a/python/quadrants/lang/matrix.py
+++ b/python/quadrants/lang/matrix.py
@@ -11,6 +11,7 @@ from quadrants._lib import core as qd_python_core
 from quadrants._lib.utils import qd_python_core as _qd_python_core
 from quadrants.lang import expr, impl, runtime_ops
 from quadrants.lang import ops as ops_mod
+from quadrants.lang._metal_interop import mps_sync_if_metal
 from quadrants.lang._ndarray import Ndarray, NdarrayHostAccess
 from quadrants.lang.common_ops import QuadrantsOperations
 from quadrants.lang.exception import (
@@ -23,7 +24,6 @@ from quadrants.lang.field import (
     Field,
     ScalarField,
     SNodeHostAccess,
-    _mps_sync_if_metal,
     _try_zerocopy_numpy,
     _try_zerocopy_torch,
 )
@@ -1486,7 +1486,7 @@ class MatrixField(Field):
 
         matrix_to_ext_arr(self, arr, as_vector)
         runtime_ops.sync()
-        _mps_sync_if_metal()
+        mps_sync_if_metal()
         return arr
 
     @python_scope

--- a/quadrants/program/compile_config.h
+++ b/quadrants/program/compile_config.h
@@ -105,6 +105,10 @@ struct CompileConfig {
 
   size_t cuda_stack_limit{0};
 
+  // Metal backend: if non-zero, use this as an externally-owned MTLCommandQueue* instead of creating a new one.
+  // The caller retains ownership and must keep the queue alive for the lifetime of the Quadrants runtime.
+  uint64_t external_metal_command_queue{0};
+
   CompileConfig();
 
   void fit();

--- a/quadrants/program/compile_config.h
+++ b/quadrants/program/compile_config.h
@@ -109,6 +109,10 @@ struct CompileConfig {
   // The queue is borrowed (not retained) — the caller must keep it alive for the lifetime of the Quadrants runtime.
   uint64_t external_metal_command_queue{0};
 
+  // When true, the external_metal_command_queue is PyTorch MPS's queue, so Quadrants can skip explicit
+  // cross-framework synchronisation at interop points (to_torch / from_torch).
+  bool external_metal_command_queue_is_torch_queue{false};
+
   CompileConfig();
 
   void fit();

--- a/quadrants/program/compile_config.h
+++ b/quadrants/program/compile_config.h
@@ -106,7 +106,7 @@ struct CompileConfig {
   size_t cuda_stack_limit{0};
 
   // Metal backend: if non-zero, use this as an externally-owned MTLCommandQueue* instead of creating a new one.
-  // The caller retains ownership and must keep the queue alive for the lifetime of the Quadrants runtime.
+  // The queue is borrowed (not retained) — the caller must keep it alive for the lifetime of the Quadrants runtime.
   uint64_t external_metal_command_queue{0};
 
   CompileConfig();

--- a/quadrants/program/compile_config.h
+++ b/quadrants/program/compile_config.h
@@ -109,8 +109,8 @@ struct CompileConfig {
   // The queue is borrowed (not retained) — the caller must keep it alive for the lifetime of the Quadrants runtime.
   uint64_t external_metal_command_queue{0};
 
-  // When true, the external_metal_command_queue is PyTorch MPS's queue, so Quadrants can skip explicit
-  // cross-framework synchronisation at interop points (to_torch / from_torch).
+  // When true, the external_metal_command_queue is PyTorch MPS's queue, so Quadrants can skip explicit cross-framework
+  // synchronisation at interop points (to_torch / from_torch).
   bool external_metal_command_queue_is_torch_queue{false};
 
   CompileConfig();

--- a/quadrants/python/export_lang.cpp
+++ b/quadrants/python/export_lang.cpp
@@ -225,7 +225,8 @@ void export_lang(py::module &m) {
       .def_readwrite("offline_cache_cleaning_factor", &CompileConfig::offline_cache_cleaning_factor)
       .def_readwrite("num_compile_threads", &CompileConfig::num_compile_threads)
       .def_readwrite("vk_api_version", &CompileConfig::vk_api_version)
-      .def_readwrite("cuda_stack_limit", &CompileConfig::cuda_stack_limit);
+      .def_readwrite("cuda_stack_limit", &CompileConfig::cuda_stack_limit)
+      .def_readwrite("external_metal_command_queue", &CompileConfig::external_metal_command_queue);
 
   m.def("reset_default_compile_config", [&]() { default_compile_config = CompileConfig(); });
 

--- a/quadrants/python/export_lang.cpp
+++ b/quadrants/python/export_lang.cpp
@@ -226,7 +226,9 @@ void export_lang(py::module &m) {
       .def_readwrite("num_compile_threads", &CompileConfig::num_compile_threads)
       .def_readwrite("vk_api_version", &CompileConfig::vk_api_version)
       .def_readwrite("cuda_stack_limit", &CompileConfig::cuda_stack_limit)
-      .def_readwrite("external_metal_command_queue", &CompileConfig::external_metal_command_queue);
+      .def_readwrite("external_metal_command_queue", &CompileConfig::external_metal_command_queue)
+      .def_readwrite("external_metal_command_queue_is_torch_queue",
+                     &CompileConfig::external_metal_command_queue_is_torch_queue);
 
   m.def("reset_default_compile_config", [&]() { default_compile_config = CompileConfig(); });
 

--- a/quadrants/rhi/metal/metal_device.h
+++ b/quadrants/rhi/metal/metal_device.h
@@ -420,10 +420,12 @@ class MetalCommandList final : public CommandList {
 class MetalStream final : public Stream {
  public:
   // `mtl_command_queue` should be already retained.
-  explicit MetalStream(const MetalDevice &device, MTLCommandQueue_id mtl_command_queue);
+  // If `owns_queue` is false the stream will NOT release the queue on destruction (caller retains ownership).
+  explicit MetalStream(const MetalDevice &device, MTLCommandQueue_id mtl_command_queue, bool owns_queue = true);
   ~MetalStream() override;
 
   static MetalStream *create(const MetalDevice &device);
+  static MetalStream *create_with_external_queue(const MetalDevice &device, MTLCommandQueue_id external_queue);
   void destroy();
 
   MTLCommandQueue_id mtl_command_queue() const {
@@ -440,6 +442,7 @@ class MetalStream final : public Stream {
   const MetalDevice *device_;
   MTLCommandQueue_id mtl_command_queue_;
   std::vector<MTLCommandBuffer_id> pending_cmdbufs_;
+  bool owns_queue_{true};
   bool is_destroyed_{false};
 };
 
@@ -487,7 +490,8 @@ constexpr auto kMetalVertFunctionName = "vert_function";
 class MetalDevice final : public GraphicsDevice {
  public:
   // `mtl_device` should be already retained.
-  explicit MetalDevice(MTLDevice_id mtl_device);
+  // If `external_command_queue` is non-null, it is used instead of creating a new one (caller retains ownership).
+  explicit MetalDevice(MTLDevice_id mtl_device, MTLCommandQueue_id external_command_queue = nullptr);
   ~MetalDevice() override;
 
   Arch arch() const override {
@@ -498,6 +502,7 @@ class MetalDevice final : public GraphicsDevice {
   }
 
   static MetalDevice *create();
+  static MetalDevice *create_with_external_queue(uint64_t external_queue_ptr);
   void destroy();
 
   std::unique_ptr<Surface> create_surface(const SurfaceConfig &config) override;

--- a/quadrants/rhi/metal/metal_device.h
+++ b/quadrants/rhi/metal/metal_device.h
@@ -419,8 +419,9 @@ class MetalCommandList final : public CommandList {
 
 class MetalStream final : public Stream {
  public:
-  // `mtl_command_queue` should be already retained.
-  // If `owns_queue` is false the stream will NOT release the queue on destruction (caller retains ownership).
+  // When `owns_queue` is true (the default), `mtl_command_queue` should be already retained; the stream will
+  // release it on destruction.  When false, the queue is borrowed — the stream will NOT retain or release it,
+  // and the caller must keep it alive for the stream's lifetime.
   explicit MetalStream(const MetalDevice &device, MTLCommandQueue_id mtl_command_queue, bool owns_queue = true);
   ~MetalStream() override;
 
@@ -490,7 +491,8 @@ constexpr auto kMetalVertFunctionName = "vert_function";
 class MetalDevice final : public GraphicsDevice {
  public:
   // `mtl_device` should be already retained.
-  // If `external_command_queue` is non-null, it is used instead of creating a new one (caller retains ownership).
+  // If `external_command_queue` is non-null, it is used instead of creating a new one.  The queue is borrowed
+  // (not retained) — the caller must keep it alive for the device's lifetime.
   explicit MetalDevice(MTLDevice_id mtl_device, MTLCommandQueue_id external_command_queue = nullptr);
   ~MetalDevice() override;
 

--- a/quadrants/rhi/metal/metal_device.mm
+++ b/quadrants/rhi/metal/metal_device.mm
@@ -1016,18 +1016,26 @@ void MetalCommandList::blit_image(DeviceAllocation dst_img,
 MTLCommandBuffer_id MetalCommandList::finalize() { return cmdbuf_; }
 
 MetalStream::MetalStream(const MetalDevice &device,
-                         MTLCommandQueue_id mtl_command_queue)
-    : device_(&device), mtl_command_queue_(mtl_command_queue) {}
+                         MTLCommandQueue_id mtl_command_queue,
+                         bool owns_queue)
+    : device_(&device), mtl_command_queue_(mtl_command_queue), owns_queue_(owns_queue) {}
 MetalStream::~MetalStream() { destroy(); }
 
 MetalStream *MetalStream::create(const MetalDevice &device) {
   MTLCommandQueue_id compute_queue = [device.mtl_device() newCommandQueue];
-  return new MetalStream(device, compute_queue);
+  return new MetalStream(device, compute_queue, /*owns_queue=*/true);
+}
+MetalStream *MetalStream::create_with_external_queue(const MetalDevice &device,
+                                                     MTLCommandQueue_id external_queue) {
+  [external_queue retain];
+  return new MetalStream(device, external_queue, /*owns_queue=*/false);
 }
 void MetalStream::destroy() {
   if (!is_destroyed_) {
     command_sync();
-    [mtl_command_queue_ release];
+    if (owns_queue_) {
+      [mtl_command_queue_ release];
+    }
     is_destroyed_ = true;
   }
 }
@@ -1212,8 +1220,15 @@ void MetalSurface::resize(uint32_t width, uint32_t height) {
   layer_.drawableSize = CGSizeMake(width_, height_);
 }
 
-MetalDevice::MetalDevice(MTLDevice_id mtl_device) : mtl_device_(mtl_device) {
-  compute_stream_ = std::unique_ptr<MetalStream>(MetalStream::create(*this));
+MetalDevice::MetalDevice(MTLDevice_id mtl_device,
+                         MTLCommandQueue_id external_command_queue)
+    : mtl_device_(mtl_device) {
+  if (external_command_queue != nil) {
+    compute_stream_ =
+        std::unique_ptr<MetalStream>(MetalStream::create_with_external_queue(*this, external_command_queue));
+  } else {
+    compute_stream_ = std::unique_ptr<MetalStream>(MetalStream::create(*this));
+  }
 
   default_sampler_ = create_sampler(mtl_device);
 
@@ -1224,8 +1239,12 @@ MetalDevice::~MetalDevice() { destroy(); }
 
 MetalDevice *MetalDevice::create() {
   MTLDevice_id mtl_device = MTLCreateSystemDefaultDevice();
-
   return new MetalDevice(mtl_device);
+}
+MetalDevice *MetalDevice::create_with_external_queue(uint64_t external_queue_ptr) {
+  MTLDevice_id mtl_device = MTLCreateSystemDefaultDevice();
+  auto *queue = reinterpret_cast<MTLCommandQueue_id>(external_queue_ptr);
+  return new MetalDevice(mtl_device, queue);
 }
 void MetalDevice::destroy() {
   if (!is_destroyed_) {

--- a/quadrants/rhi/metal/metal_device.mm
+++ b/quadrants/rhi/metal/metal_device.mm
@@ -1028,7 +1028,6 @@ MetalStream *MetalStream::create(const MetalDevice &device) {
 MetalStream *
 MetalStream::create_with_external_queue(const MetalDevice &device,
                                         MTLCommandQueue_id external_queue) {
-  [external_queue retain];
   return new MetalStream(device, external_queue, /*owns_queue=*/false);
 }
 void MetalStream::destroy() {

--- a/quadrants/rhi/metal/metal_device.mm
+++ b/quadrants/rhi/metal/metal_device.mm
@@ -1016,17 +1016,18 @@ void MetalCommandList::blit_image(DeviceAllocation dst_img,
 MTLCommandBuffer_id MetalCommandList::finalize() { return cmdbuf_; }
 
 MetalStream::MetalStream(const MetalDevice &device,
-                         MTLCommandQueue_id mtl_command_queue,
-                         bool owns_queue)
-    : device_(&device), mtl_command_queue_(mtl_command_queue), owns_queue_(owns_queue) {}
+                         MTLCommandQueue_id mtl_command_queue, bool owns_queue)
+    : device_(&device), mtl_command_queue_(mtl_command_queue),
+      owns_queue_(owns_queue) {}
 MetalStream::~MetalStream() { destroy(); }
 
 MetalStream *MetalStream::create(const MetalDevice &device) {
   MTLCommandQueue_id compute_queue = [device.mtl_device() newCommandQueue];
   return new MetalStream(device, compute_queue, /*owns_queue=*/true);
 }
-MetalStream *MetalStream::create_with_external_queue(const MetalDevice &device,
-                                                     MTLCommandQueue_id external_queue) {
+MetalStream *
+MetalStream::create_with_external_queue(const MetalDevice &device,
+                                        MTLCommandQueue_id external_queue) {
   [external_queue retain];
   return new MetalStream(device, external_queue, /*owns_queue=*/false);
 }
@@ -1224,8 +1225,8 @@ MetalDevice::MetalDevice(MTLDevice_id mtl_device,
                          MTLCommandQueue_id external_command_queue)
     : mtl_device_(mtl_device) {
   if (external_command_queue != nil) {
-    compute_stream_ =
-        std::unique_ptr<MetalStream>(MetalStream::create_with_external_queue(*this, external_command_queue));
+    compute_stream_ = std::unique_ptr<MetalStream>(
+        MetalStream::create_with_external_queue(*this, external_command_queue));
   } else {
     compute_stream_ = std::unique_ptr<MetalStream>(MetalStream::create(*this));
   }
@@ -1241,7 +1242,8 @@ MetalDevice *MetalDevice::create() {
   MTLDevice_id mtl_device = MTLCreateSystemDefaultDevice();
   return new MetalDevice(mtl_device);
 }
-MetalDevice *MetalDevice::create_with_external_queue(uint64_t external_queue_ptr) {
+MetalDevice *
+MetalDevice::create_with_external_queue(uint64_t external_queue_ptr) {
   MTLDevice_id mtl_device = MTLCreateSystemDefaultDevice();
   auto *queue = reinterpret_cast<MTLCommandQueue_id>(external_queue_ptr);
   return new MetalDevice(mtl_device, queue);

--- a/quadrants/runtime/program_impls/metal/metal_program.cpp
+++ b/quadrants/runtime/program_impls/metal/metal_program.cpp
@@ -17,7 +17,12 @@ void MetalProgramImpl::materialize_runtime(KernelProfilerBase *profiler, uint64 
   *result_buffer_ptr =
       (uint64 *)HostMemoryPool::get_instance().allocate(sizeof(uint64) * quadrants_result_buffer_entries, 8);
 
-  device_ = std::unique_ptr<metal::MetalDevice>(metal::MetalDevice::create());
+  if (config->external_metal_command_queue != 0) {
+    device_ = std::unique_ptr<metal::MetalDevice>(
+        metal::MetalDevice::create_with_external_queue(config->external_metal_command_queue));
+  } else {
+    device_ = std::unique_ptr<metal::MetalDevice>(metal::MetalDevice::create());
+  }
 
   gfx::GfxRuntime::Params params;
   params.device = device_.get();

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -162,6 +162,7 @@ user_api[qd] = [
     "ikl",
     "il",
     "init",
+    "interop",
     "int16",
     "int32",
     "int64",
@@ -454,6 +455,7 @@ user_api[qd.VectorNdarray] = [
     "to_numpy",
     "to_torch",
 ]
+user_api[qd.interop] = ["get_mps_command_queue"]
 user_api[qd.sparse] = ["grid", "usage"]
 
 

--- a/tests/python/test_metal_shared_queue.py
+++ b/tests/python/test_metal_shared_queue.py
@@ -12,9 +12,6 @@ pytestmark = pytest.mark.needs_torch
 
 def _get_mps_command_queue() -> int:
     """Extract PyTorch MPS's MTLCommandQueue* via ``qd.interop``."""
-    import torch
-
-    torch.zeros(1, device="mps")
     queue_ptr = qd.interop.get_mps_command_queue()
     if not queue_ptr:
         pytest.skip("qd.interop.get_mps_command_queue() returned 0")
@@ -139,7 +136,6 @@ def test_interop_get_mps_command_queue():
 
     if not hasattr(torch.backends, "mps") or not torch.backends.mps.is_available():
         pytest.skip("PyTorch MPS not available")
-    torch.zeros(1, device="mps")
     ptr = qd.interop.get_mps_command_queue()
     assert isinstance(ptr, int)
     assert ptr != 0

--- a/tests/python/test_metal_shared_queue.py
+++ b/tests/python/test_metal_shared_queue.py
@@ -11,45 +11,13 @@ pytestmark = pytest.mark.needs_torch
 
 
 def _get_mps_command_queue() -> int:
-    """Extract PyTorch MPS's MTLCommandQueue* as a Python int.
-
-    Uses dlsym + ObjC runtime to reach into PyTorch's C++ internals without any build-time dependency.
-    """
-    import ctypes
-    import os
-
+    """Extract PyTorch MPS's MTLCommandQueue* via ``qd.interop``."""
     import torch
 
     torch.zeros(1, device="mps")
-
-    torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib", "libtorch_cpu.dylib")
-    handle = ctypes.CDLL(torch_lib)._handle
-
-    libdl = ctypes.CDLL(None)
-    dlsym = libdl.dlsym
-    dlsym.restype = ctypes.c_void_p
-    dlsym.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
-
-    func_addr = dlsym(handle, b"_ZN2at3mps19getDefaultMPSStreamEv")
-    if func_addr is None:
-        pytest.skip("Cannot find getDefaultMPSStream symbol")
-    stream_ptr = ctypes.CFUNCTYPE(ctypes.c_void_p)(func_addr)()
-
-    cb_addr = dlsym(handle, b"_ZN2at3mps9MPSStream13commandBufferEv")
-    if cb_addr is None:
-        pytest.skip("Cannot find MPSStream::commandBuffer symbol")
-    cb_ptr = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p)(cb_addr)(stream_ptr)
-
-    objc = ctypes.CDLL("/usr/lib/libobjc.A.dylib")
-    sel_reg = objc.sel_registerName
-    sel_reg.restype = ctypes.c_void_p
-    sel_reg.argtypes = [ctypes.c_char_p]
-    msg_send = objc.objc_msgSend
-    msg_send.restype = ctypes.c_void_p
-    msg_send.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-
-    queue_ptr = msg_send(cb_ptr, sel_reg(b"commandQueue"))
-    assert queue_ptr, "Failed to extract MTLCommandQueue from PyTorch MPS"
+    queue_ptr = qd.interop.get_mps_command_queue()
+    if not queue_ptr:
+        pytest.skip("qd.interop.get_mps_command_queue() returned 0")
     return queue_ptr
 
 
@@ -162,6 +130,19 @@ def test_sync_skipped_with_shared_queue():
 
         mps_sync_if_metal()
         mock_mps_sync.assert_not_called()
+
+
+@test_utils.test(arch=[qd.metal])
+def test_interop_get_mps_command_queue():
+    """qd.interop.get_mps_command_queue() returns a non-zero pointer on MPS-capable machines."""
+    import torch
+
+    if not hasattr(torch.backends, "mps") or not torch.backends.mps.is_available():
+        pytest.skip("PyTorch MPS not available")
+    torch.zeros(1, device="mps")
+    ptr = qd.interop.get_mps_command_queue()
+    assert isinstance(ptr, int)
+    assert ptr != 0
 
 
 @test_utils.test(arch=[qd.metal])

--- a/tests/python/test_metal_shared_queue.py
+++ b/tests/python/test_metal_shared_queue.py
@@ -1,0 +1,153 @@
+"""Tests for the external Metal command queue feature (``external_metal_command_queue``)."""
+
+import platform
+
+import numpy as np
+import pytest
+
+import quadrants as qd
+from tests import test_utils
+
+
+def _get_mps_command_queue() -> int:
+    """Extract PyTorch MPS's MTLCommandQueue* as a Python int.
+
+    Uses dlsym + ObjC runtime to reach into PyTorch's C++ internals without any build-time dependency.
+    """
+    import ctypes
+    import os
+
+    import torch
+
+    torch.zeros(1, device="mps")
+
+    torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib", "libtorch_cpu.dylib")
+    handle = ctypes.CDLL(torch_lib)._handle
+
+    libdl = ctypes.CDLL(None)
+    dlsym = libdl.dlsym
+    dlsym.restype = ctypes.c_void_p
+    dlsym.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+
+    func_addr = dlsym(handle, b"_ZN2at3mps19getDefaultMPSStreamEv")
+    if func_addr is None:
+        pytest.skip("Cannot find getDefaultMPSStream symbol")
+    stream_ptr = ctypes.CFUNCTYPE(ctypes.c_void_p)(func_addr)()
+
+    cb_addr = dlsym(handle, b"_ZN2at3mps9MPSStream13commandBufferEv")
+    if cb_addr is None:
+        pytest.skip("Cannot find MPSStream::commandBuffer symbol")
+    cb_ptr = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p)(cb_addr)(stream_ptr)
+
+    objc = ctypes.CDLL("/usr/lib/libobjc.A.dylib")
+    sel_reg = objc.sel_registerName
+    sel_reg.restype = ctypes.c_void_p
+    sel_reg.argtypes = [ctypes.c_char_p]
+    msg_send = objc.objc_msgSend
+    msg_send.restype = ctypes.c_void_p
+    msg_send.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+    queue_ptr = msg_send(cb_ptr, sel_reg(b"commandQueue"))
+    assert queue_ptr, "Failed to extract MTLCommandQueue from PyTorch MPS"
+    return queue_ptr
+
+
+def _reinit_with_shared_queue():
+    """Reset and re-init Quadrants with PyTorch MPS's shared command queue."""
+    import torch
+
+    if not hasattr(torch.backends, "mps") or not torch.backends.mps.is_available():
+        pytest.skip("PyTorch MPS not available")
+    queue_ptr = _get_mps_command_queue()
+    qd.reset()
+    qd.init(arch=qd.metal, external_metal_command_queue=queue_ptr)
+    return queue_ptr
+
+
+@test_utils.test(arch=[qd.metal])
+def test_init_with_external_queue():
+    """Quadrants initializes successfully with an external Metal command queue."""
+    queue_ptr = _reinit_with_shared_queue()
+    assert qd.cfg.external_metal_command_queue == queue_ptr
+
+    x = qd.field(dtype=qd.f32, shape=(16,))
+
+    @qd.kernel
+    def fill():
+        for i in x:
+            x[i] = 42.0
+
+    fill()
+    qd.sync()
+    np.testing.assert_allclose(x.to_numpy(), np.full(16, 42.0))
+
+
+@test_utils.test(arch=[qd.metal])
+def test_init_without_external_queue():
+    """Default init (no external queue) still works and config field is 0."""
+    assert qd.cfg.external_metal_command_queue == 0
+
+    x = qd.field(dtype=qd.f32, shape=(4,))
+
+    @qd.kernel
+    def fill():
+        for i in x:
+            x[i] = 7.0
+
+    fill()
+    qd.sync()
+    np.testing.assert_allclose(x.to_numpy(), np.full(4, 7.0))
+
+
+@test_utils.test(arch=[qd.metal])
+def test_zerocopy_with_shared_queue():
+    """Zero-copy torch tensor is valid and on MPS device when using a shared queue."""
+    import torch
+
+    _reinit_with_shared_queue()
+
+    x = qd.field(dtype=qd.f32, shape=(64,))
+
+    @qd.kernel
+    def write_val(v: qd.f32):
+        for i in x:
+            x[i] = v
+
+    write_val(42.0)
+    qd.sync()
+    tc = x.to_torch(copy=False)
+    assert tc.device.type == "mps"
+    assert tc.shape == (64,)
+
+    clone = tc.clone()
+    torch.mps.synchronize()
+    np.testing.assert_allclose(clone.cpu().numpy(), np.full(64, 42.0))
+
+
+@test_utils.test(arch=[qd.metal])
+def test_sync_skipped_with_shared_queue():
+    """When using a shared queue, _mps_sync_if_metal and _try_zerocopy_torch skip explicit sync."""
+    from unittest.mock import patch
+
+    import torch  # noqa: F401
+
+    _reinit_with_shared_queue()
+
+    x = qd.field(dtype=qd.f32, shape=(4,))
+
+    @qd.kernel
+    def fill():
+        for i in x:
+            x[i] = 1.0
+
+    fill()
+
+    with patch("quadrants.lang.runtime_ops.sync") as mock_sync:
+        x.to_torch(copy=False)
+        mock_sync.assert_not_called()
+
+    with patch("torch.mps.synchronize") as mock_mps_sync:
+        from quadrants.lang.field import _mps_sync_if_metal
+
+        _mps_sync_if_metal()
+        mock_mps_sync.assert_not_called()

--- a/tests/python/test_metal_shared_queue.py
+++ b/tests/python/test_metal_shared_queue.py
@@ -7,6 +7,8 @@ import quadrants as qd
 
 from tests import test_utils
 
+pytestmark = pytest.mark.needs_torch
+
 
 def _get_mps_command_queue() -> int:
     """Extract PyTorch MPS's MTLCommandQueue* as a Python int.

--- a/tests/python/test_metal_shared_queue.py
+++ b/tests/python/test_metal_shared_queue.py
@@ -134,7 +134,7 @@ def test_zerocopy_with_shared_queue():
 @test_utils.test(arch=[qd.metal])
 def test_sync_skipped_with_shared_queue():
     """When using a shared queue, mps_sync_if_metal and _try_zerocopy_torch skip explicit sync."""
-    from unittest.mock import patch
+    from unittest.mock import MagicMock, patch
 
     import torch  # noqa: F401
 
@@ -149,7 +149,11 @@ def test_sync_skipped_with_shared_queue():
 
     fill()
 
-    with patch("quadrants.lang.runtime_ops.sync") as mock_sync:
+    from quadrants.lang import impl
+
+    runtime = impl.get_runtime()
+    mock_sync = MagicMock()
+    with patch.object(runtime, "sync", mock_sync):
         x.to_torch(copy=False)
         mock_sync.assert_not_called()
 

--- a/tests/python/test_metal_shared_queue.py
+++ b/tests/python/test_metal_shared_queue.py
@@ -1,11 +1,10 @@
 """Tests for the external Metal command queue feature (``external_metal_command_queue``)."""
 
-import platform
-
 import numpy as np
 import pytest
 
 import quadrants as qd
+
 from tests import test_utils
 
 

--- a/tests/python/test_metal_shared_queue.py
+++ b/tests/python/test_metal_shared_queue.py
@@ -53,7 +53,7 @@ def _get_mps_command_queue() -> int:
     return queue_ptr
 
 
-def _reinit_with_shared_queue():
+def _reinit_with_shared_queue(is_torch_queue=True):
     """Reset and re-init Quadrants with PyTorch MPS's shared command queue."""
     import torch
 
@@ -61,7 +61,11 @@ def _reinit_with_shared_queue():
         pytest.skip("PyTorch MPS not available")
     queue_ptr = _get_mps_command_queue()
     qd.reset()
-    qd.init(arch=qd.metal, external_metal_command_queue=queue_ptr)
+    qd.init(
+        arch=qd.metal,
+        external_metal_command_queue=queue_ptr,
+        external_metal_command_queue_is_torch_queue=is_torch_queue,
+    )
     return queue_ptr
 
 
@@ -70,6 +74,7 @@ def test_init_with_external_queue():
     """Quadrants initializes successfully with an external Metal command queue."""
     queue_ptr = _reinit_with_shared_queue()
     assert qd.cfg.external_metal_command_queue == queue_ptr
+    assert qd.cfg.external_metal_command_queue_is_torch_queue is True
 
     x = qd.field(dtype=qd.f32, shape=(16,))
 
@@ -87,6 +92,7 @@ def test_init_with_external_queue():
 def test_init_without_external_queue():
     """Default init (no external queue) still works and config field is 0."""
     assert qd.cfg.external_metal_command_queue == 0
+    assert qd.cfg.external_metal_command_queue_is_torch_queue is False
 
     x = qd.field(dtype=qd.f32, shape=(4,))
 
@@ -152,3 +158,39 @@ def test_sync_skipped_with_shared_queue():
 
         _mps_sync_if_metal()
         mock_mps_sync.assert_not_called()
+
+
+@test_utils.test(arch=[qd.metal])
+def test_sync_preserved_with_non_torch_external_queue():
+    """When external queue is provided but is_torch_queue=False, syncs still fire."""
+    from unittest.mock import MagicMock, patch
+
+    import torch  # noqa: F401
+
+    _reinit_with_shared_queue(is_torch_queue=False)
+    assert qd.cfg.external_metal_command_queue != 0
+    assert qd.cfg.external_metal_command_queue_is_torch_queue is False
+
+    x = qd.field(dtype=qd.f32, shape=(4,))
+
+    @qd.kernel
+    def fill():
+        for i in x:
+            x[i] = 1.0
+
+    fill()
+
+    from quadrants.lang import impl
+
+    runtime = impl.get_runtime()
+    original_sync = runtime.sync
+    mock_sync = MagicMock(side_effect=original_sync)
+    with patch.object(runtime, "sync", mock_sync):
+        x.to_torch(copy=False)
+        mock_sync.assert_called()
+
+    with patch("torch.mps.synchronize") as mock_mps_sync:
+        from quadrants.lang.field import _mps_sync_if_metal
+
+        _mps_sync_if_metal()
+        mock_mps_sync.assert_called()

--- a/tests/python/test_metal_shared_queue.py
+++ b/tests/python/test_metal_shared_queue.py
@@ -133,7 +133,7 @@ def test_zerocopy_with_shared_queue():
 
 @test_utils.test(arch=[qd.metal])
 def test_sync_skipped_with_shared_queue():
-    """When using a shared queue, _mps_sync_if_metal and _try_zerocopy_torch skip explicit sync."""
+    """When using a shared queue, mps_sync_if_metal and _try_zerocopy_torch skip explicit sync."""
     from unittest.mock import patch
 
     import torch  # noqa: F401
@@ -154,9 +154,9 @@ def test_sync_skipped_with_shared_queue():
         mock_sync.assert_not_called()
 
     with patch("torch.mps.synchronize") as mock_mps_sync:
-        from quadrants.lang.field import _mps_sync_if_metal
+        from quadrants.lang._metal_interop import mps_sync_if_metal
 
-        _mps_sync_if_metal()
+        mps_sync_if_metal()
         mock_mps_sync.assert_not_called()
 
 
@@ -190,7 +190,7 @@ def test_sync_preserved_with_non_torch_external_queue():
         mock_sync.assert_called()
 
     with patch("torch.mps.synchronize") as mock_mps_sync:
-        from quadrants.lang.field import _mps_sync_if_metal
+        from quadrants.lang._metal_interop import mps_sync_if_metal
 
-        _mps_sync_if_metal()
+        mps_sync_if_metal()
         mock_mps_sync.assert_called()


### PR DESCRIPTION
Allow callers (e.g. Genesis) to share PyTorch MPS's MTLCommandQueue with Quadrants so both frameworks dispatch GPU work on the same Metal queue. This eliminates the need for qd.sync() + torch.mps.synchronize() at every DLPack zero-copy interop point — Metal's sequential command buffer semantics guarantee ordering automatically.

Changes:
- CompileConfig: add external_metal_command_queue (uint64_t, default 0)
- MetalStream: add owns_queue_ flag; create_with_external_queue() factory
- MetalDevice: accept optional external queue; create_with_external_queue()
- MetalProgramImpl: route config→device creation
- export_lang.cpp: expose new field to Python
- field.py: gate qd.sync() and torch.mps.synchronize() on shared queue
- test_metal_shared_queue.py: 4 tests covering init, zero-copy, and sync gating

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
