### PR TITLE
[AutoDiff] Disable EliminateRecomputableAdStackPushes pending mutated-SNode chain-leaf fix

### DIFF
--- a/quadrants/transforms/auto_diff/auto_diff.cpp
+++ b/quadrants/transforms/auto_diff/auto_diff.cpp
@@ -37,14 +37,13 @@ void auto_diff(IRNode *root, const CompileConfig &config, AutodiffMode autodiff_
         replace_local_var_with_stacks(ib, config.ad_stack_size);
         type_check(root, config);
 
-        // Drop AdStackAllocas whose pushed value is recomputable from already-stack-backed allocas + args + const +
-        // loop-index. Trades forward-pass adstack memory traffic (one push + one load per iter per intermediate spill)
-        // for cloned arithmetic in the reverse scope, which `BackupSSA::generic_visit` generates on demand via the same
-        // RecomputableChainCloner path. Must run after `replace_local_var_with_stacks` (so the analyzer sees the
-        // AdStackAlloca shape, not the alloca-with-store shape promote_ssa_to_local_var emits) and before
-        // `make_adjoint` (so the reverse pass is generated against the cleaned forward IR with no spurious push/load
-        // scaffolding).
-        eliminate_recomputable_ad_stack_pushes(ib);
+        // Disabled: `RecomputableChainAnalyzer` admits `GlobalLoadStmt` as a recomputable interior node without
+        // verifying SNode read-only-ness. When the chain reaches a `GlobalLoadStmt` of an SNode written elsewhere in
+        // the same kernel execution, `BackupSSA`'s reverse-side re-clone reads post-write state instead of the iter-k
+        // value the original `AdStackLoadTopStmt` would have returned, silently corrupting gradients on MPM-style
+        // kernels that mix per-particle reads with grid writes. Re-enable once the chain analyzer rejects
+        // mutated-SNode loads (or the cost model gates on read-only-verified leaves).
+        // eliminate_recomputable_ad_stack_pushes(ib);
         type_check(root, config);
 
         make_adjoint(ib);


### PR DESCRIPTION
> Stop-gap revert of the new pass while a sound chain-leaf rule is designed.

## TL;DR
Comment out the call site of `eliminate_recomputable_ad_stack_pushes(ib)` in `auto_diff()`. The pass machinery and tests stay in place; only the invocation is gated.

## Why
`tests/test_grad.py::test_differentiable_push[cpu]` and `[gpu]` (Genesis, on `autodiff_dyn_loop`) both regressed at `2fc5472a` ([AutoDiff] EliminateRecomputableAdStackPushes pass + leaf extensions, #621): the gradient `v_list[i].grad` for early `i` collapses to zero, tripping the `(v_i.grad.abs() > gs.EPS).any()` assertion. The bug is at the IR-transform level, before backend code generation, so every backend miscompiles the same way.

Bisected the elimination cap to a single rewrite (#244 of 1018 in this kernel set, on the CPU run). The offender is an `i32` index spill `\$452520` whose pushed value `\$448881 = sub \$445664 \$449056` transitively reaches `\$445183 = global load S74place[particle, ...]` (a particle position read). The same kernel (`kernel_step_2_c500_1`) writes S74place later via `global store \$445464`/`\$445512`. After elimination, `BackupSSA` re-clones the chain in the reverse pass; the cloned `GlobalLoadStmt` reads the post-write value, so the integer cell index used to look up the grid gradient is off, and the chain of MPM gradients loses the per-iteration v_i contributions.

`RecomputableChainAnalyzer::is_recomputable` admits `GlobalLoadStmt` as a recomputable interior node unconditionally (auto_diff_common.h:146-148). The same file's comment already flags this as a known soundness hole pending read-only-SNode verification.

## Mechanism
- Single edit in `quadrants/transforms/auto_diff/auto_diff.cpp`: comment out `eliminate_recomputable_ad_stack_pushes(ib)` and replace the rationale comment with a short note explaining the disable.
- No code path or symbol is removed; the implementation, judger, and unit tests on the C++ side are untouched, so re-enabling is a one-line change once the chain analyzer rejects mutated-SNode loads.

## Side-effect audit
- Forward IR regrows the AdStackPush/AdStackLoadTopStmt scaffolding the pass would have stripped; reverse pass uses `load_top` to restore the iter-k value instead of cloning the chain, matching pre-#621 correctness.
- Reverses the FPS gain claimed by #621 on dynamic-loop kernels; to be reclaimed when the analyzer is fixed.
- C++ unit tests for the pass (`tests/python/test_adstack.py`) still exercise the implementation directly and continue to pass.