### PR TITLE
[CI] Disable quadrants pytest plugin during quadrants internal coverage runs

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -43,6 +43,11 @@ def _test_python(args, default_dir="python"):
             _spec = importlib.util.find_spec("quadrants")
             assert _spec is not None and _spec.origin is not None, "quadrants package not found"
             _cov_src = os.path.dirname(_spec.origin)
+            # Disable the quadrants pytest plugin (pytest11 entry point) during coverage runs.  Loading the plugin
+            # forces Python to import the quadrants parent package before pytest-cov starts measuring, so module-level
+            # code (imports, def lines, etc.) appears uncovered.  The plugin is still useful for *external* users who
+            # run `pytest --cov` on their own code — they don't measure quadrants' own coverage.  We replicate the
+            # plugin's env-var setup (QD_KERNEL_COVERAGE, _QD_KCOV_ARC) above.
             pytest_args += [
                 "--cov-branch",
                 f"--cov={_cov_src}",

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -39,10 +39,17 @@ def _test_python(args, default_dir="python"):
     try:
         if args.coverage:
             os.environ.setdefault("QD_KERNEL_COVERAGE", "1")
+            os.environ.setdefault("_QD_KCOV_ARC", "1")
             _spec = importlib.util.find_spec("quadrants")
             assert _spec is not None and _spec.origin is not None, "quadrants package not found"
             _cov_src = os.path.dirname(_spec.origin)
-            pytest_args += ["--cov-branch", f"--cov={_cov_src}", f"--cov={test_dir}"]
+            pytest_args += [
+                "--cov-branch",
+                f"--cov={_cov_src}",
+                f"--cov={test_dir}",
+                "-p",
+                "no:quadrants",
+            ]
         if args.cov_append:
             pytest_args += ["--cov-append"]
         if args.keys:

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -39,7 +39,7 @@ def _test_python(args, default_dir="python"):
     try:
         if args.coverage:
             os.environ.setdefault("QD_KERNEL_COVERAGE", "1")
-            os.environ.setdefault("_QD_KCOV_ARC", "1")
+            os.environ["_QD_KCOV_ARC"] = "1"
             _spec = importlib.util.find_spec("quadrants")
             assert _spec is not None and _spec.origin is not None, "quadrants package not found"
             _cov_src = os.path.dirname(_spec.origin)


### PR DESCRIPTION
## Summary

- The quadrants package registers as a pytest plugin (`pytest11` entry point). When pytest loads this plugin, it imports the `quadrants` parent package, executing all module-level code **before** `pytest-cov` starts measuring coverage. This is the real root cause of `def` lines, imports, and module-level statements showing as uncovered in coverage reports.
- Disable the plugin with `-p no:quadrants` when collecting coverage in `run_tests.py`, and set `_QD_KCOV_ARC` directly (which the plugin would otherwise set).
- Follows up on #623 which addressed the `import quadrants` in `run_tests.py` itself but didn't fix the issue because the pytest plugin was the actual culprit.

## Diagnosis

The import ordering was verified locally:

| Method | Module-level lines covered | First HIT line |
|--------|---------------------------|----------------|
| `pytest --cov` (before fix) | 43 / 391 | line 321 |
| `pytest --cov -p no:quadrants` | 154 / 391 | line 4 |
| `coverage run -m pytest` | 154 / 391 | line 4 |

## Test plan

- [ ] CI coverage report should show `def` lines as covered (green) when their bodies are exercised
- [ ] Kernel coverage (`_QD_KCOV_ARC`) still works correctly

Made with [Cursor](https://cursor.com)