### PR TITLE
[CI] Encode Python-first testing policy in coverage-check prompt

### DIFF
--- a/.github/workflows/check_test_coverage.yml
+++ b/.github/workflows/check_test_coverage.yml
@@ -92,18 +92,14 @@ jobs:
             (a) Hardware-capability gating or other negative paths that require mocked device
                 state (e.g. a function that returns empty when a SPIR-V capability is missing) —
                 Python tests on real devices either skip or never enter the branch.
-            (b) Binary/IR-level assertions on generated artifacts (SPIR-V opcodes, capability
-                declarations, LLVM IR structure) that are not observable from Python.
-            (c) Internal IR transforms or codegen helpers with no public Python entry point,
-                where Python coverage would require a large indirect integration test.
-            (d) Parity with an existing C++ test for an analogous function (e.g. if foo_a has a
+            (b) Parity with an existing C++ test for an analogous function (e.g. if foo_a has a
                 C++ unit test and the PR adds foo_b of the same shape, mirror the test).
 
           What to flag:
           - New public functions/methods/classes with no test coverage at all
           - New modules/files with no corresponding test file
           - Significant behavior changes (new branches, new error handling) with no test for the new behavior
-          - C++ additions matching one of the (a)–(d) exceptions above with no C++ test
+          - C++ additions matching one of the (a)–(b) exceptions above with no C++ test
 
           What NOT to flag:
           - Pure refactors that don't change behavior (renames, moves, reformatting)

--- a/.github/workflows/check_test_coverage.yml
+++ b/.github/workflows/check_test_coverage.yml
@@ -82,10 +82,28 @@ jobs:
              - C++ tests: tests/cpp/ (mirrors the source subdirs)
              Test files are typically named test_<feature>.py or test_<feature>.cpp.
 
+          Repo testing policy — Python is the default:
+          - Prefer Python tests under tests/python/. Most C++ behavior is reachable via the Python
+            API and is best tested end-to-end from Python.
+          - Do NOT flag missing C++ tests when adequate Python coverage (existing or added in this
+            PR) already exercises the changed behavior end-to-end.
+          - Only flag a missing C++ test under tests/cpp/ when the behavior is impossible or
+            impractical to exercise from Python. Narrow exceptions:
+            (a) Hardware-capability gating or other negative paths that require mocked device
+                state (e.g. a function that returns empty when a SPIR-V capability is missing) —
+                Python tests on real devices either skip or never enter the branch.
+            (b) Binary/IR-level assertions on generated artifacts (SPIR-V opcodes, capability
+                declarations, LLVM IR structure) that are not observable from Python.
+            (c) Internal IR transforms or codegen helpers with no public Python entry point,
+                where Python coverage would require a large indirect integration test.
+            (d) Parity with an existing C++ test for an analogous function (e.g. if foo_a has a
+                C++ unit test and the PR adds foo_b of the same shape, mirror the test).
+
           What to flag:
           - New public functions/methods/classes with no test coverage at all
           - New modules/files with no corresponding test file
           - Significant behavior changes (new branches, new error handling) with no test for the new behavior
+          - C++ additions matching one of the (a)–(d) exceptions above with no C++ test
 
           What NOT to flag:
           - Pure refactors that don't change behavior (renames, moves, reformatting)
@@ -94,6 +112,7 @@ jobs:
           - Config files, build files, CI files
           - Changes to test infrastructure itself (conftest.py, test utilities)
           - Bug fixes where the fix is obviously correct and narrow
+          - Missing C++ tests for code already adequately covered by Python end-to-end tests
 
           Be pragmatic. Not every line needs a test. Focus on substantial untested additions.
           Do NOT modify any files.


### PR DESCRIPTION
The coverage-check agent had no awareness of the team's preference for Python end-to-end tests over C++ unit tests, so it could flag missing C++ tests on changes that are already adequately covered from Python. Add a "Repo testing policy" section that:

- Defaults to Python tests under tests/python/.
- Lists narrow exceptions where a C++ test is still warranted: hardware capability gating / negative paths needing mocked device state, binary/IR-level assertions on generated artifacts, internal IR or codegen helpers with no Python entry point, and parity with an existing C++ test for an analogous function.
- Explicitly tells the agent not to flag missing C++ tests for code that is already covered by Python.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
