### PR TITLE
[Perf] Generic launcher: persistent context, JIT-pointer reuse, Metal compute encoder, LLVM-GPU async memory ops (Part 1/2)

### DIFF
--- a/quadrants/program/program.cpp
+++ b/quadrants/program/program.cpp
@@ -199,6 +199,8 @@ void Program::destroy_snode_tree(SNodeTree *snode_tree) {
 
   program_impl_->destroy_snode_tree(snode_tree);
   free_snode_tree_ids_.push(snode_tree->id());
+  // The destroyed tree's `SNode *`s are about to be freed; cached entries pointing into them must go.
+  snode_id_cache_.clear();
 }
 
 SNodeTree *Program::add_snode_tree(std::unique_ptr<SNode> root, bool compile_only) {
@@ -216,6 +218,8 @@ SNodeTree *Program::add_snode_tree(std::unique_ptr<SNode> root, bool compile_onl
     QD_ASSERT(id == snode_trees_.size());
     snode_trees_.push_back(std::move(tree));
   }
+  // Wipe so any negative `nullptr` entry in the cache does not shadow an snode id newly satisfiable by this tree.
+  snode_id_cache_.clear();
   return snode_trees_[id].get();
 }
 
@@ -225,6 +229,16 @@ SNode *Program::get_snode_root(int tree_id) {
 
 void Program::synchronize() {
   program_impl_->synchronize();
+}
+
+void Program::synchronize_and_assert() {
+  program_impl_->synchronize_and_assert();
+}
+
+void Program::record_size_expr_eval(const SerializedSizeExpr *expr_key,
+                                    int64_t result,
+                                    std::vector<SizeExprReadObservation> reads) {
+  size_expr_cache_[expr_key] = SizeExprCacheEntry{result, std::move(reads)};
 }
 
 StreamSemaphore Program::flush() {
@@ -251,11 +265,16 @@ SNode *find_snode_by_id_recursive(SNode *root, int snode_id) {
 }  // namespace
 
 SNode *Program::get_snode_by_id(int snode_id) {
+  auto it = snode_id_cache_.find(snode_id);
+  if (it != snode_id_cache_.end())
+    return it->second;
   for (auto &tree : snode_trees_) {
     if (auto *hit = find_snode_by_id_recursive(tree->root(), snode_id)) {
+      snode_id_cache_[snode_id] = hit;
       return hit;
     }
   }
+  snode_id_cache_[snode_id] = nullptr;
   return nullptr;
 }
 

--- a/quadrants/program/program.h
+++ b/quadrants/program/program.h
@@ -100,7 +100,11 @@ class QD_DLL_EXPORT Program {
     return profiler.get();
   }
 
+  // Drain the backend command queue. Does not raise; for internal use only.
   void synchronize();
+
+  // Drain the queue and raise on any pending user-visible assert (e.g. adstack overflow). Bound to `qd.sync()`.
+  void synchronize_and_assert();
 
   StreamSemaphore flush();
 
@@ -198,11 +202,37 @@ class QD_DLL_EXPORT Program {
     return snode_rw_accessors_bank_;
   }
 
-  // Look up an `SNode` in this `Program`'s snode trees by its global `SNode::id`. Used by the host-side adstack
-  // size-expression evaluator to rehydrate an `SNode *` from a `snode_id` that survived the offline cache. Linear
-  // over all snode trees; called at most once per adstack leaf per kernel launch so the cost is negligible in
-  // practice.
+  // Resolve an `SNode *` from its global `SNode::id`. Lazy `snode_id_cache_` lookup; the cache is wiped by
+  // `add_snode_tree` and `destroy_snode_tree`.
   SNode *get_snode_by_id(int snode_id);
+
+  // One input read observed during a `evaluate_adstack_size_expr` walk. The cache entry records these so
+  // a subsequent lookup re-reads the same inputs and compares to `observed_value`; a single mismatch
+  // forces a full re-walk.
+  struct SizeExprReadObservation {
+    enum Kind : uint8_t { FieldLoadObs, ExternalShapeObs, ExternalReadObs };
+    Kind kind;
+    int snode_id;                  // FieldLoad
+    std::vector<int> indices;      // FieldLoad / ExternalReadObs: resolved indices
+    std::vector<int> arg_id_path;  // External*: arg_id_path
+    int arg_shape_axis;            // ExternalShapeObs
+    int prim_dt;                   // ExternalReadObs: PrimitiveTypeID
+    int64_t observed_value;
+  };
+  struct SizeExprCacheEntry {
+    int64_t result;
+    std::vector<SizeExprReadObservation> reads;
+  };
+  // Replay the recorded reads against the live state and `ctx`; on full match write `result` to
+  // `out_result` and return true. Any mismatch erases the entry and returns false, leaving the caller
+  // to run a full eval and repopulate the cache via `record_size_expr_eval`.
+  bool try_size_expr_cache_hit(const SerializedSizeExpr *expr_key, LaunchContextBuilder *ctx, int64_t &out_result);
+  void record_size_expr_eval(const SerializedSizeExpr *expr_key,
+                             int64_t result,
+                             std::vector<SizeExprReadObservation> reads);
+  void invalidate_size_expr_cache() {
+    size_expr_cache_.clear();
+  }
 
   /**
    * Destroys a new SNode tree.
@@ -338,6 +368,10 @@ class QD_DLL_EXPORT Program {
   SNodeRwAccessorsBank snode_rw_accessors_bank_;
 
   std::vector<std::unique_ptr<SNodeTree>> snode_trees_;
+  // Lazy cache for `get_snode_by_id`. Invalidated by `add_snode_tree` and `destroy_snode_tree`.
+  std::unordered_map<int, SNode *> snode_id_cache_;
+  // Cache backing `try_size_expr_cache_hit` / `record_size_expr_eval`.
+  std::unordered_map<const SerializedSizeExpr *, SizeExprCacheEntry> size_expr_cache_;
   std::stack<int> free_snode_tree_ids_;
 
   std::vector<std::unique_ptr<Function>> functions_;

--- a/quadrants/program/program.h
+++ b/quadrants/program/program.h
@@ -202,8 +202,10 @@ class QD_DLL_EXPORT Program {
     return snode_rw_accessors_bank_;
   }
 
-  // Resolve an `SNode *` from its global `SNode::id`. Lazy `snode_id_cache_` lookup; the cache is wiped by
-  // `add_snode_tree` and `destroy_snode_tree`.
+  // Look up an `SNode` in this `Program`'s snode trees by its global `SNode::id`. Used by the host-side adstack
+  // size-expression evaluator to rehydrate an `SNode *` from a `snode_id` that survived the offline cache. Linear
+  // over all snode trees; called at most once per adstack leaf per kernel launch so the cost is negligible in
+  // practice.
   SNode *get_snode_by_id(int snode_id);
 
   // One input read observed during a `evaluate_adstack_size_expr` walk. The cache entry records these so

--- a/quadrants/program/program_impl.h
+++ b/quadrants/program/program_impl.h
@@ -66,9 +66,17 @@ class ProgramImpl {
   virtual std::size_t get_snode_num_dynamically_allocated(SNode *snode, uint64 *result_buffer) = 0;
 
   /**
-   * Perform a backend synchronization.
+   * Drain the backend command queue. Does not raise.
    */
   virtual void synchronize() = 0;
+
+  /**
+   * Drain the queue and raise on any pending user-visible assert (e.g. adstack overflow). Override on
+   * backends that have such asserts.
+   */
+  virtual void synchronize_and_assert() {
+    synchronize();
+  }
 
   virtual StreamSemaphore flush() {
     synchronize();
@@ -135,9 +143,8 @@ class ProgramImpl {
   virtual void finalize() {
   }
 
-  // Hook invoked by `Program::finalize()` before any teardown sync. Lets backends flip state (e.g. the LLVM
-  // `finalizing_` flag used to suppress adstack-overflow polling) so the two `Program::synchronize()` calls that
-  // precede `finalize()` do not throw into the Program destructor path.
+  // Invoked by `Program::finalize()` before any teardown sync, so the backend can flip state that
+  // silences user-visible asserts during destructor unwinding.
   virtual void pre_finalize() {
   }
 

--- a/quadrants/program/program_impl.h
+++ b/quadrants/program/program_impl.h
@@ -143,8 +143,9 @@ class ProgramImpl {
   virtual void finalize() {
   }
 
-  // Invoked by `Program::finalize()` before any teardown sync, so the backend can flip state that
-  // silences user-visible asserts during destructor unwinding.
+  // Hook invoked by `Program::finalize()` before any teardown sync. Lets backends flip state (e.g. the LLVM
+  // `finalizing_` flag used to suppress adstack-overflow polling) so the two `Program::synchronize()` calls that
+  // precede `finalize()` do not throw into the Program destructor path.
   virtual void pre_finalize() {
   }
 

--- a/quadrants/program/snode_rw_accessors_bank.cpp
+++ b/quadrants/program/snode_rw_accessors_bank.cpp
@@ -23,18 +23,27 @@ SNodeRwAccessorsBank::Accessors SNodeRwAccessorsBank::get(SNode *snode) {
   return Accessors(snode, kernels, program_);
 }
 
-SNodeRwAccessorsBank::Accessors::Accessors(const SNode *snode, const RwKernels &kernels, Program *prog)
-    : snode_(snode), prog_(prog), reader_(kernels.reader), writer_(kernels.writer) {
+SNodeRwAccessorsBank::Accessors::Accessors(const SNode *snode, RwKernels &kernels, Program *prog)
+    : snode_(snode), prog_(prog), reader_(kernels.reader), writer_(kernels.writer), kernels_(kernels) {
   QD_ASSERT(reader_ != nullptr);
   QD_ASSERT(writer_ != nullptr);
 }
+
+// Compile on first call, memoise the result in `slot`, and reuse on every subsequent call.
+static const CompiledKernelData &get_or_compile(const CompiledKernelData *&slot, Program *prog, const Kernel &k) {
+  if (slot == nullptr) {
+    CompileResult compile_result = prog->compile_kernel(prog->compile_config(), prog->get_device_caps(), k);
+    slot = &compile_result.compiled_kernel_data;
+  }
+  return *slot;
+}
+
 void SNodeRwAccessorsBank::Accessors::write_float(const std::vector<int> &I, float64 val) {
   auto launch_ctx = writer_->make_launch_context();
   set_kernel_args(I, snode_->num_active_indices, &launch_ctx);
   launch_ctx.set_arg_float(snode_->num_active_indices, val);
   prog_->synchronize();
-  CompileResult compile_result = prog_->compile_kernel(prog_->compile_config(), prog_->get_device_caps(), *writer_);
-  auto &compiled_kernel_data = compile_result.compiled_kernel_data;
+  const auto &compiled_kernel_data = get_or_compile(kernels_.writer_compiled, prog_, *writer_);
   prog_->launch_kernel(compiled_kernel_data, launch_ctx);
 }
 
@@ -42,9 +51,7 @@ float64 SNodeRwAccessorsBank::Accessors::read_float(const std::vector<int> &I) {
   prog_->synchronize();
   auto launch_ctx = reader_->make_launch_context();
   set_kernel_args(I, snode_->num_active_indices, &launch_ctx);
-  const CompileResult compile_result =
-      prog_->compile_kernel(prog_->compile_config(), prog_->get_device_caps(), *reader_);
-  auto &compiled_kernel_data = compile_result.compiled_kernel_data;
+  const auto &compiled_kernel_data = get_or_compile(kernels_.reader_compiled, prog_, *reader_);
   prog_->launch_kernel(compiled_kernel_data, launch_ctx);
   prog_->synchronize();
   return launch_ctx.get_struct_ret_float({0});
@@ -56,8 +63,7 @@ void SNodeRwAccessorsBank::Accessors::write_int(const std::vector<int> &I, int64
   set_kernel_args(I, snode_->num_active_indices, &launch_ctx);
   launch_ctx.set_arg_int(snode_->num_active_indices, val);
   prog_->synchronize();
-  CompileResult compile_result = prog_->compile_kernel(prog_->compile_config(), prog_->get_device_caps(), *writer_);
-  auto &compiled_kernel_data = compile_result.compiled_kernel_data;
+  const auto &compiled_kernel_data = get_or_compile(kernels_.writer_compiled, prog_, *writer_);
   prog_->launch_kernel(compiled_kernel_data, launch_ctx);
 }
 
@@ -67,8 +73,7 @@ void SNodeRwAccessorsBank::Accessors::write_uint(const std::vector<int> &I, uint
   set_kernel_args(I, snode_->num_active_indices, &launch_ctx);
   launch_ctx.set_arg_uint(snode_->num_active_indices, val);
   prog_->synchronize();
-  CompileResult compile_result = prog_->compile_kernel(prog_->compile_config(), prog_->get_device_caps(), *writer_);
-  auto &compiled_kernel_data = compile_result.compiled_kernel_data;
+  const auto &compiled_kernel_data = get_or_compile(kernels_.writer_compiled, prog_, *writer_);
   prog_->launch_kernel(compiled_kernel_data, launch_ctx);
 }
 
@@ -76,8 +81,7 @@ int64 SNodeRwAccessorsBank::Accessors::read_int(const std::vector<int> &I) {
   prog_->synchronize();
   auto launch_ctx = reader_->make_launch_context();
   set_kernel_args(I, snode_->num_active_indices, &launch_ctx);
-  CompileResult compile_result = prog_->compile_kernel(prog_->compile_config(), prog_->get_device_caps(), *reader_);
-  auto &compiled_kernel_data = compile_result.compiled_kernel_data;
+  const auto &compiled_kernel_data = get_or_compile(kernels_.reader_compiled, prog_, *reader_);
   prog_->launch_kernel(compiled_kernel_data, launch_ctx);
   prog_->synchronize();
   return launch_ctx.get_struct_ret_int({0});
@@ -87,8 +91,7 @@ uint64 SNodeRwAccessorsBank::Accessors::read_uint(const std::vector<int> &I) {
   prog_->synchronize();
   auto launch_ctx = reader_->make_launch_context();
   set_kernel_args(I, snode_->num_active_indices, &launch_ctx);
-  CompileResult compile_result = prog_->compile_kernel(prog_->compile_config(), prog_->get_device_caps(), *reader_);
-  auto &compiled_kernel_data = compile_result.compiled_kernel_data;
+  const auto &compiled_kernel_data = get_or_compile(kernels_.reader_compiled, prog_, *reader_);
   prog_->launch_kernel(compiled_kernel_data, launch_ctx);
   prog_->synchronize();
   return launch_ctx.get_struct_ret_uint({0});

--- a/quadrants/program/snode_rw_accessors_bank.h
+++ b/quadrants/program/snode_rw_accessors_bank.h
@@ -8,24 +8,29 @@
 namespace quadrants::lang {
 
 class Program;
+class CompiledKernelData;
 
 /** A mapping from an SNode to its read/write access kernels.
  *
- * The main purpose of this class is to decouple the accessor kernels from the
- * SNode class itself. Ideally, SNode should be nothing more than a group of
- * plain data.
+ * The main purpose of this class is to decouple the accessor kernels from the SNode class itself.
+ * Ideally, SNode should be nothing more than a group of plain data.
+ *
+ * `RwKernels` also memoises each SNode's `CompiledKernelData *` so repeated reads/writes bypass the
+ * string-keyed `KernelCompilationManager` lookup.
  */
 class SNodeRwAccessorsBank {
  private:
   struct RwKernels {
     Kernel *reader{nullptr};
     Kernel *writer{nullptr};
+    const CompiledKernelData *reader_compiled{nullptr};
+    const CompiledKernelData *writer_compiled{nullptr};
   };
 
  public:
   class Accessors {
    public:
-    explicit Accessors(const SNode *snode, const RwKernels &kernels, Program *prog);
+    explicit Accessors(const SNode *snode, RwKernels &kernels, Program *prog);
 
     // for float and double
     void write_float(const std::vector<int> &I, float64 val);
@@ -42,6 +47,7 @@ class SNodeRwAccessorsBank {
     Program *prog_;
     Kernel *reader_;
     Kernel *writer_;
+    RwKernels &kernels_;
   };
 
   explicit SNodeRwAccessorsBank(Program *program) : program_(program) {

--- a/quadrants/python/export_lang.cpp
+++ b/quadrants/python/export_lang.cpp
@@ -351,7 +351,7 @@ void export_lang(py::module &m) {
       .def("finalize", &Program::finalize)
       .def("get_total_compilation_time", &Program::get_total_compilation_time)
       .def("get_snode_num_dynamically_allocated", &Program::get_snode_num_dynamically_allocated)
-      .def("synchronize", &Program::synchronize)
+      .def("synchronize", &Program::synchronize_and_assert)
       .def("materialize_runtime", &Program::materialize_runtime)
       .def("get_snode_tree_size", &Program::get_snode_tree_size)
       .def("get_snode_root", &Program::get_snode_root, py::return_value_policy::reference)

--- a/quadrants/rhi/metal/metal_device.h
+++ b/quadrants/rhi/metal/metal_device.h
@@ -175,15 +175,18 @@ struct MetalShaderBindingMapping {
   // Map GLSL binding to MSL index (buffer/texture index, sampler index)
   std::unordered_map<int, std::pair<int, int>> vertex;
   std::unordered_map<int, std::pair<int, int>> fragment;
-  // The highest used buffer index used in the MSL vertex function Vertex attributes use up vertex buffer indices in
-  // Metal, but SPIRV-cross generated MSL doesn't know how many buffer indices the vertex attributes will take. So bind
-  // vertex input after the other buffers.
+  // The highest used buffer index used in the MSL vertex function
+  // Vertex attributes use up vertex buffer indices in Metal, but
+  // SPIRV-cross generated MSL doesn't know how many buffer indices
+  // the vertex attributes will take. So bind vertex input after the other
+  // buffers.
   int max_vert_buffer_index{-1};
 };
 
 class MetalPipeline final : public Pipeline, public rhi_impl::NonAssignable {
  public:
-  // `mtl_library`, `mtl_function`, `mtl_compute_pipeline_state` should be already retained.
+  // `mtl_library`, `mtl_function`, `mtl_compute_pipeline_state` should be
+  // already retained.
   explicit MetalPipeline(const MetalDevice &device,
                          MTLLibrary_id mtl_library,
                          MTLFunction_id mtl_function,
@@ -379,7 +382,8 @@ class MetalCommandList final : public CommandList {
   void set_line_width(float width) override;
 
   MTLCommandBuffer_id finalize();
-  // If noclear is false, ignore whatever is set in details This may be used to "resume" the current renderpass
+  // If noclear is false, ignore whatever is set in details
+  // This may be used to "resume" the current renderpass
   MTLRenderPassDescriptor *create_render_pass_desc(bool depth_write, bool noclear = false);
 
   bool is_renderpass_active() const;
@@ -405,12 +409,12 @@ class MetalCommandList final : public CommandList {
   std::vector<MTLTexture_id> render_targets_;
   MTLTexture_id depth_target_;
 
-  // Buffers accessed via physical storage buffer pointers in the next dispatch. Needed for Metal hazard tracking since
-  // these are not explicitly bound.
+  // Buffers accessed via physical storage buffer pointers in the next dispatch.
+  // Needed for Metal hazard tracking since these are not explicitly bound.
   std::vector<DeviceAllocation> tracked_physical_buffers_;
 
-  // For renderpass resuming, track whether a renderpass has been started Used to override LoadAction, to prevent
-  // uninteded clearing when resuming
+  // For renderpass resuming, track whether a renderpass has been started
+  // Used to override LoadAction, to prevent uninteded clearing when resuming
   bool is_renderpass_active_{false};
 
   // Persistent compute command encoder reused across consecutive `dispatch()` calls so the GPU sees one

--- a/quadrants/rhi/metal/metal_device.h
+++ b/quadrants/rhi/metal/metal_device.h
@@ -5,6 +5,7 @@
 #include "quadrants/rhi/metal/metal_api.h"
 #include <memory>
 #include <regex>
+#include <unordered_set>
 
 // clang-format off
 #if defined(__APPLE__) && defined(__OBJC__)
@@ -174,18 +175,15 @@ struct MetalShaderBindingMapping {
   // Map GLSL binding to MSL index (buffer/texture index, sampler index)
   std::unordered_map<int, std::pair<int, int>> vertex;
   std::unordered_map<int, std::pair<int, int>> fragment;
-  // The highest used buffer index used in the MSL vertex function
-  // Vertex attributes use up vertex buffer indices in Metal, but
-  // SPIRV-cross generated MSL doesn't know how many buffer indices
-  // the vertex attributes will take. So bind vertex input after the other
-  // buffers.
+  // The highest used buffer index used in the MSL vertex function Vertex attributes use up vertex buffer indices in
+  // Metal, but SPIRV-cross generated MSL doesn't know how many buffer indices the vertex attributes will take. So bind
+  // vertex input after the other buffers.
   int max_vert_buffer_index{-1};
 };
 
 class MetalPipeline final : public Pipeline, public rhi_impl::NonAssignable {
  public:
-  // `mtl_library`, `mtl_function`, `mtl_compute_pipeline_state` should be
-  // already retained.
+  // `mtl_library`, `mtl_function`, `mtl_compute_pipeline_state` should be already retained.
   explicit MetalPipeline(const MetalDevice &device,
                          MTLLibrary_id mtl_library,
                          MTLFunction_id mtl_function,
@@ -381,8 +379,7 @@ class MetalCommandList final : public CommandList {
   void set_line_width(float width) override;
 
   MTLCommandBuffer_id finalize();
-  // If noclear is false, ignore whatever is set in details
-  // This may be used to "resume" the current renderpass
+  // If noclear is false, ignore whatever is set in details This may be used to "resume" the current renderpass
   MTLRenderPassDescriptor *create_render_pass_desc(bool depth_write, bool noclear = false);
 
   bool is_renderpass_active() const;
@@ -408,13 +405,29 @@ class MetalCommandList final : public CommandList {
   std::vector<MTLTexture_id> render_targets_;
   MTLTexture_id depth_target_;
 
-  // Buffers accessed via physical storage buffer pointers in the next dispatch.
-  // Needed for Metal hazard tracking since these are not explicitly bound.
+  // Buffers accessed via physical storage buffer pointers in the next dispatch. Needed for Metal hazard tracking since
+  // these are not explicitly bound.
   std::vector<DeviceAllocation> tracked_physical_buffers_;
 
-  // For renderpass resuming, track whether a renderpass has been started
-  // Used to override LoadAction, to prevent uninteded clearing when resuming
+  // For renderpass resuming, track whether a renderpass has been started Used to override LoadAction, to prevent
+  // uninteded clearing when resuming
   bool is_renderpass_active_{false};
+
+  // Persistent compute command encoder reused across consecutive `dispatch()` calls so the GPU sees one
+  // MTLComputeCommandEncoder per dispatch chain instead of one per dispatch. Each encoder begin / end pair on Apple
+  // Silicon's M-series GPUs costs ~700 us of inter-dispatch gap (encoder teardown plus re-bind state), and Metal's
+  // `dispatchType=Serial` already gives the same per-dispatch ordering inside a single encoder, so coalescing into one
+  // encoder is semantics-preserving and shaves the gap to driver-scheduling overhead. The encoder is opened lazily on
+  // the first `dispatch()` call and torn down via `flush_pending_encoder_` before any encoder-incompatible op
+  // (`buffer_copy`, `buffer_fill`, `begin_renderpass`) and before `finalize()` returns the cmdbuf to the stream for
+  // commit. Set of physical buffers already passed through `useResource:` in this encoder lifetime is tracked alongside
+  // so we don't issue redundant `useResource:` calls inside one encoder. Initialised to `nullptr` (the C++ form of
+  // Metal's `nil`) so this header compiles in both ObjC++ (.mm) and plain C++ contexts. `DEFINE_METAL_ID_TYPE` above
+  // maps the type to `id<MTLComputeCommandEncoder>` in ObjC++ and to `struct MTLComputeCommandEncoder_t *` in C++;
+  // `nullptr` is a valid initialiser for both.
+  MTLComputeCommandEncoder_id current_compute_encoder_{nullptr};
+  std::unordered_set<uint64_t> compute_encoder_resident_alloc_ids_;
+  void flush_pending_encoder_();
 };
 
 class MetalStream final : public Stream {

--- a/quadrants/rhi/metal/metal_device.h
+++ b/quadrants/rhi/metal/metal_device.h
@@ -422,7 +422,7 @@ class MetalCommandList final : public CommandList {
   // Silicon's M-series GPUs costs ~700 us of inter-dispatch gap (encoder teardown plus re-bind state), and Metal's
   // `dispatchType=Serial` already gives the same per-dispatch ordering inside a single encoder, so coalescing into one
   // encoder is semantics-preserving and shaves the gap to driver-scheduling overhead. The encoder is opened lazily on
-  // the first `dispatch()` call and torn down via `flush_pending_encoder_` before any encoder-incompatible op
+  // the first `dispatch()` call and torn down via `flush_pending_encoder` before any encoder-incompatible op
   // (`buffer_copy`, `buffer_fill`, `begin_renderpass`) and before `finalize()` returns the cmdbuf to the stream for
   // commit. Set of physical buffers already passed through `useResource:` in this encoder lifetime is tracked alongside
   // so we don't issue redundant `useResource:` calls inside one encoder. Initialised to `nullptr` (the C++ form of
@@ -431,7 +431,7 @@ class MetalCommandList final : public CommandList {
   // `nullptr` is a valid initialiser for both.
   MTLComputeCommandEncoder_id current_compute_encoder_{nullptr};
   std::unordered_set<uint64_t> compute_encoder_resident_alloc_ids_;
-  void flush_pending_encoder_();
+  void flush_pending_encoder();
 };
 
 class MetalStream final : public Stream {

--- a/quadrants/rhi/metal/metal_device.mm
+++ b/quadrants/rhi/metal/metal_device.mm
@@ -412,7 +412,24 @@ MetalCommandList::MetalCommandList(const MetalDevice &device,
   }
 }
 
-MetalCommandList::~MetalCommandList() { [cmdbuf_ release]; }
+MetalCommandList::~MetalCommandList() {
+  flush_pending_encoder_();
+  [cmdbuf_ release];
+}
+
+// End the persistent compute encoder if one is open. Called before any op that
+// needs a different encoder type (blit / render) and before the cmdbuf is
+// returned for commit, so a long chain of `dispatch()` calls collapses to a
+// single MTLComputeCommandEncoder while incompatible ops still observe the
+// right per-encoder boundary that Metal's hazard tracking relies on.
+void MetalCommandList::flush_pending_encoder_() {
+  if (current_compute_encoder_ != nil) {
+    [current_compute_encoder_ endEncoding];
+    [current_compute_encoder_ release];
+    current_compute_encoder_ = nullptr;
+    compute_encoder_resident_alloc_ids_.clear();
+  }
+}
 
 void MetalCommandList::bind_pipeline(Pipeline *p) noexcept {
   RHI_ASSERT(p != nullptr);
@@ -470,6 +487,7 @@ void MetalCommandList::track_physical_buffer(DeviceAllocation alloc) noexcept {
 
 void MetalCommandList::buffer_copy(DevicePtr dst, DevicePtr src,
                                    size_t size) noexcept {
+  flush_pending_encoder_();
   const MetalMemory &src_memory = device_->get_memory(src.alloc_id);
   const MetalMemory &dst_memory = device_->get_memory(dst.alloc_id);
 
@@ -497,6 +515,7 @@ void MetalCommandList::buffer_copy(DevicePtr dst, DevicePtr src,
 void MetalCommandList::buffer_fill(DevicePtr ptr, size_t size,
                                    uint32_t data) noexcept {
   RHI_ASSERT(data == 0);
+  flush_pending_encoder_();
 
   const MetalMemory &memory = device_->get_memory(ptr.alloc_id);
 
@@ -531,7 +550,23 @@ RhiResult MetalCommandList::dispatch(uint32_t x, uint32_t y,
       current_shader_resource_set_->resources();
 
   @autoreleasepool {
-    MTLComputeCommandEncoder_id encoder = [cmdbuf_ computeCommandEncoder];
+    // Reuse the persistent compute encoder across consecutive dispatches in
+    // this cmdlist. MTLComputeCommandEncoder defaults to MTLDispatchTypeSerial,
+    // so per-dispatch ordering inside one encoder is the same as separate
+    // encoders, but we save the ~700 us of encoder-end / encoder-begin gap that
+    // the Metal System Trace surfaces between every quadrants dispatch. The
+    // encoder is torn down by `flush_pending_encoder_` whenever an
+    // encoder-incompatible op (blit / render / cmdbuf finalize) needs to start.
+    if (current_compute_encoder_ == nullptr) {
+      // `[cmdbuf_ computeCommandEncoder]` returns an autoreleased encoder.
+      // Retain it so the encoder survives past the enclosing `@autoreleasepool`
+      // drain into the next `dispatch()` call; without this the autoreleased
+      // encoder is freed before we end it, and Metal's
+      // `_MTLCommandEncoder dealloc` asserts "Command encoder released without
+      // endEncoding". Released by `flush_pending_encoder_` after `endEncoding`.
+      current_compute_encoder_ = [[cmdbuf_ computeCommandEncoder] retain];
+    }
+    MTLComputeCommandEncoder_id encoder = current_compute_encoder_;
 
     for (const MetalShaderResource &resource : shader_resources) {
       switch (resource.ty) {
@@ -556,16 +591,24 @@ RhiResult MetalCommandList::dispatch(uint32_t x, uint32_t y,
     }
 
     for (const DeviceAllocation &alloc : tracked_physical_buffers_) {
-      const MetalMemory &mem = device_->get_memory(alloc.alloc_id);
-      [encoder useResource:mem.mtl_buffer()
-                     usage:MTLResourceUsageRead | MTLResourceUsageWrite];
+      // `useResource:` only needs to be issued once per (encoder, resource)
+      // pair: a resource declared resident at one point in the encoder stays
+      // resident until the encoder ends. Skip re-declaring any allocation we
+      // already announced in the current encoder lifetime; this drops the
+      // per-dispatch driver work on benches that bind the same physical buffer
+      // (e.g. the ndarray data ptr and adstack heap on every backward kernel)
+      // into every dispatch.
+      if (compute_encoder_resident_alloc_ids_.insert(alloc.alloc_id).second) {
+        const MetalMemory &mem = device_->get_memory(alloc.alloc_id);
+        [encoder useResource:mem.mtl_buffer()
+                       usage:MTLResourceUsageRead | MTLResourceUsageWrite];
+      }
     }
     tracked_physical_buffers_.clear();
 
     [encoder setComputePipelineState:mtl_compute_pipeline_state];
     [encoder dispatchThreadgroups:MTLSizeMake(x, y, z)
             threadsPerThreadgroup:MTLSizeMake(local_x, local_y, local_z)];
-    [encoder endEncoding];
   };
 
   return RhiResult::success;
@@ -578,6 +621,7 @@ void MetalCommandList::begin_renderpass(int x0, int y0, int x1, int y1,
                                         std::vector<float> *clear_colors,
                                         DeviceAllocation *depth_attachment,
                                         bool depth_clear) {
+  flush_pending_encoder_();
   current_renderpass_details_.clear_depth = depth_clear;
 
   int rendertarget_height = 0;
@@ -727,6 +771,7 @@ bool MetalCommandList::is_renderpass_active() const {
 void MetalCommandList::set_renderpass_active() { is_renderpass_active_ = true; }
 
 MTLRenderCommandEncoder_id MetalCommandList::pre_draw_setup() {
+  flush_pending_encoder_();
   const RasterParams *raster_params = current_pipeline_->raster_params();
 
   MTLRenderPassDescriptor *rpd = create_render_pass_desc(
@@ -938,6 +983,7 @@ void MetalCommandList::buffer_to_image(DeviceAllocation dst_img,
   buffer_image_copy_params_to_mtl(params, src_buf.offset,
                                   dst_image.mtl_texture(), &mtl_params);
 
+  flush_pending_encoder_();
   @autoreleasepool {
     MTLBlitCommandEncoder_id encoder = [cmdbuf_ blitCommandEncoder];
     [encoder copyFromBuffer:src_buffer.mtl_buffer()
@@ -965,6 +1011,7 @@ void MetalCommandList::image_to_buffer(DevicePtr dst_buf,
   buffer_image_copy_params_to_mtl(params, dst_buf.offset,
                                   src_image.mtl_texture(), &mtl_params);
 
+  flush_pending_encoder_();
   @autoreleasepool {
     MTLBlitCommandEncoder_id encoder = [cmdbuf_ blitCommandEncoder];
     [encoder copyFromTexture:src_image.mtl_texture()
@@ -989,6 +1036,7 @@ void MetalCommandList::copy_image(DeviceAllocation dst_img,
   const MetalImage &src_image = device_->get_image(src_img.alloc_id);
   const MetalImage &dst_image = device_->get_image(dst_img.alloc_id);
 
+  flush_pending_encoder_();
   @autoreleasepool {
     MTLBlitCommandEncoder_id encoder = [cmdbuf_ blitCommandEncoder];
     [encoder
@@ -1013,7 +1061,10 @@ void MetalCommandList::blit_image(DeviceAllocation dst_img,
   copy_image(dst_img, src_img, dst_img_layout, src_img_layout, params);
 }
 
-MTLCommandBuffer_id MetalCommandList::finalize() { return cmdbuf_; }
+MTLCommandBuffer_id MetalCommandList::finalize() {
+  flush_pending_encoder_();
+  return cmdbuf_;
+}
 
 MetalStream::MetalStream(const MetalDevice &device,
                          MTLCommandQueue_id mtl_command_queue)

--- a/quadrants/rhi/metal/metal_device.mm
+++ b/quadrants/rhi/metal/metal_device.mm
@@ -413,7 +413,7 @@ MetalCommandList::MetalCommandList(const MetalDevice &device,
 }
 
 MetalCommandList::~MetalCommandList() {
-  flush_pending_encoder_();
+  flush_pending_encoder();
   [cmdbuf_ release];
 }
 
@@ -422,7 +422,7 @@ MetalCommandList::~MetalCommandList() {
 // returned for commit, so a long chain of `dispatch()` calls collapses to a
 // single MTLComputeCommandEncoder while incompatible ops still observe the
 // right per-encoder boundary that Metal's hazard tracking relies on.
-void MetalCommandList::flush_pending_encoder_() {
+void MetalCommandList::flush_pending_encoder() {
   if (current_compute_encoder_ != nil) {
     [current_compute_encoder_ endEncoding];
     [current_compute_encoder_ release];
@@ -487,7 +487,7 @@ void MetalCommandList::track_physical_buffer(DeviceAllocation alloc) noexcept {
 
 void MetalCommandList::buffer_copy(DevicePtr dst, DevicePtr src,
                                    size_t size) noexcept {
-  flush_pending_encoder_();
+  flush_pending_encoder();
   const MetalMemory &src_memory = device_->get_memory(src.alloc_id);
   const MetalMemory &dst_memory = device_->get_memory(dst.alloc_id);
 
@@ -515,7 +515,7 @@ void MetalCommandList::buffer_copy(DevicePtr dst, DevicePtr src,
 void MetalCommandList::buffer_fill(DevicePtr ptr, size_t size,
                                    uint32_t data) noexcept {
   RHI_ASSERT(data == 0);
-  flush_pending_encoder_();
+  flush_pending_encoder();
 
   const MetalMemory &memory = device_->get_memory(ptr.alloc_id);
 
@@ -555,7 +555,7 @@ RhiResult MetalCommandList::dispatch(uint32_t x, uint32_t y,
     // so per-dispatch ordering inside one encoder is the same as separate
     // encoders, but we save the ~700 us of encoder-end / encoder-begin gap that
     // the Metal System Trace surfaces between every quadrants dispatch. The
-    // encoder is torn down by `flush_pending_encoder_` whenever an
+    // encoder is torn down by `flush_pending_encoder` whenever an
     // encoder-incompatible op (blit / render / cmdbuf finalize) needs to start.
     if (current_compute_encoder_ == nullptr) {
       // `[cmdbuf_ computeCommandEncoder]` returns an autoreleased encoder.
@@ -563,7 +563,7 @@ RhiResult MetalCommandList::dispatch(uint32_t x, uint32_t y,
       // drain into the next `dispatch()` call; without this the autoreleased
       // encoder is freed before we end it, and Metal's
       // `_MTLCommandEncoder dealloc` asserts "Command encoder released without
-      // endEncoding". Released by `flush_pending_encoder_` after `endEncoding`.
+      // endEncoding". Released by `flush_pending_encoder` after `endEncoding`.
       current_compute_encoder_ = [[cmdbuf_ computeCommandEncoder] retain];
     }
     MTLComputeCommandEncoder_id encoder = current_compute_encoder_;
@@ -621,7 +621,7 @@ void MetalCommandList::begin_renderpass(int x0, int y0, int x1, int y1,
                                         std::vector<float> *clear_colors,
                                         DeviceAllocation *depth_attachment,
                                         bool depth_clear) {
-  flush_pending_encoder_();
+  flush_pending_encoder();
   current_renderpass_details_.clear_depth = depth_clear;
 
   int rendertarget_height = 0;
@@ -771,7 +771,7 @@ bool MetalCommandList::is_renderpass_active() const {
 void MetalCommandList::set_renderpass_active() { is_renderpass_active_ = true; }
 
 MTLRenderCommandEncoder_id MetalCommandList::pre_draw_setup() {
-  flush_pending_encoder_();
+  flush_pending_encoder();
   const RasterParams *raster_params = current_pipeline_->raster_params();
 
   MTLRenderPassDescriptor *rpd = create_render_pass_desc(
@@ -983,7 +983,7 @@ void MetalCommandList::buffer_to_image(DeviceAllocation dst_img,
   buffer_image_copy_params_to_mtl(params, src_buf.offset,
                                   dst_image.mtl_texture(), &mtl_params);
 
-  flush_pending_encoder_();
+  flush_pending_encoder();
   @autoreleasepool {
     MTLBlitCommandEncoder_id encoder = [cmdbuf_ blitCommandEncoder];
     [encoder copyFromBuffer:src_buffer.mtl_buffer()
@@ -1011,7 +1011,7 @@ void MetalCommandList::image_to_buffer(DevicePtr dst_buf,
   buffer_image_copy_params_to_mtl(params, dst_buf.offset,
                                   src_image.mtl_texture(), &mtl_params);
 
-  flush_pending_encoder_();
+  flush_pending_encoder();
   @autoreleasepool {
     MTLBlitCommandEncoder_id encoder = [cmdbuf_ blitCommandEncoder];
     [encoder copyFromTexture:src_image.mtl_texture()
@@ -1036,7 +1036,7 @@ void MetalCommandList::copy_image(DeviceAllocation dst_img,
   const MetalImage &src_image = device_->get_image(src_img.alloc_id);
   const MetalImage &dst_image = device_->get_image(dst_img.alloc_id);
 
-  flush_pending_encoder_();
+  flush_pending_encoder();
   @autoreleasepool {
     MTLBlitCommandEncoder_id encoder = [cmdbuf_ blitCommandEncoder];
     [encoder
@@ -1062,7 +1062,7 @@ void MetalCommandList::blit_image(DeviceAllocation dst_img,
 }
 
 MTLCommandBuffer_id MetalCommandList::finalize() {
-  flush_pending_encoder_();
+  flush_pending_encoder();
   return cmdbuf_;
 }
 

--- a/quadrants/runtime/amdgpu/kernel_launcher.cpp
+++ b/quadrants/runtime/amdgpu/kernel_launcher.cpp
@@ -149,7 +149,10 @@ bool KernelLauncher::on_amdgpu_device(void *ptr) {
 
 void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx) {
   QD_ASSERT(handle.get_launch_id() < contexts_.size());
-  auto launcher_ctx = contexts_[handle.get_launch_id()];
+  // Mutable reference: per-handle persistent buffers are lazy-allocated / grow on demand on the first launch of
+  // each kernel. Recursive launches from `publish_adstack_metadata`'s host-eval (snode-reader kernels) hit a
+  // *different* handle's `Context` and so cannot clobber the parent's `arg_buffer_dev_ptr` / `runtime_context_dev_ptr`.
+  auto &launcher_ctx = contexts_[handle.get_launch_id()];
   auto *executor = get_runtime_executor();
   auto *amdgpu_module = launcher_ctx.jit_module;
   const auto &parameters = *launcher_ctx.parameters;
@@ -171,7 +174,18 @@ void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx
   //   Memory access fault by GPU node-1 (Agent handle: 0xeda5ca0) on address
   //   (nil). Reason: Page not present or supervisor privilege.
   // if you don't allocate it.
-  AMDGPUDriver::get_instance().malloc((void **)&device_result_buffer, std::max(ctx.result_buffer_size, sizeof(uint64)));
+  // Launcher-global persistent `result_buffer`: see `kernel_launcher.h` for why this one stays shared across handles
+  // (kernels write it, host reads it back synchronously before any next reader runs).
+  const std::size_t needed_result = std::max(ctx.result_buffer_size, sizeof(uint64));
+  if (needed_result > persistent_result_buffer_capacity_) {
+    if (persistent_result_buffer_dev_ptr_ != nullptr) {
+      AMDGPUDriver::get_instance().mem_free_async(persistent_result_buffer_dev_ptr_, nullptr);
+    }
+    const std::size_t new_cap = std::max(needed_result, 2 * persistent_result_buffer_capacity_);
+    AMDGPUDriver::get_instance().malloc_async(&persistent_result_buffer_dev_ptr_, new_cap, nullptr);
+    persistent_result_buffer_capacity_ = new_cap;
+  }
+  device_result_buffer = static_cast<char *>(persistent_result_buffer_dev_ptr_);
 
   for (int i = 0; i < (int)parameters.size(); i++) {
     const auto &kv = parameters[i];
@@ -243,15 +257,26 @@ void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx
   }
   char *device_arg_buffer = nullptr;
   if (ctx.arg_buffer_size > 0) {
-    AMDGPUDriver::get_instance().malloc((void **)&device_arg_buffer, ctx.arg_buffer_size);
-    AMDGPUDriver::get_instance().memcpy_host_to_device(device_arg_buffer, ctx.get_context().arg_buffer,
-                                                       ctx.arg_buffer_size);
+    if (ctx.arg_buffer_size > launcher_ctx.arg_buffer_capacity) {
+      if (launcher_ctx.arg_buffer_dev_ptr != nullptr) {
+        AMDGPUDriver::get_instance().mem_free_async(launcher_ctx.arg_buffer_dev_ptr, nullptr);
+      }
+      const std::size_t new_cap = std::max<std::size_t>(ctx.arg_buffer_size, 2 * launcher_ctx.arg_buffer_capacity);
+      AMDGPUDriver::get_instance().malloc_async(&launcher_ctx.arg_buffer_dev_ptr, new_cap, nullptr);
+      launcher_ctx.arg_buffer_capacity = new_cap;
+    }
+    device_arg_buffer = static_cast<char *>(launcher_ctx.arg_buffer_dev_ptr);
+    AMDGPUDriver::get_instance().memcpy_host_to_device_async(device_arg_buffer, ctx.get_context().arg_buffer,
+                                                             ctx.arg_buffer_size, nullptr);
     ctx.get_context().arg_buffer = device_arg_buffer;
   }
-  void *context_pointer;
   int arg_size = sizeof(RuntimeContext *);
-  AMDGPUDriver::get_instance().malloc((void **)&context_pointer, sizeof(RuntimeContext));
-  AMDGPUDriver::get_instance().memcpy_host_to_device(context_pointer, &ctx.get_context(), sizeof(RuntimeContext));
+  if (launcher_ctx.runtime_context_dev_ptr == nullptr) {
+    AMDGPUDriver::get_instance().malloc_async(&launcher_ctx.runtime_context_dev_ptr, sizeof(RuntimeContext), nullptr);
+  }
+  void *context_pointer = launcher_ctx.runtime_context_dev_ptr;
+  AMDGPUDriver::get_instance().memcpy_host_to_device_async(context_pointer, &ctx.get_context(), sizeof(RuntimeContext),
+                                                           nullptr);
 
   if (ctx.graph_do_while_arg_id >= 0) {
     QD_ASSERT(ctx.graph_do_while_flag_dev_ptr);
@@ -260,9 +285,7 @@ void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx
     launch_offloaded_tasks(ctx, amdgpu_module, offloaded_tasks, context_pointer, arg_size);
   }
   QD_TRACE("Launching kernel");
-  if (ctx.arg_buffer_size > 0) {
-    AMDGPUDriver::get_instance().mem_free(device_arg_buffer);
-  }
+  // Persistent scratch: no per-launch free for arg_buffer. The scratch lives until the launcher is destroyed.
   if (ctx.result_buffer_size > 0) {
     AMDGPUDriver::get_instance().memcpy_device_to_host(host_result_buffer, device_result_buffer,
                                                        ctx.result_buffer_size);
@@ -276,16 +299,25 @@ void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx
       executor->deallocate_memory_on_device(itr->second.second);
     }
   }
-  // Since we always allocating above then we should always free
-  AMDGPUDriver::get_instance().mem_free(device_result_buffer);
-  // Free the per-launch `RuntimeContext` device allocation. `hipFree` synchronizes implicitly with pending
-  // kernels on the device, so this is safe even when the launches above were asynchronous. Done here rather
-  // than through `AMDGPUContext`'s deferred free list because that list used to be drained by
-  // `LlvmRuntimeExecutor::synchronize`, which is also called from `fetch_result_uint64` during
-  // `ensure_adstack_heap`'s field-pointer query -- that path would hipFree `context_pointer` mid-launch, and
-  // HIP could recycle the freed address for the adstack heap allocated right after, clobbering the
-  // `RuntimeContext` the next task still reads from.
-  AMDGPUDriver::get_instance().mem_free(context_pointer);
+  // Persistent scratch: no per-launch free for the per-handle `arg_buffer` / `runtime_context` or the launcher-global
+  // `result_buffer`. All three live until the launcher is destroyed; the dtor handles the final `mem_free_async`.
+}
+
+KernelLauncher::~KernelLauncher() {
+  // Free per-handle and launcher-global persistent scratch. `mem_free_async` queues behind any in-flight kernel
+  // reads on the default stream, so the bytes stay valid until the launcher actually goes away. Skipped when the
+  // buffer was never allocated (kernel was never launched).
+  for (auto &launcher_ctx : contexts_) {
+    if (launcher_ctx.arg_buffer_dev_ptr != nullptr) {
+      AMDGPUDriver::get_instance().mem_free_async(launcher_ctx.arg_buffer_dev_ptr, nullptr);
+    }
+    if (launcher_ctx.runtime_context_dev_ptr != nullptr) {
+      AMDGPUDriver::get_instance().mem_free_async(launcher_ctx.runtime_context_dev_ptr, nullptr);
+    }
+  }
+  if (persistent_result_buffer_dev_ptr_ != nullptr) {
+    AMDGPUDriver::get_instance().mem_free_async(persistent_result_buffer_dev_ptr_, nullptr);
+  }
 }
 
 KernelLauncher::Handle KernelLauncher::register_llvm_kernel(const LLVM::CompiledKernelData &compiled) {

--- a/quadrants/runtime/amdgpu/kernel_launcher.h
+++ b/quadrants/runtime/amdgpu/kernel_launcher.h
@@ -13,6 +13,16 @@ class KernelLauncher : public LLVM::KernelLauncher {
     JITModule *jit_module{nullptr};
     const std::vector<std::pair<int, Callable::Parameter>> *parameters;
     std::vector<OffloadedTask> offloaded_tasks;
+    // Per-kernel-handle persistent scratch. Allocated lazily on first use, grown amortised-doubling on demand,
+    // freed only on launcher destruction. Stored per-handle (not per-launcher) because `publish_adstack_metadata`'s
+    // host-eval branch evaluates `FieldLoad` SizeExpr leaves through `SNodeRwAccessorsBank`, which recursively
+    // launches `snode_reader_*` kernels via the same launcher singleton; sharing one device-side `arg_buffer` /
+    // `RuntimeContext` across kernels would let the recursive launch overwrite the parent's args before the parent
+    // kernel reads them. Per-handle buffers give each kernel a private device address that recursive launches
+    // cannot touch.
+    void *arg_buffer_dev_ptr{nullptr};
+    std::size_t arg_buffer_capacity{0};
+    void *runtime_context_dev_ptr{nullptr};
   };
 
  public:
@@ -33,7 +43,16 @@ class KernelLauncher : public LLVM::KernelLauncher {
                                             void *context_pointer,
                                             int arg_size);
   bool on_amdgpu_device(void *ptr);
+  // `result_buffer` is the only scratch that stays launcher-global: kernels write to it then the host reads it
+  // back via `hipMemcpyDtoH` before the next kernel runs, so recursive snode-reader launches that reuse it cannot
+  // smuggle stale bytes into the parent's read (the parent's host-side `fetch_result_uint64` happens after every
+  // child completes, before the parent kernel that would be the next reader). Grown amortised-doubling.
+  void *persistent_result_buffer_dev_ptr_{nullptr};
+  std::size_t persistent_result_buffer_capacity_{0};
   std::vector<Context> contexts_;
+
+ public:
+  ~KernelLauncher();
 };
 
 }  // namespace amdgpu

--- a/quadrants/runtime/amdgpu/kernel_launcher.h
+++ b/quadrants/runtime/amdgpu/kernel_launcher.h
@@ -52,7 +52,7 @@ class KernelLauncher : public LLVM::KernelLauncher {
   std::vector<Context> contexts_;
 
  public:
-  ~KernelLauncher();
+  ~KernelLauncher() override;
 };
 
 }  // namespace amdgpu

--- a/quadrants/runtime/cpu/kernel_launcher.cpp
+++ b/quadrants/runtime/cpu/kernel_launcher.cpp
@@ -91,7 +91,10 @@ void KernelLauncher::launch_offloaded_tasks_with_do_while(LaunchContextBuilder &
 
 void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx) {
   QD_ASSERT(handle.get_launch_id() < contexts_.size());
-  auto launcher_ctx = contexts_[handle.get_launch_id()];
+  // Hold a reference to the `Context` rather than a copy. Safe because `contexts_` is a `std::deque`
+  // (see `kernel_launcher.h`) - a nested `register_llvm_kernel` running inside this same launch cannot
+  // relocate the entry held here.
+  const auto &launcher_ctx = contexts_[handle.get_launch_id()];
   auto *executor = get_runtime_executor();
 
   ctx.get_context().runtime = executor->get_llvm_runtime();

--- a/quadrants/runtime/cpu/kernel_launcher.h
+++ b/quadrants/runtime/cpu/kernel_launcher.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <deque>
+
 #include "quadrants/codegen/llvm/compiled_kernel_data.h"
 #include "quadrants/runtime/llvm/kernel_launcher.h"
 
@@ -38,7 +40,8 @@ class KernelLauncher : public LLVM::KernelLauncher {
                                             const std::vector<AdStackSizingInfo> &ad_stacks,
                                             const std::vector<std::size_t> &num_threads_per_task);
 
-  std::vector<Context> contexts_;
+  // `std::deque` so references to existing entries survive an `emplace_back` from a nested launch.
+  std::deque<Context> contexts_;
 };
 
 }  // namespace cpu

--- a/quadrants/runtime/cuda/kernel_launcher.cpp
+++ b/quadrants/runtime/cuda/kernel_launcher.cpp
@@ -183,7 +183,10 @@ void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx
   }
   graph_manager_.mark_not_used();
 
-  auto launcher_ctx = contexts_[handle.get_launch_id()];
+  // Mutable reference: per-handle persistent buffers grow on demand on first launch. See the matching comment
+  // in `runtime/amdgpu/kernel_launcher.cpp` and the `Context` struct in `kernel_launcher.h` for why these have
+  // to be per-handle (recursive launches from `publish_adstack_metadata` host-eval).
+  auto &launcher_ctx = contexts_[handle.get_launch_id()];
   auto *executor = get_runtime_executor();
   auto *cuda_module = launcher_ctx.jit_module;
   const auto &parameters = *launcher_ctx.parameters;
@@ -210,8 +213,19 @@ void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx
   std::unordered_map<ArgArrayPtrKey, void *, ArgArrayPtrKeyHasher> device_ptrs;
 
   char *device_result_buffer{nullptr};
-  CUDADriver::get_instance().malloc_async((void **)&device_result_buffer,
-                                          std::max(ctx.result_buffer_size, sizeof(uint64)), nullptr);
+  // Launcher-global persistent `result_buffer`. See `kernel_launcher.h` for why this one is shared across handles
+  // (kernel writes + synchronous host readback before any other reader runs). `arg_buffer` and `runtime_context`
+  // are per-handle (in `Context`) to avoid recursive snode-reader launches clobbering the parent's args.
+  const std::size_t needed_result = std::max(ctx.result_buffer_size, sizeof(uint64));
+  if (needed_result > persistent_result_buffer_capacity_) {
+    if (persistent_result_buffer_dev_ptr_ != nullptr) {
+      CUDADriver::get_instance().mem_free_async(persistent_result_buffer_dev_ptr_, nullptr);
+    }
+    const std::size_t new_cap = std::max(needed_result, 2 * persistent_result_buffer_capacity_);
+    CUDADriver::get_instance().malloc_async(&persistent_result_buffer_dev_ptr_, new_cap, nullptr);
+    persistent_result_buffer_capacity_ = new_cap;
+  }
+  device_result_buffer = static_cast<char *>(persistent_result_buffer_dev_ptr_);
   ctx.get_context().runtime = executor->get_llvm_runtime();
 
   for (int i = 0; i < (int)parameters.size(); i++) {
@@ -290,7 +304,15 @@ void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx
   }
   char *device_arg_buffer = nullptr;
   if (ctx.arg_buffer_size > 0) {
-    CUDADriver::get_instance().malloc_async((void **)&device_arg_buffer, ctx.arg_buffer_size, nullptr);
+    if (ctx.arg_buffer_size > launcher_ctx.arg_buffer_capacity) {
+      if (launcher_ctx.arg_buffer_dev_ptr != nullptr) {
+        CUDADriver::get_instance().mem_free_async(launcher_ctx.arg_buffer_dev_ptr, nullptr);
+      }
+      const std::size_t new_cap = std::max<std::size_t>(ctx.arg_buffer_size, 2 * launcher_ctx.arg_buffer_capacity);
+      CUDADriver::get_instance().malloc_async(&launcher_ctx.arg_buffer_dev_ptr, new_cap, nullptr);
+      launcher_ctx.arg_buffer_capacity = new_cap;
+    }
+    device_arg_buffer = static_cast<char *>(launcher_ctx.arg_buffer_dev_ptr);
     CUDADriver::get_instance().memcpy_host_to_device_async(device_arg_buffer, ctx.get_context().arg_buffer,
                                                            ctx.arg_buffer_size, nullptr);
     ctx.get_context().arg_buffer = device_arg_buffer;
@@ -317,7 +339,10 @@ void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx
   needs_sizer_device_ctx = needs_sizer_device_ctx && !CUDAContext::get_instance().supports_pageable_memory_access();
   void *device_context_ptr = nullptr;
   if (needs_sizer_device_ctx) {
-    CUDADriver::get_instance().malloc_async(&device_context_ptr, sizeof(RuntimeContext), nullptr);
+    if (launcher_ctx.runtime_context_dev_ptr == nullptr) {
+      CUDADriver::get_instance().malloc_async(&launcher_ctx.runtime_context_dev_ptr, sizeof(RuntimeContext), nullptr);
+    }
+    device_context_ptr = launcher_ctx.runtime_context_dev_ptr;
     CUDADriver::get_instance().memcpy_host_to_device_async(device_context_ptr, &ctx.get_context(),
                                                            sizeof(RuntimeContext), nullptr);
   }
@@ -328,17 +353,12 @@ void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx
   } else {
     launch_offloaded_tasks(ctx, cuda_module, offloaded_tasks, device_context_ptr);
   }
-  if (needs_sizer_device_ctx) {
-    CUDADriver::get_instance().mem_free_async(device_context_ptr, nullptr);
-  }
-  if (ctx.arg_buffer_size > 0) {
-    CUDADriver::get_instance().mem_free_async(device_arg_buffer, nullptr);
-  }
+  // Persistent scratch: no per-launch free for the per-handle `arg_buffer` / `runtime_context` or the launcher-
+  // global `result_buffer`. All live until launcher destruction; the dtor handles the final `mem_free_async`.
   if (ctx.result_buffer_size > 0) {
     CUDADriver::get_instance().memcpy_device_to_host_async(host_result_buffer, device_result_buffer,
                                                            ctx.result_buffer_size, nullptr);
   }
-  CUDADriver::get_instance().mem_free_async(device_result_buffer, nullptr);
   // copy data back to host
   if (transfers.size() > 0) {
     CUDADriver::get_instance().stream_synchronize(nullptr);
@@ -348,6 +368,22 @@ void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx
                                                        ctx.array_runtime_sizes[idx.arg_id]);
       executor->deallocate_memory_on_device(itr->second.second);
     }
+  }
+}
+
+KernelLauncher::~KernelLauncher() {
+  // Free per-handle and launcher-global persistent scratch. `mem_free_async` queues behind any in-flight kernel
+  // reads on the default stream, so the bytes stay valid until the launcher actually goes away.
+  for (auto &launcher_ctx : contexts_) {
+    if (launcher_ctx.arg_buffer_dev_ptr != nullptr) {
+      CUDADriver::get_instance().mem_free_async(launcher_ctx.arg_buffer_dev_ptr, nullptr);
+    }
+    if (launcher_ctx.runtime_context_dev_ptr != nullptr) {
+      CUDADriver::get_instance().mem_free_async(launcher_ctx.runtime_context_dev_ptr, nullptr);
+    }
+  }
+  if (persistent_result_buffer_dev_ptr_ != nullptr) {
+    CUDADriver::get_instance().mem_free_async(persistent_result_buffer_dev_ptr_, nullptr);
   }
 }
 

--- a/quadrants/runtime/cuda/kernel_launcher.h
+++ b/quadrants/runtime/cuda/kernel_launcher.h
@@ -65,7 +65,7 @@ class KernelLauncher : public LLVM::KernelLauncher {
   std::size_t persistent_result_buffer_capacity_{0};
 
  public:
-  ~KernelLauncher();
+  ~KernelLauncher() override;
 };
 
 }  // namespace cuda

--- a/quadrants/runtime/cuda/kernel_launcher.h
+++ b/quadrants/runtime/cuda/kernel_launcher.h
@@ -17,6 +17,14 @@ class KernelLauncher : public LLVM::KernelLauncher {
     JITModule *jit_module{nullptr};
     const std::vector<std::pair<int, Callable::Parameter>> *parameters;
     std::vector<OffloadedTask> offloaded_tasks;
+    // Per-kernel-handle persistent scratch. See the matching AMDGPU `Context` struct in
+    // `runtime/amdgpu/kernel_launcher.h` for the rationale: `publish_adstack_metadata`'s host-eval branch
+    // recursively launches `snode_reader_*` kernels via this same launcher, and a launcher-global persistent
+    // buffer would let those recursive launches overwrite the parent's `arg_buffer` / `RuntimeContext` before
+    // the parent kernel reads them. Per-handle isolation prevents the cross-clobber.
+    void *arg_buffer_dev_ptr{nullptr};
+    std::size_t arg_buffer_capacity{0};
+    void *runtime_context_dev_ptr{nullptr};
   };
 
  public:
@@ -49,6 +57,15 @@ class KernelLauncher : public LLVM::KernelLauncher {
 
   std::vector<Context> contexts_;
   GraphManager graph_manager_;
+  // `result_buffer` stays launcher-global: kernels write to it, the host reads it back synchronously before any
+  // other kernel runs as a reader, so recursive snode-reader launches that reuse the buffer cannot smuggle stale
+  // bytes into the parent's read path. Grown amortised-doubling. See `runtime/amdgpu/kernel_launcher.h` for the
+  // matching scheme and the recursive-launch rationale this whole layout is designed around.
+  void *persistent_result_buffer_dev_ptr_{nullptr};
+  std::size_t persistent_result_buffer_capacity_{0};
+
+ public:
+  ~KernelLauncher();
 };
 
 }  // namespace cuda

--- a/quadrants/runtime/llvm/llvm_adstack_lazy_claim.cpp
+++ b/quadrants/runtime/llvm/llvm_adstack_lazy_claim.cpp
@@ -647,8 +647,20 @@ void LlvmRuntimeExecutor::check_adstack_overflow() {
   if (llvm_runtime_ == nullptr || result_buffer_cache_ == nullptr) {
     return;
   }
+  // `lookup_function` returns a host-callable pointer only on direct-dispatch backends (CPU LLVM JIT). CUDA / AMDGPU
+  // return device-side pointers and require the arg-marshalling `JITModule::call` path; the cached fast path therefore
+  // only fires when `direct_dispatch()` is true.
   auto *runtime_jit_module = get_runtime_jit_module();
-  runtime_jit_module->call<void *>("runtime_retrieve_and_reset_adstack_overflow", llvm_runtime_);
+  if (runtime_jit_module->direct_dispatch()) {
+    if (adstack_overflow_retriever_ == nullptr) {
+      adstack_overflow_retriever_ = reinterpret_cast<void (*)(void *)>(
+          runtime_jit_module->lookup_function("runtime_retrieve_and_reset_adstack_overflow"));
+      QD_ASSERT(adstack_overflow_retriever_ != nullptr);
+    }
+    adstack_overflow_retriever_(llvm_runtime_);
+  } else {
+    runtime_jit_module->call<void *>("runtime_retrieve_and_reset_adstack_overflow", llvm_runtime_);
+  }
   auto flag = fetch_result<int64>(quadrants_result_buffer_error_id, result_buffer_cache_);
   if (flag != 0) {
     throw QuadrantsAssertionError(

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -207,6 +207,7 @@ void LlvmRuntimeExecutor::synchronize() {
     QD_ERROR("No AMDGPU support");
 #endif
   }
+  fflush(stdout);
 }
 
 uint64 LlvmRuntimeExecutor::fetch_result_uint64(int i, uint64 *result_buffer) {

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -207,7 +207,6 @@ void LlvmRuntimeExecutor::synchronize() {
     QD_ERROR("No AMDGPU support");
 #endif
   }
-  fflush(stdout);
 }
 
 uint64 LlvmRuntimeExecutor::fetch_result_uint64(int i, uint64 *result_buffer) {

--- a/quadrants/runtime/llvm/llvm_runtime_executor.h
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.h
@@ -240,6 +240,11 @@ class LlvmRuntimeExecutor {
   // this cache, so avoid that.
   uint64 *result_buffer_cache_{nullptr};
 
+  // Memoised host-callable pointer to `runtime_retrieve_and_reset_adstack_overflow`. Populated only on backends
+  // whose JIT module supports direct dispatch (CPU LLVM); other backends leave it null and route through
+  // `JITModule::call`. Valid for the lifetime of the runtime JIT module.
+  void (*adstack_overflow_retriever_)(void *){nullptr};
+
   std::unique_ptr<ThreadPool> thread_pool_{nullptr};
   std::shared_ptr<Device> device_{nullptr};
 

--- a/quadrants/runtime/program_impls/llvm/llvm_program.h
+++ b/quadrants/runtime/program_impls/llvm/llvm_program.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdio>
 #include <memory>
 
 #include "quadrants/runtime/llvm/llvm_offline_cache.h"
@@ -99,11 +100,8 @@ class LlvmProgramImpl : public ProgramImpl {
     return runtime_exec_->fetch_result<T>(i, result_buffer);
   }
 
-  // Skip the adstack-overflow poll from this point on: `Program::finalize()` invokes `pre_finalize()` before the
-  // two teardown `synchronize()` calls, and we do not want `check_adstack_overflow()` to throw into a
-  // `~Program()` unwinding path - that would terminate the process with a bare `QuadrantsAssertionError` instead
-  // of letting the user handle it at their own `qd.sync()` site. The flag only affects the internal poll; the
-  // user can still call `qd.sync()` explicitly before finalize to observe the raise.
+  // Mark the impl as shutting down so `synchronize_and_assert()` skips the overflow poll, preventing a
+  // `qd.sync()` racing with destruction from throwing inside `~Program()` unwinding.
   void pre_finalize() override {
     finalizing_ = true;
   }
@@ -160,9 +158,15 @@ class LlvmProgramImpl : public ProgramImpl {
 
   void synchronize() override {
     runtime_exec_->synchronize();
+  }
+
+  void synchronize_and_assert() override {
+    runtime_exec_->synchronize();
     if (!finalizing_) {
       runtime_exec_->check_adstack_overflow();
     }
+    // Flush JIT-generated `qd.print()` output at every user-visible sync.
+    fflush(stdout);
   }
 
   LLVMRuntime *get_llvm_runtime() {
@@ -263,11 +267,8 @@ class LlvmProgramImpl : public ProgramImpl {
   std::size_t num_snode_trees_processed_{0};
   std::unique_ptr<LlvmRuntimeExecutor> runtime_exec_;
   std::unique_ptr<LlvmOfflineCache> cache_data_;
-  // Flipped on by `pre_finalize()` (with a defensive re-assignment in `finalize()`) so the `synchronize()`
-  // override stops polling the adstack-overflow flag during teardown. `Program::finalize()` invokes
-  // `pre_finalize()` before its two teardown syncs, so the flag is already true when those syncs run; moving
-  // the assignment back into `finalize()` alone would silently re-introduce the `std::terminate()` teardown bug
-  // this field was introduced to fix.
+  // Set by `pre_finalize()` / `finalize()` so `synchronize_and_assert()` skips the overflow poll while
+  // teardown is in progress.
   bool finalizing_{false};
 };
 

--- a/quadrants/runtime/program_impls/llvm/llvm_program.h
+++ b/quadrants/runtime/program_impls/llvm/llvm_program.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdio>
 #include <memory>
 
 #include "quadrants/runtime/llvm/llvm_offline_cache.h"
@@ -100,8 +99,11 @@ class LlvmProgramImpl : public ProgramImpl {
     return runtime_exec_->fetch_result<T>(i, result_buffer);
   }
 
-  // Mark the impl as shutting down so `synchronize_and_assert()` skips the overflow poll, preventing a
-  // `qd.sync()` racing with destruction from throwing inside `~Program()` unwinding.
+  // Skip the adstack-overflow poll from this point on: `Program::finalize()` invokes `pre_finalize()` before the
+  // two teardown `synchronize()` calls, and we do not want `check_adstack_overflow()` to throw into a
+  // `~Program()` unwinding path - that would terminate the process with a bare `QuadrantsAssertionError` instead
+  // of letting the user handle it at their own `qd.sync()` site. The flag only affects the internal poll; the
+  // user can still call `qd.sync()` explicitly before finalize to observe the raise.
   void pre_finalize() override {
     finalizing_ = true;
   }
@@ -165,8 +167,6 @@ class LlvmProgramImpl : public ProgramImpl {
     if (!finalizing_) {
       runtime_exec_->check_adstack_overflow();
     }
-    // Flush JIT-generated `qd.print()` output at every user-visible sync.
-    fflush(stdout);
   }
 
   LLVMRuntime *get_llvm_runtime() {
@@ -267,8 +267,11 @@ class LlvmProgramImpl : public ProgramImpl {
   std::size_t num_snode_trees_processed_{0};
   std::unique_ptr<LlvmRuntimeExecutor> runtime_exec_;
   std::unique_ptr<LlvmOfflineCache> cache_data_;
-  // Set by `pre_finalize()` / `finalize()` so `synchronize_and_assert()` skips the overflow poll while
-  // teardown is in progress.
+  // Flipped on by `pre_finalize()` (with a defensive re-assignment in `finalize()`) so the `synchronize()`
+  // override stops polling the adstack-overflow flag during teardown. `Program::finalize()` invokes
+  // `pre_finalize()` before its two teardown syncs, so the flag is already true when those syncs run; moving
+  // the assignment back into `finalize()` alone would silently re-introduce the `std::terminate()` teardown bug
+  // this field was introduced to fix.
   bool finalizing_{false};
 };
 


### PR DESCRIPTION
# Generic launcher: persistent context, JIT-pointer reuse, Metal compute encoder, LLVM-GPU async memory ops

> **Part 1 of 2** in the adstack-perf series. This PR lands the generic launcher infrastructure (persistent device scratch, JIT-pointer caches, Metal encoder reuse, async memory ops, host-eval evaluator hot-path cleanup) that the per-task adstack-sizer metadata cache in **Part 2** (`duburcqa/perf_adstack_metadata_cache`) is built on top of.

## TL;DR

The generic LLVM-GPU + Metal + CPU launchers were paying per-launch costs that show up as a flat tax on every reverse-mode kernel: `hipMalloc` + `hipMemcpy` + `hipFree` cycles per launch on AMDGPU / CUDA, fresh `MTLComputeCommandEncoder` per dispatch on Metal, repeated `lookup_function` ORC calls for every `runtime_retrieve_and_reset_adstack_overflow`, repeated linear `find_snode_by_id_recursive` walks for every `evaluate_adstack_size_expr` leaf. None of these scale well with kernel count, and Genesis runs 50+ kernels per sim step.

This PR reworks the per-launch path to amortise that work:

- **Metal RHI**: persistent `MTLComputeCommandEncoder` carried across dispatches inside one command-buffer flush.
- **LLVM-GPU launchers (CUDA + AMDGPU)**: per-launch `malloc` / `memcpy` / `free` becomes `malloc_async` / `memcpy_async` / `free_async` on the default stream; `result_buffer` becomes a launcher-global persistent scratch (grow-only); `arg_buffer` and `RuntimeContext` become **per-handle** persistent scratch (one buffer per registered kernel).
- **CPU launcher**: switched the `Context` storage to `std::deque` so `launch_llvm_kernel` can hold a `const auto &` instead of copying.
- **JIT pointer cache**: `runtime_retrieve_and_reset_adstack_overflow` device-callable pointer is looked up once and stashed.
- **`Program::get_snode_by_id`**: lazy `snode_id_cache_` map invalidated by `add_snode_tree` / `destroy_snode_tree`.
- **`SNodeRwAccessorsBank`**: cache the `CompiledKernelData` per `SNode` so each accessor compiles once across a kernel's lifetime.
- **`Program::synchronize` split**: a drain-only path for internal syncs (no raise, no `fflush`) plus `synchronize_and_assert` for the user-bound `qd.sync()`. The `fflush(stdout)` libc call moved out of the inner drain.
- **`evaluate_node` MaxOverRange**: bound-var binding mutates the existing map in place + restores on exit instead of copying the entire `unordered_map` per outer iteration.

## Why

A reverse-mode rigid step in Genesis dispatches dozens of kernels per substep. Profiling showed the host-side launcher path was a real fraction of wall time on every backend, not just the GPU. The work below was either (a) trivially memoizable, (b) duplicated state-tracking, or (c) a per-launch `malloc` / `free` cycle that the underlying driver explicitly supports amortising.

The single non-obvious item in this PR is the **per-handle** (vs launcher-global) split for LLVM-GPU `arg_buffer` / `RuntimeContext`. The naive choice would be a single launcher-global persistent buffer per kind. That breaks reverse-mode adstack accumulation on AMDGPU because `publish_adstack_metadata`'s host-eval branch evaluates `FieldLoad` SizeExpr leaves through `SNodeRwAccessorsBank`, which **recursively launches `snode_reader_*` kernels via the same launcher singleton**. With one shared `arg_buffer` device address, the recursive child launch overwrites the parent's args before the parent kernel reads them. Symptom: one outer-iter contribution silently dropped (e.g. `x.grad[0..7] = 0.6` instead of `0.8` on a 4-iter loop). Per-handle isolation gives each registered kernel a private device address that recursive launches cannot touch. `result_buffer` does not need this treatment - kernels write to it then the host reads it back synchronously before any next kernel runs as a reader, so reuse there is safe.

## Surface API

Zero user-visible change. `qd.init(...)` / `qd.field(...)` / kernel launch / `qd.sync()` / `qd.kernel.grad(...)` all behave identically. The split between `synchronize()` and `synchronize_and_assert()` is internal; `qd.sync` is rebound to the asserting variant so that user-visible assert behaviour is preserved.

## Mechanism end-to-end

### 1. Metal RHI: persistent compute encoder

`quadrants/rhi/metal/metal_device.{h,mm}` - `MetalDevice` now holds an active `MTLComputeCommandEncoder` and a flag tracking whether it's currently encoding. `Stream::dispatch_compute` reuses the live encoder for back-to-back compute dispatches; the encoder is end-encoded only when a barrier / blit / flush forces a state change. Previous behaviour was one fresh encoder per dispatch.

### 2. LLVM-GPU launchers: persistent scratch + async memory ops

`quadrants/runtime/{cuda,amdgpu}/kernel_launcher.{h,cpp}`. The `Context` struct (one per registered kernel handle) gains `arg_buffer_dev_ptr` / `arg_buffer_capacity` / `runtime_context_dev_ptr`. The launcher class itself gains `persistent_result_buffer_dev_ptr_` / `persistent_result_buffer_capacity_`. `launch_llvm_kernel` grows the per-handle / launcher-global buffers amortised-doubling on demand and never frees per launch. Per-launch `malloc` / `memcpy` / `free` are replaced by `malloc_async` / `memcpy_host_to_device_async` / `mem_free_async` on the default stream. Frees move to the destructor (`mem_free_async` queues behind any in-flight kernel reads, so the bytes stay valid until the launcher actually goes away).

The per-handle vs launcher-global split rationale (recursive snode-reader clobber) is documented in the header comments next to the field declarations.

### 3. CPU launcher: deque-backed context storage

`quadrants/runtime/cpu/kernel_launcher.{h,cpp}`. `contexts_` switches from `std::vector<Context>` to `std::deque<Context>`. The change lets `launch_llvm_kernel` hold a `const auto &launcher_ctx = contexts_[handle.get_launch_id()]` instead of copying the `Context` by value (which it had to do before, because growing the vector could invalidate the reference). On a hot path that fires once per launch this matters.

### 4. LLVM JIT pointer cache for adstack-overflow check

`quadrants/runtime/llvm/llvm_adstack_lazy_claim.cpp` - `LlvmRuntimeExecutor::check_adstack_overflow()` now caches `adstack_overflow_retriever_` (a `void(*)(void *)` resolved via `lookup_function`) on first call when the JIT module reports `direct_dispatch()` (CPU LLVM). Subsequent calls invoke the cached function pointer directly and skip the per-call ORC lookup. CUDA / AMDGPU return device-side pointers, so they keep the original `JITModule::call` arg-marshalling path.

### 5. `Program::get_snode_by_id` caching

`quadrants/program/program.{h,cpp}` - lazy `std::unordered_map<int, SNode *> snode_id_cache_`. Filled on first lookup; invalidated by `add_snode_tree` / `destroy_snode_tree` (the only paths that can change the snode-tree set). The previous implementation walked every snode tree linearly per call, which the host-side adstack size-expression evaluator hits once per `FieldLoad` leaf per launch.

### 6. `SNodeRwAccessorsBank`: per-SNode `CompiledKernelData` cache

`quadrants/program/snode_rw_accessors_bank.{h,cpp}` - the bank keeps a `std::unordered_map<SNode *, CompiledKernelData>` for both readers and writers. `compile_kernel_for(...)` consults the cache first; the entry is computed once per SNode + once per accessor kind and reused for every subsequent read / write of that snode. The entry is keyed by `SNode *` (stable for the snode's lifetime).

### 7. `Program::synchronize` split

`quadrants/program/program.{h,cpp}` - `synchronize()` is now drain-only (no raise, no `fflush(stdout)`). `synchronize_and_assert()` does the drain + raises any pending user-visible assertion (adstack overflow today) + flushes stdout. `qd.sync()` is bound to the asserting variant via `quadrants/python/export_lang.cpp`. Internal callers that just need the queue drained (e.g. `fetch_result_uint64`) call `synchronize()` directly and skip the libc `fflush` cost.

### 8. `evaluate_node` MaxOverRange: in-place bound-var binding

`quadrants/program/adstack_size_expr_eval.cpp` - the `MaxOverRange` evaluator used to clone `bound_vars` into an `extended` map per outer iteration, write `extended[var_id] = i`, and recurse. Now it writes directly into the caller's map and restores the previous binding on exit. Saves one full `unordered_map` copy per `MaxOverRange` iteration.

## Per-backend coverage matrix

| Mechanism                                  | CPU | CUDA | AMDGPU | Metal | Vulkan |
|--------------------------------------------|-----|------|--------|-------|--------|
| Persistent `MTLComputeCommandEncoder`      |     |      |        |  ✓    |        |
| Per-handle persistent `arg_buffer`         |     |  ✓   |  ✓     |       |        |
| Per-handle persistent `RuntimeContext`     |     |  ✓   |  ✓     |       |        |
| Launcher-global persistent `result_buffer` |     |  ✓   |  ✓     |       |        |
| Async malloc / memcpy / free on stream 0   |     |  ✓   |  ✓     |       |        |
| `std::deque` Context (const-ref launch)    |  ✓  |      |        |       |        |
| JIT-pointer cache (overflow retriever)     |  ✓  |      |        |       |        |
| `Program::get_snode_by_id` cache           |  ✓  |  ✓   |  ✓     |  ✓    |  ✓     |
| `SNodeRwAccessorsBank` `CompiledKernelData` cache | ✓ | ✓ | ✓ | ✓ | ✓ |
| `synchronize()` / `synchronize_and_assert()` split | ✓ | ✓ | ✓ | ✓ | ✓ |
| MaxOverRange in-place `bound_vars`         |  ✓  |  ✓   |  ✓     |  ✓    |  ✓     |

## Side-effect audit

| Concern                                                         | Verdict                                                                                |
|-----------------------------------------------------------------|----------------------------------------------------------------------------------------|
| Snode tree mutation invalidates `snode_id_cache_`               | `add_snode_tree` / `destroy_snode_tree` clear the map; covered.                         |
| Snode rebuild invalidates `SNodeRwAccessorsBank` per-snode cache | Cache is keyed by `SNode *`; `SNode` lifetime spans the snode tree, no stale `SNode *` entries possible. |
| Persistent `result_buffer` reuse safe across kernels            | Kernels write to it then host reads back synchronously before any next reader fires.   |
| Persistent `arg_buffer` / `RuntimeContext` reuse safe across kernels | Per-handle storage means recursive `snode_reader_*` launches via `publish_adstack_metadata` host-eval cannot touch the parent's buffers. |
| Async memory ops vs in-flight kernel reads                      | `mem_free_async` is stream-ordered behind the kernel that read the buffer; bytes live until the actual GPU-side free is dequeued. |
| `synchronize` drain skipping `fflush`                           | Internal-only callers; `qd.sync` (user-bound) keeps `fflush` via `synchronize_and_assert`. |
| MaxOverRange in-place mutation across nested binders            | `evaluate_node` saves `prev_it` / `had_prev` and restores on exit, so nested binders of the same `var_id` see correct state. |
| Cross-kernel MTLComputeCommandEncoder reuse vs barriers / blits | Encoder is end-encoded on every state change that requires it; reused only between consecutive compute dispatches with no intervening dependency. |