### PR TITLE
[CI] Lines changed report: collapse PR comment to a single linked totals line

### DIFF
--- a/.github/workflows/pr_change_report.yml
+++ b/.github/workflows/pr_change_report.yml
@@ -42,27 +42,45 @@ jobs:
             --output-dir /tmp/pr_change_report \
             --commit-hash "$SHORT_SHA"
 
-          if [ ! -s /tmp/pr_change_report/file_list.txt ]; then
+          # Primary skip gate: any source-file change at all (modifications, additions, OR
+          # deletions). summary.json is the full set; file_list.txt is the agent-input subset
+          # that excludes deletions, so gating on file_list.txt would silently drop
+          # deletion-only PRs.
+          NUM_FILES=$(jq 'length' /tmp/pr_change_report/summary.json)
+          if [ "$NUM_FILES" -eq 0 ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "No source files changed."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
             echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
-            echo "Files in report:"
-            cat /tmp/pr_change_report/file_list.txt
+            echo "Files in summary.json: $NUM_FILES"
             echo
             echo "Pre-computed file headers:"
             cat /tmp/pr_change_report/report_header.md
+
+            # Secondary skip gate: per-function attribution requires at least one non-deleted
+            # file (the agent reads HEAD content). For deletion-only PRs there is nothing for
+            # the agent to do, so skip the Cursor CLI install and agent invocation.
+            if [ -s /tmp/pr_change_report/file_list.txt ]; then
+              echo "skip_agent=false" >> "$GITHUB_OUTPUT"
+              echo
+              echo "Files for agent attribution:"
+              cat /tmp/pr_change_report/file_list.txt
+            else
+              echo "skip_agent=true" >> "$GITHUB_OUTPUT"
+              echo
+              echo "All changed source files are deletions; skipping per-function agent step."
+            fi
           fi
 
       - name: Install Cursor CLI
-        if: steps.inputs.outputs.skip != 'true'
+        if: steps.inputs.outputs.skip != 'true' && steps.inputs.outputs.skip_agent != 'true'
         run: |
           curl https://cursor.com/install -fsS | bash
           echo "$HOME/.cursor/bin" >> $GITHUB_PATH
 
       - name: Identify changed function ranges with Cursor agent
-        if: steps.inputs.outputs.skip != 'true'
+        if: steps.inputs.outputs.skip != 'true' && steps.inputs.outputs.skip_agent != 'true'
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_KEY_HUGH }}
         run: |

--- a/.github/workflows/pr_change_report.yml
+++ b/.github/workflows/pr_change_report.yml
@@ -219,11 +219,15 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            let body = fs.readFileSync('/tmp/pr_change_report/report_comment.md', 'utf8');
+            const summary = JSON.parse(
+              fs.readFileSync('/tmp/pr_change_report/summary.json', 'utf8'));
+            const numFiles = summary.length;
+            const totalAdded = summary.reduce((acc, s) => acc + s.added, 0);
+            const totalRemoved = summary.reduce((acc, s) => acc + s.removed, 0);
+            const text = `Total: ${numFiles} file(s) changed, ` +
+              `+${totalAdded} -${totalRemoved} code lines.`;
             const url = process.env.REPORT_URL;
-            if (url) {
-              body += `\n\n[Full per-function report](${url})`;
-            }
+            const body = url ? `[${text}](${url})` : text;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/scripts_new/pr_change_report/build_inputs.py
+++ b/.github/workflows/scripts_new/pr_change_report/build_inputs.py
@@ -347,8 +347,10 @@ def render_comment_markdown(summaries: list[FileSummary], commit: str) -> str:
     if not summaries:
         lines.append("No source files (.py, .c, .cc, .cpp, .h, .hpp, .cu) changed in this PR.")
         return "\n".join(lines) + "\n"
-    lines.append("LoC = code lines in the file BEFORE this PR (0 for newly-added files). "
-                 "Excludes blank lines, comment-only lines, and Python multi-line strings.")
+    lines.append(
+        "LoC = code lines in the file BEFORE this PR (0 for newly-added files). "
+        "Excludes blank lines, comment-only lines, and Python multi-line strings."
+    )
     lines.append("")
     lines.append("| File | LoC | Added | Removed |")
     lines.append("|------|-----|-------|---------|")
@@ -423,9 +425,11 @@ def main() -> int:
         if base_content:
             write_file(base_dir / path, base_content)
 
-        summaries.append(FileSummary(
-            path=path, language=lang, total=len(base_codes),
-            added=added, removed=removed, is_deleted=is_deleted))
+        summaries.append(
+            FileSummary(
+                path=path, language=lang, total=len(base_codes), added=added, removed=removed, is_deleted=is_deleted
+            )
+        )
 
     # Sort files by descending lines added, then descending lines removed, then path. This is the
     # order used for every downstream artifact (summary.json, file_list.txt, report_header.md,
@@ -433,8 +437,14 @@ def main() -> int:
     summaries.sort(key=lambda s: (-s.added, -s.removed, s.path))
 
     summary_dicts = [
-        {"path": s.path, "language": s.language, "total": s.total,
-         "added": s.added, "removed": s.removed, "is_deleted": s.is_deleted}
+        {
+            "path": s.path,
+            "language": s.language,
+            "total": s.total,
+            "added": s.added,
+            "removed": s.removed,
+            "is_deleted": s.is_deleted,
+        }
         for s in summaries
     ]
     (output_dir / "summary.json").write_text(json.dumps(summary_dicts, indent=2) + "\n")

--- a/.github/workflows/scripts_new/pr_change_report/build_inputs.py
+++ b/.github/workflows/scripts_new/pr_change_report/build_inputs.py
@@ -3,8 +3,9 @@
 
 For each source file changed in the PR (.py / .c / .cc / .cpp / .h / .hpp / .cu) this writes:
 
-  ``<output_dir>/summary.json``        list of ``{path, language, total, added, removed}``
-  ``<output_dir>/file_list.txt``       one path per line (same order as ``summary.json``)
+  ``<output_dir>/summary.json``        list of ``{path, language, total, added, removed, is_deleted}``
+  ``<output_dir>/file_list.txt``       one path per line; SAME order as ``summary.json`` but EXCLUDES
+                                       deleted files (they have no HEAD content for the agent to attribute)
   ``<output_dir>/report_header.md``    pre-formatted file-header lines (verbatim for the report)
   ``<output_dir>/report_comment.md``   compact PR-comment markdown (table + totals line)
   ``<output_dir>/diffs/<path>.diff``   per-file unified diff vs. merge-base
@@ -318,6 +319,7 @@ class FileSummary:
     total: int
     added: int
     removed: int
+    is_deleted: bool = False
 
 
 def write_file(path: Path, content: str) -> None:
@@ -390,8 +392,7 @@ def main() -> int:
             continue
         parts = line.split("\t")
         status = parts[0]
-        if status.startswith("D"):
-            continue
+        is_deleted = status.startswith("D")
         # For renames / copies the new path is the last field; for plain modifications it is the only path.
         path = parts[-1]
         lang = language_for(path)
@@ -402,19 +403,29 @@ def main() -> int:
         if not diff_text.strip():
             continue
 
-        head_content = run_git(["show", f"{args.head_ref}:{path}"], check=False)
-        base_content = run_git(["show", f"{merge_base}:{path}"], check=False)
-
-        head_codes = code_line_set(head_content, lang)
-        base_codes = code_line_set(base_content, lang) if base_content else set()
-        added, removed = diff_added_removed(diff_text, head_codes, base_codes)
+        if is_deleted:
+            head_content = ""
+            base_content = run_git(["show", f"{merge_base}:{path}"], check=False)
+            head_codes: set[int] = set()
+            base_codes = code_line_set(base_content, lang) if base_content else set()
+            added = 0
+            removed = len(base_codes)
+        else:
+            head_content = run_git(["show", f"{args.head_ref}:{path}"], check=False)
+            base_content = run_git(["show", f"{merge_base}:{path}"], check=False)
+            head_codes = code_line_set(head_content, lang)
+            base_codes = code_line_set(base_content, lang) if base_content else set()
+            added, removed = diff_added_removed(diff_text, head_codes, base_codes)
 
         write_file(diffs_dir / f"{path}.diff", diff_text)
-        write_file(head_dir / path, head_content)
+        if head_content:
+            write_file(head_dir / path, head_content)
         if base_content:
             write_file(base_dir / path, base_content)
 
-        summaries.append(FileSummary(path=path, language=lang, total=len(base_codes), added=added, removed=removed))
+        summaries.append(FileSummary(
+            path=path, language=lang, total=len(base_codes),
+            added=added, removed=removed, is_deleted=is_deleted))
 
     # Sort files by descending lines added, then descending lines removed, then path. This is the
     # order used for every downstream artifact (summary.json, file_list.txt, report_header.md,
@@ -422,12 +433,16 @@ def main() -> int:
     summaries.sort(key=lambda s: (-s.added, -s.removed, s.path))
 
     summary_dicts = [
-        {"path": s.path, "language": s.language, "total": s.total, "added": s.added, "removed": s.removed}
+        {"path": s.path, "language": s.language, "total": s.total,
+         "added": s.added, "removed": s.removed, "is_deleted": s.is_deleted}
         for s in summaries
     ]
     (output_dir / "summary.json").write_text(json.dumps(summary_dicts, indent=2) + "\n")
 
-    file_list = "\n".join(s.path for s in summaries)
+    # file_list.txt and touched_ranges.txt feed the agent. Deleted files have no HEAD content
+    # and no per-function attribution to compute, so they are excluded from both. They still
+    # appear in summary.json / report_comment.md / report.txt with correct totals.
+    file_list = "\n".join(s.path for s in summaries if not s.is_deleted)
     (output_dir / "file_list.txt").write_text(file_list + ("\n" if file_list else ""))
 
     headers = "\n".join(format_header(s) for s in summaries)
@@ -437,6 +452,8 @@ def main() -> int:
 
     touched_lines = []
     for s in summaries:
+        if s.is_deleted:
+            continue
         diff_text = (diffs_dir / f"{s.path}.diff").read_text()
         head_ranges, base_ranges = diff_touched_ranges(diff_text)
         head_str = ", ".join(f"{a}-{b}" for a, b in head_ranges) or "(none)"

--- a/.github/workflows/scripts_new/pr_change_report/build_inputs.py
+++ b/.github/workflows/scripts_new/pr_change_report/build_inputs.py
@@ -11,11 +11,12 @@ For each source file changed in the PR (.py / .c / .cc / .cpp / .h / .hpp / .cu)
   ``<output_dir>/head/<path>``         HEAD content of the file (always present)
   ``<output_dir>/base/<path>``         file content at merge-base (absent for newly added files)
 
-``total`` is the number of code lines in the HEAD version of the file. ``added`` and ``removed`` are
-the number of code lines added or removed by this PR (vs. merge-base). A "code line" excludes blank
-lines, lines whose only non-whitespace content is a comment, and (in Python) lines whose only token
-content is a string literal -- i.e. docstrings and continuation lines of multi-line strings. C/C++
-``/* ... */`` block comments are stripped before counting.
+``total`` is the number of code lines in the BASE (pre-PR, merge-base) version of the file -- the
+size of the file before this PR's changes. For newly-added files this is 0. ``added`` and
+``removed`` are the number of code lines added or removed by this PR (vs. merge-base). A "code
+line" excludes blank lines, lines whose only non-whitespace content is a comment, and (in Python)
+lines whose only token content is a string literal -- i.e. docstrings and continuation lines of
+multi-line strings. C/C++ ``/* ... */`` block comments are stripped before counting.
 
 The agent consumes these inputs to produce the per-function breakdown.
 """
@@ -344,7 +345,8 @@ def render_comment_markdown(summaries: list[FileSummary], commit: str) -> str:
     if not summaries:
         lines.append("No source files (.py, .c, .cc, .cpp, .h, .hpp, .cu) changed in this PR.")
         return "\n".join(lines) + "\n"
-    lines.append("Code lines (excluding blank lines, comment-only lines, and Python multi-line strings).")
+    lines.append("LoC = code lines in the file BEFORE this PR (0 for newly-added files). "
+                 "Excludes blank lines, comment-only lines, and Python multi-line strings.")
     lines.append("")
     lines.append("| File | LoC | Added | Removed |")
     lines.append("|------|-----|-------|---------|")
@@ -412,7 +414,7 @@ def main() -> int:
         if base_content:
             write_file(base_dir / path, base_content)
 
-        summaries.append(FileSummary(path=path, language=lang, total=len(head_codes), added=added, removed=removed))
+        summaries.append(FileSummary(path=path, language=lang, total=len(base_codes), added=added, removed=removed))
 
     # Sort files by descending lines added, then descending lines removed, then path. This is the
     # order used for every downstream artifact (summary.json, file_list.txt, report_header.md,

--- a/.github/workflows/scripts_new/pr_change_report/build_inputs.py
+++ b/.github/workflows/scripts_new/pr_change_report/build_inputs.py
@@ -12,12 +12,12 @@ For each source file changed in the PR (.py / .c / .cc / .cpp / .h / .hpp / .cu)
   ``<output_dir>/head/<path>``         HEAD content of the file (always present)
   ``<output_dir>/base/<path>``         file content at merge-base (absent for newly added files)
 
-``total`` is the number of code lines in the BASE (pre-PR, merge-base) version of the file -- the
-size of the file before this PR's changes. For newly-added files this is 0. ``added`` and
+``total`` is the number of code lines in the BASE (pre-PR, merge-base) version of the file, i.e.
+the size of the file before this PR's changes. For newly-added files this is 0. ``added`` and
 ``removed`` are the number of code lines added or removed by this PR (vs. merge-base). A "code
 line" excludes blank lines, lines whose only non-whitespace content is a comment, and (in Python)
-lines whose only token content is a string literal -- i.e. docstrings and continuation lines of
-multi-line strings. C/C++ ``/* ... */`` block comments are stripped before counting.
+lines whose only token content is a string literal (i.e. docstrings and continuation lines of
+multi-line strings). C/C++ ``/* ... */`` block comments are stripped before counting.
 
 The agent consumes these inputs to produce the per-function breakdown.
 """

--- a/.github/workflows/scripts_new/pr_change_report/render_report.py
+++ b/.github/workflows/scripts_new/pr_change_report/render_report.py
@@ -69,6 +69,7 @@ class _FileBookkeeping:
     base_codes: set[int]
     added_line_nos: list[int]
     removed_line_nos: list[int]
+    is_deleted: bool = False
 
 
 def _load_function_entries(jsonl_path: Path) -> dict[str, list[_FunctionEntry]]:
@@ -149,6 +150,7 @@ def _build_file_bookkeeping(summary: dict, output_dir: Path) -> _FileBookkeeping
         base_codes=base_codes,
         added_line_nos=added_line_nos,
         removed_line_nos=removed_line_nos,
+        is_deleted=bool(summary.get("is_deleted", False)),
     )
 
 
@@ -273,6 +275,9 @@ def _emit_file_section(book: _FileBookkeeping, attributed: list[_AttributedEntry
     appended by the caller, not here.
     """
     lines: list[str] = [format_header(_HeaderProxy(book))]
+    if book.is_deleted:
+        lines.append(f"{_GROUP_INDENT}# entire file deleted (per-function breakdown skipped)")
+        return lines, 0, 0
     if not attributed:
         if book.added or book.removed:
             lines.append(f"{_GROUP_INDENT}# note: no per-function attribution available")

--- a/.github/workflows/scripts_new/pr_change_report/render_report.py
+++ b/.github/workflows/scripts_new/pr_change_report/render_report.py
@@ -157,7 +157,7 @@ def _build_file_bookkeeping(summary: dict, output_dir: Path) -> _FileBookkeeping
 def _attribute_function(entry: _FunctionEntry, book: _FileBookkeeping) -> tuple[int, int, int, bool, bool]:
     """Return ``(total, added, removed, is_new, is_deleted)`` for a single function entry.
 
-    ``total`` is the number of code lines in the function's BASE (pre-PR) body -- i.e. how big
+    ``total`` is the number of code lines in the function's BASE (pre-PR) body, i.e. how big
     this function was before this PR. For NEW functions (no base body) this is 0. ``added`` /
     ``removed`` are the number of ``+`` / ``-`` diff lines that fall inside the function's
     HEAD / base range AND are themselves code lines (excluding comments / blank lines / Python

--- a/.github/workflows/scripts_new/pr_change_report/render_report.py
+++ b/.github/workflows/scripts_new/pr_change_report/render_report.py
@@ -16,16 +16,22 @@ Output ``report.txt`` shape::
 
   <path> <total> +<added> -<removed>
       New:
-        <func>()                                   NEW    +<added>
+        <func>()                              <total>  +<added>
         ...
       Existing:
-        <func>()                              <total>     +<added>   -<removed>
+        <func>()                              <total>  +<added>  -<removed>
+        ...
+      Deleted:
+        <func>()                              <total>            -<removed>
         ...
 
-Within each file, functions are split into a ``New:`` group (added by this PR) and an
-``Existing:`` group (modified or deleted by this PR), and within each group sorted by added
-lines descending, then removed lines descending. Function-name and numeric columns are
-padded with spaces so the columns line up within a file.
+The ``<total>`` column at every level is the BASE (pre-PR) code-line count: file size before
+the PR (or 0 for newly-added files); function body size before the PR (or 0 for new functions;
+the original body size for deleted functions). Within each file, functions are split into a
+``New:`` group (added by this PR), an ``Existing:`` group (modified by this PR), and a
+``Deleted:`` group (removed by this PR), and within each group sorted by added lines descending,
+then removed lines descending. Function-name and numeric columns are padded with spaces so the
+columns line up within a file.
 """
 
 from __future__ import annotations
@@ -149,20 +155,22 @@ def _build_file_bookkeeping(summary: dict, output_dir: Path) -> _FileBookkeeping
 def _attribute_function(entry: _FunctionEntry, book: _FileBookkeeping) -> tuple[int, int, int, bool, bool]:
     """Return ``(total, added, removed, is_new, is_deleted)`` for a single function entry.
 
-    ``total`` is the number of code lines in the function's HEAD body. ``added`` / ``removed``
-    are the number of ``+`` / ``-`` diff lines that fall inside the function's HEAD / base range
-    AND are themselves code lines (excluding comments / blank lines / Python multi-line strings).
+    ``total`` is the number of code lines in the function's BASE (pre-PR) body -- i.e. how big
+    this function was before this PR. For NEW functions (no base body) this is 0. ``added`` /
+    ``removed`` are the number of ``+`` / ``-`` diff lines that fall inside the function's
+    HEAD / base range AND are themselves code lines (excluding comments / blank lines / Python
+    multi-line strings).
     """
     total = 0
     added = 0
     removed = 0
-    if entry.head_range is not None:
-        a, b = entry.head_range
-        total = sum(1 for ln in book.head_codes if a <= ln <= b)
-        added = sum(1 for ln in book.added_line_nos if a <= ln <= b and ln in book.head_codes)
     if entry.base_range is not None:
         c, d = entry.base_range
+        total = sum(1 for ln in book.base_codes if c <= ln <= d)
         removed = sum(1 for ln in book.removed_line_nos if c <= ln <= d and ln in book.base_codes)
+    if entry.head_range is not None:
+        a, b = entry.head_range
+        added = sum(1 for ln in book.added_line_nos if a <= ln <= b and ln in book.head_codes)
     is_new = entry.head_range is not None and entry.base_range is None
     is_deleted = entry.head_range is None and entry.base_range is not None
     return total, added, removed, is_new, is_deleted
@@ -223,9 +231,9 @@ def _impact_sort_key(a: _AttributedEntry) -> tuple[int, int, str]:
 
 
 # Column widths chosen to fit the longest expected token in each column without crowding adjacent
-# columns. ``DELETED`` is 7 chars (the longest total token); five-digit ``+``/``-`` counts are
-# the longest expected numeric tokens.
-_TOTAL_WIDTH = 8
+# columns. Five-digit ``+``/``-`` counts are the longest expected numeric tokens; the total
+# column holds a base (pre-PR) line count so it never exceeds a few digits in practice.
+_TOTAL_WIDTH = 6
 _ADDED_WIDTH = 7
 _REMOVED_WIDTH = 7
 _FUNC_INDENT = "      "
@@ -233,10 +241,6 @@ _GROUP_INDENT = "    "
 
 
 def _format_total(a: _AttributedEntry) -> str:
-    if a.is_deleted:
-        return "DELETED"
-    if a.is_new:
-        return "NEW"
     return str(a.total)
 
 
@@ -275,11 +279,15 @@ def _emit_file_section(book: _FileBookkeeping, attributed: list[_AttributedEntry
         return lines, 0, 0
 
     new_group = sorted([a for a in attributed if a.is_new], key=_impact_sort_key)
-    existing_group = sorted([a for a in attributed if not a.is_new], key=_impact_sort_key)
+    deleted_group = sorted([a for a in attributed if a.is_deleted], key=_impact_sort_key)
+    existing_group = sorted(
+        [a for a in attributed if not a.is_new and not a.is_deleted],
+        key=_impact_sort_key)
 
-    # Pad function names to the longest name across BOTH groups so the New: and Existing:
-    # subsections line up with each other.
-    all_names = [_function_label(a.entry.name) for a in new_group + existing_group]
+    # Pad function names to the longest name across ALL groups so the New: / Existing: /
+    # Deleted: subsections line up with each other.
+    all_names = [_function_label(a.entry.name)
+                 for a in new_group + existing_group + deleted_group]
     name_width = max((len(n) for n in all_names), default=0)
 
     if new_group:
@@ -289,6 +297,10 @@ def _emit_file_section(book: _FileBookkeeping, attributed: list[_AttributedEntry
     if existing_group:
         lines.append(f"{_GROUP_INDENT}Existing:")
         for a in existing_group:
+            lines.append(_format_aligned_function(a, name_width))
+    if deleted_group:
+        lines.append(f"{_GROUP_INDENT}Deleted:")
+        for a in deleted_group:
             lines.append(_format_aligned_function(a, name_width))
 
     per_added = sum(a.added for a in attributed)

--- a/.github/workflows/scripts_new/pr_change_report/render_report.py
+++ b/.github/workflows/scripts_new/pr_change_report/render_report.py
@@ -285,14 +285,11 @@ def _emit_file_section(book: _FileBookkeeping, attributed: list[_AttributedEntry
 
     new_group = sorted([a for a in attributed if a.is_new], key=_impact_sort_key)
     deleted_group = sorted([a for a in attributed if a.is_deleted], key=_impact_sort_key)
-    existing_group = sorted(
-        [a for a in attributed if not a.is_new and not a.is_deleted],
-        key=_impact_sort_key)
+    existing_group = sorted([a for a in attributed if not a.is_new and not a.is_deleted], key=_impact_sort_key)
 
     # Pad function names to the longest name across ALL groups so the New: / Existing: /
     # Deleted: subsections line up with each other.
-    all_names = [_function_label(a.entry.name)
-                 for a in new_group + existing_group + deleted_group]
+    all_names = [_function_label(a.entry.name) for a in new_group + existing_group + deleted_group]
     name_width = max((len(n) for n in all_names), default=0)
 
     if new_group:

--- a/.github/workflows/scripts_new/pr_change_report/render_report.py
+++ b/.github/workflows/scripts_new/pr_change_report/render_report.py
@@ -315,6 +315,18 @@ def _emit_file_section(book: _FileBookkeeping, attributed: list[_AttributedEntry
     return lines, per_added, per_removed
 
 
+_FOOTER = (
+    "Notes:\n"
+    "  * The number columns (without a + or - sign) are code-line counts in the "
+    "BASE (pre-PR) version: file size before this PR (0 for newly-added files), "
+    "function body size before this PR (0 for new functions; original body size "
+    "for deleted functions).\n"
+    "  * +<n> / -<n> are code lines added / removed by this PR.\n"
+    "  * Code lines exclude blank lines, comment-only lines, and Python "
+    "multi-line strings."
+)
+
+
 def render(summary_json: Path, jsonl_path: Path, output_dir: Path) -> str:
     summaries: list[dict] = json.loads(summary_json.read_text())
     by_path = _load_function_entries(jsonl_path)
@@ -328,6 +340,9 @@ def render(summary_json: Path, jsonl_path: Path, output_dir: Path) -> str:
         out_lines.append("")
     while out_lines and out_lines[-1] == "":
         out_lines.pop()
+    if out_lines:
+        out_lines.append("")
+        out_lines.append(_FOOTER)
     return "\n".join(out_lines) + ("\n" if out_lines else "")
 
 

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -160,16 +160,26 @@ The number columns on the Check page (without a `+` or `-` sign) are code-line c
 Files are sorted by added lines descending. Within each file, functions are split into a `New:` group (added by this PR), an `Existing:` group (modified by this PR), and a `Deleted:` group (removed by this PR), and within each group sorted by added lines descending, then removed lines descending. Files that are deleted in their entirety appear as a single per-file row (so the totals stay accurate) but skip the per-function breakdown. Sample shape:
 
 ```
-src/lib.py 12 +8 -4
+quadrants/program/program_stream.cpp 0 +151
     New:
-      brand_new()       0       +4
-    Existing:
-      to_modify()       5       +3       -1
-    Deleted:
-      to_delete()       3                -3
+      StreamManager::create_event()             0     +18
+      StreamManager::create_stream()            0     +18
+      StreamManager::record_event()             0     +15
+      StreamManager::destroy_event()            0     +13
+      StreamManager::destroy_stream()           0     +13
 
-src/doomed.py 6 -6
+python/quadrants/lang/stream.py 0 +111
+    New:
+      Event.destroy()             0      +9
+      Stream.destroy()            0      +9
+      Event._destroy_prog()       0      +8
+      Stream._destroy_prog()      0      +8
+      Event.__del__()             0      +7
+
+quadrants/program/legacy_stream.cpp 42 -42
     # entire file deleted (per-function breakdown skipped)
 ```
+
+The `0` in the LoC column for the two new files reflects that both files did not exist before this PR (their pre-PR code-line count is 0). The `42 -42` row for `legacy_stream.cpp` is a fully-deleted file: 42 code lines existed before this PR and all 42 were removed.
 
 This check is delayed by 30 minutes, to avoid running repeatedly if multiple commits pushed with a short delay between each.

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -157,7 +157,7 @@ Posts a fresh PR comment on every push consisting of a single line — the total
 
 The number columns on the Check page (without a `+` or `-` sign) are code-line counts in the BASE (pre-PR) version: file size before this PR (0 for newly-added files), function body size before this PR (0 for new functions; original body size for deleted functions). `+<n>` / `-<n>` are code lines added / removed by this PR.
 
-Files are sorted by added lines descending. Within each file, functions are split into a `New:` group (added by this PR), an `Existing:` group (modified by this PR), and a `Deleted:` group (removed by this PR), and within each group sorted by added lines descending, then removed lines descending. Sample shape:
+Files are sorted by added lines descending. Within each file, functions are split into a `New:` group (added by this PR), an `Existing:` group (modified by this PR), and a `Deleted:` group (removed by this PR), and within each group sorted by added lines descending, then removed lines descending. Files that are deleted in their entirety appear as a single per-file row (so the totals stay accurate) but skip the per-function breakdown. Sample shape:
 
 ```
 src/lib.py 12 +8 -4
@@ -167,6 +167,9 @@ src/lib.py 12 +8 -4
       to_modify()       5       +3       -1
     Deleted:
       to_delete()       3                -3
+
+src/doomed.py 6 -6
+    # entire file deleted (per-function breakdown skipped)
 ```
 
 This check is delayed by 30 minutes, to avoid running repeatedly if multiple commits pushed with a short delay between each.

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -153,7 +153,7 @@ The agent reports up to 5 violations, each annotated with the host file's hotnes
 
 ### PR change report (`pr_change_report.yml`)
 
-Posts a fresh PR comment on every push consisting of a single line — the totals (file count, code lines added, code lines removed) formatted as a markdown link to a GitHub Check whose page contains the full per-file / per-function breakdown. "Code lines" exclude blank lines, comment-only lines, and (in Python) lines whose only token content is a string literal — i.e. docstrings and continuation lines of multi-line strings. C/C++ `/* … */` block comments are stripped before counting.
+Posts a fresh PR comment on every push. The comment is a single line: the totals (file count, code lines added, code lines removed) formatted as a markdown link to a GitHub Check whose page contains the full per-file / per-function breakdown. "Code lines" exclude blank lines, comment-only lines, and (in Python) lines whose only token content is a string literal (i.e. docstrings and continuation lines of multi-line strings). C/C++ `/* … */` block comments are stripped before counting.
 
 The number columns on the Check page (without a `+` or `-` sign) are code-line counts in the BASE (pre-PR) version: file size before this PR (0 for newly-added files), function body size before this PR (0 for new functions; original body size for deleted functions). `+<n>` / `-<n>` are code lines added / removed by this PR.
 

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -153,26 +153,20 @@ The agent reports up to 5 violations, each annotated with the host file's hotnes
 
 ### PR change report (`pr_change_report.yml`)
 
-Posts a fresh PR comment on every push pointing at a GitHub Check whose page contains a per-file / per-function breakdown of code-line additions and removals. "Code lines" exclude blank lines, comment-only lines, and (in Python) lines whose only token content is a string literal — i.e. docstrings and continuation lines of multi-line strings. C/C++ `/* … */` block comments are stripped before counting.
+Posts a fresh PR comment on every push consisting of a single line — the totals (file count, code lines added, code lines removed) formatted as a markdown link to a GitHub Check whose page contains the full per-file / per-function breakdown. "Code lines" exclude blank lines, comment-only lines, and (in Python) lines whose only token content is a string literal — i.e. docstrings and continuation lines of multi-line strings. C/C++ `/* … */` block comments are stripped before counting.
 
-Files are sorted by added lines descending. Within each file, functions are split into a `New:` group (added by this PR) and an `Existing:` group (modified or deleted), and within each group sorted by added lines descending. Sample shape:
+The number columns on the Check page (without a `+` or `-` sign) are code-line counts in the BASE (pre-PR) version: file size before this PR (0 for newly-added files), function body size before this PR (0 for new functions; original body size for deleted functions). `+<n>` / `-<n>` are code lines added / removed by this PR.
+
+Files are sorted by added lines descending. Within each file, functions are split into a `New:` group (added by this PR), an `Existing:` group (modified by this PR), and a `Deleted:` group (removed by this PR), and within each group sorted by added lines descending, then removed lines descending. Sample shape:
 
 ```
-quadrants/program/program_stream.cpp 151 +151
+src/lib.py 12 +8 -4
     New:
-      StreamManager::create_event()             NEW      +18
-      StreamManager::create_stream()            NEW      +18
-      StreamManager::record_event()             NEW      +15
-      StreamManager::destroy_event()            NEW      +13
-      StreamManager::destroy_stream()           NEW      +13
-
-python/quadrants/lang/stream.py 111 +111
-    New:
-      Event.destroy()              NEW       +9
-      Stream.destroy()             NEW       +9
-      Event._destroy_prog()        NEW       +8
-      Stream._destroy_prog()       NEW       +8
-      Event.__del__()              NEW       +7
+      brand_new()       0       +4
+    Existing:
+      to_modify()       5       +3       -1
+    Deleted:
+      to_delete()       3                -3
 ```
 
 This check is delayed by 30 minutes, to avoid running repeatedly if multiple commits pushed with a short delay between each.


### PR DESCRIPTION
Issue: #

### Brief Summary

- single line comment in PR
- totals are prior total, before changes
- add lines from deleted files

copilot:summary

### Walkthrough

copilot:walkthrough
