### PR TITLE
[CI] Gate PR workflows by paths via dorny/paths-filter (SHA-pinned); skip non-docs / non-.github jobs on doc-or-CI-only PRs

### DIFF
--- a/.github/workflows/check_deleted_comments.yml
+++ b/.github/workflows/check_deleted_comments.yml
@@ -10,7 +10,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            src:
+              - '!docs/**'
+              - '!.github/**'
   check-deleted-comments:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: Check deleted comments
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check_feature_factorization.yml
+++ b/.github/workflows/check_feature_factorization.yml
@@ -10,7 +10,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            src:
+              - '!docs/**'
+              - '!.github/**'
   check-feature-factorization:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: Check feature factorization
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check_markup_links.yml
+++ b/.github/workflows/check_markup_links.yml
@@ -7,7 +7,24 @@ on:
       - synchronize
   workflow_dispatch:
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      docs: ${{ steps.filter.outputs.docs || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
   markdown-link-check:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/check_test_coverage.yml
+++ b/.github/workflows/check_test_coverage.yml
@@ -10,7 +10,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            src:
+              - '!docs/**'
+              - '!.github/**'
   check-test-coverage:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: Check test coverage for changes
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -10,7 +10,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            src:
+              - '!docs/**'
+              - '!.github/**'
   build:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: clang-tidy
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,7 +10,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            src:
+              - '!docs/**'
+              - '!.github/**'
   build:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: Linters
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            src:
+              - '!docs/**'
+              - '!.github/**'
   build:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -12,7 +12,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'release' }}
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            src:
+              - '!docs/**'
+              - '!.github/**'
   build_mac:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/manylinux_wheel.yml
+++ b/.github/workflows/manylinux_wheel.yml
@@ -14,7 +14,26 @@ on:
 permissions:
   contents: write
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            src:
+              - '!docs/**'
+              - '!.github/**'
   build_wheel:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: Manylinux wheel Build
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'quay.io/pypa/manylinux_2_28_x86_64:latest' || matrix.os == 'ubuntu-22.04-arm' && 'quay.io/pypa/manylinux_2_34_aarch64:2025.11.11-1' }}

--- a/.github/workflows/pr_change_report.yml
+++ b/.github/workflows/pr_change_report.yml
@@ -14,7 +14,26 @@ permissions:
   pull-requests: write
   checks: write
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            src:
+              - '!docs/**'
+              - '!.github/**'
   pr-change-report:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: PR change report
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -12,7 +12,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'release' }}
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            src:
+              - '!docs/**'
+              - '!.github/**'
   win_build:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: Windows 2025 Build
     runs-on: windows-2025
     strategy:


### PR DESCRIPTION
# Skip irrelevant CI jobs on docs-only / .github-only PRs

> Eleven workflow files, no behavior change for code PRs. Each PR-triggered workflow now gates on whether at least one changed file lives outside `docs/**` and `.github/**`.

## TL;DR

Each gated workflow now starts with a small `changes` job:

```yaml
jobs:
  changes:
    runs-on: ubuntu-latest
    permissions:
      contents: read
      pull-requests: read
    outputs:
      src: ${{ steps.filter.outputs.src || 'true' }}
    steps:
      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
        id: filter
        if: github.event_name == 'pull_request'
        with:
          predicate-quantifier: 'every'
          filters: |
            src:
              - '!docs/**'
              - '!.github/**'
  build:
    needs: changes
    if: needs.changes.outputs.src == 'true'
    ...
```

On a PR that only touches `docs/` or `.github/`, the `build` job is reported as "skipped" by GitHub, which counts as success for branch-protection required checks.

## Why

A docs-only or CI-config-only PR currently kicks off the full Linux / macOS / Windows / manylinux build matrix, clang-tidy, linters, the test-coverage / deleted-comments / feature-factorization / pr-change-report Cursor agents, etc. None of that exercises the changed files; the cost is real (especially the wheel matrix and the paid AI agents) and the wait-for-review feedback is worse than it needs to be.

The straightforward fix is GitHub's native `paths-ignore:` trigger filter, but it has a known interaction with required status checks: a workflow filtered out by `paths-ignore` never reports a check, and any branch-protection rule expecting that check is stuck in "waiting" forever (see [community discussion #44490](https://github.com/orgs/community/discussions/44490)). This PR uses the workaround that always triggers the workflow but skips the real job inside it - skipped jobs do report as success.

## Mechanism

### Filter

[`dorny/paths-filter@v4.0.1`](https://github.com/dorny/paths-filter) reads the PR diff via the GitHub API and outputs a boolean per filter. We pin by commit SHA (`fbd0ab8f3e69293af611ebaee6363fc25e6d187d`) rather than the floating tag to keep the supply-chain surface minimal; the `# v4.0.1` comment documents intent.

The filter expression is two negation patterns:

```yaml
filters: |
  src:
    - '!docs/**'
    - '!.github/**'
```

with `predicate-quantifier: 'every'` (default is `some`). `every` requires every changed file to satisfy every pattern, so a single `docs/foo.md` file fails the filter (it does not satisfy `!docs/**`) even though it satisfies `!.github/**`. With the default `some`, that same file would (incorrectly) make the filter pass because it satisfies one of the two patterns.

### Gating

The `changes` job runs the filter only on `pull_request` events; on `push` / `workflow_dispatch` / `release` the step is skipped and the output falls back to `'true'` via `${{ steps.filter.outputs.src || 'true' }}`, so non-PR triggers always run the real job.

The downstream job declares `needs: changes` and `if: needs.changes.outputs.src == 'true'`. Required-check compatibility relies on the GitHub behavior that a job whose `if:` evaluates false is reported with conclusion `skipped`, which branch protection treats as success.

### Per-workflow coverage

| Workflow | Trigger filter | Real job runs when |
|----------|---------------|--------------------|
| `linux.yml` | `!docs/**` AND `!.github/**` | any non-docs / non-CI source change |
| `macosx.yml` | same | same |
| `win.yml` | same | same |
| `manylinux_wheel.yml` | same | same (push to main, release, dispatch always run) |
| `clang_tidy.yml` | same | same |
| `linters.yml` | same | same |
| `check_test_coverage.yml` | same | same |
| `check_deleted_comments.yml` | same | same |
| `check_feature_factorization.yml` | same | same |
| `pr_change_report.yml` | same | same |
| `check_markup_links.yml` | `docs/**` (positive) | only when `docs/` files change |
| `check_wrapping.yml` | unchanged | every PR (line-wrap rule applies to docs too) |

Workflows used only via `workflow_call` (`api_doc.yml`, `publish_pypi.yml`, `pyright_linter.yml`, `test_gpu.yml`) do not appear here because they are not directly PR-triggered.

## Notes

- `changes` job permissions are scoped to `contents: read` + `pull-requests: read`, the minimum needed for `dorny/paths-filter` to read the PR diff via the API.
- The action is pinned by full commit SHA, not by tag or branch, so a future tag-move on `v4.0.1` cannot silently swap the implementation. Bumping requires an explicit SHA edit.
- For workflows that already had an in-job "is this docs-only?" early-skip step (`check_deleted_comments`, `check_test_coverage`, `pr_change_report`, `check_feature_factorization`), the `needs: changes` gate now shortcuts the runner spin-up entirely, which also saves the 30-minute dead-reckoning sleep those workflows do before invoking the paid Cursor agent.
