### PR TITLE
[CI] Fix coverage report showing def lines as uncovered

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,5 +1,6 @@
 import argparse
 import atexit
+import importlib.util
 import os
 import shutil
 import tempfile
@@ -38,9 +39,9 @@ def _test_python(args, default_dir="python"):
     try:
         if args.coverage:
             os.environ.setdefault("QD_KERNEL_COVERAGE", "1")
-            import quadrants as _qd
-
-            _cov_src = os.path.dirname(_qd.__file__)
+            _spec = importlib.util.find_spec("quadrants")
+            assert _spec is not None and _spec.origin is not None, "quadrants package not found"
+            _cov_src = os.path.dirname(_spec.origin)
             pytest_args += ["--cov-branch", f"--cov={_cov_src}", f"--cov={test_dir}"]
         if args.cov_append:
             pytest_args += ["--cov-append"]


### PR DESCRIPTION
run_tests.py imported quadrants before pytest-cov started measuring, so all module-level code (def lines, class definitions, imports) ran before coverage began and was recorded as hits=0. Replace the early import with importlib.util.find_spec which locates the package path without executing any quadrants code.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
