### PR TITLE
[AMDGPU] Apply device_memory_GB=0.3 cap to AMDGPU tests

### DIFF
--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -91,17 +91,15 @@ def _vulkan_debug_warmup():
 @pytest.fixture(autouse=True)
 def wanted_arch(request, req_arch, req_options):
     if req_arch is not None:
-        if req_arch == qd.cuda:
+        if req_arch in (qd.cuda, qd.amdgpu):
             if not request.node.get_closest_marker("run_in_serial"):
                 # Optimization only apply to non-serial tests, since serial tests
                 # are picked out exactly because of extensive resource consumption.
                 # Separation of serial/non-serial tests is done by the test runner
                 # through `-m run_in_serial` / `-m not run_in_serial`.
-                req_options = {
-                    "device_memory_GB": 0.3,
-                    "cuda_stack_limit": 1024,
-                    **req_options,
-                }
+                req_options = {"device_memory_GB": 0.3, **req_options}
+                if req_arch == qd.cuda:
+                    req_options = {"cuda_stack_limit": 1024, **req_options}
             else:
                 # Serial tests run without aggressive resource optimization
                 req_options = {"device_memory_GB": 1, **req_options}


### PR DESCRIPTION
Mirror the optimization that the CUDA test path already uses: cap each qd.init() during pytest to a 0.3 GB device-memory pre-allocation for non-serial tests, and 1 GB for `run_in_serial` ones.

Why this matters: under 8-worker pytest-xdist on a single MI300X virtual function, every worker preallocating the default ~1 GB chunk plus the full rand-state buffer (~960 MB) on every test pushes the shared per-VF queue / scratch / kernarg pool past its limit. The runtime then aborts the next AQL packet with
`HSA_STATUS_ERROR_OUT_OF_RESOURCES` mid-stream-sync, surfacing as `hipErrorUnknown` from the trivial 1-thread `runtime_initialize` kernel inside `materialize_runtime`.

Capping `device_memory_GB` to 0.3 GB (same value the CUDA path already uses) leaves enough headroom on the VF for 8 concurrent inits without changing what the test bodies themselves exercise.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
