### PR TITLE
[AMDGPU] Unload hipModule_t in JITModuleAMDGPU destructor

### DIFF
--- a/quadrants/rhi/amdgpu/amdgpu_driver_functions.inc.h
+++ b/quadrants/rhi/amdgpu/amdgpu_driver_functions.inc.h
@@ -43,6 +43,7 @@ PER_AMDGPU_FUNCTION(mem_get_attributes, hipPointerGetAttributes, void *, void *)
 // Module and kernels
 PER_AMDGPU_FUNCTION(module_get_function, hipModuleGetFunction, void **, void *, const char *);
 PER_AMDGPU_FUNCTION(module_load_data, hipModuleLoadData, void **, const void *);
+PER_AMDGPU_FUNCTION(module_unload, hipModuleUnload, void *);
 PER_AMDGPU_FUNCTION(launch_kernel,
                     hipModuleLaunchKernel,
                     void *,

--- a/quadrants/runtime/amdgpu/jit_amdgpu.h
+++ b/quadrants/runtime/amdgpu/jit_amdgpu.h
@@ -51,6 +51,19 @@ class JITModuleAMDGPU : public JITModule {
   explicit JITModuleAMDGPU(void *module) : module_(module) {
   }
 
+  // Without this destructor the underlying `hipModule_t` (loaded by `hipModuleLoadData` in `add_module`) is never
+  // released, so every `qd.init` adds another module's worth of GPU code memory (~80 KB measured per init/reset
+  // cycle with a trivial program; more for programs with many user kernels). The leak is monotonic across
+  // `qd.init`/`qd.reset` cycles within a single process. Mirror `hipModuleLoadData` with `hipModuleUnload` here so
+  // the destructor of the owning `unique_ptr` (held by `JITSession::modules`) plugs the leak end-to-end.
+  ~JITModuleAMDGPU() override {
+    if (module_ != nullptr) {
+      AMDGPUContext::get_instance().make_current();
+      AMDGPUDriver::get_instance().module_unload.call_with_warning(module_);
+      module_ = nullptr;
+    }
+  }
+
   void *lookup_function(const std::string &name) override {
     AMDGPUContext::get_instance().make_current();
     void *func = nullptr;


### PR DESCRIPTION
`JITModuleAMDGPU` wraps a `hipModule_t` produced by `hipModuleLoadData` in `JITSessionAMDGPU::add_module`, but had no destructor, so the underlying module was never released back to the driver. Each `qd.init`/`qd.reset` cycle therefore leaked the runtime support module plus one module per JIT-compiled user kernel -- ~80 KB per cycle for a trivial program, more for programs with several kernels -- accumulating monotonically across cycles within a single process.

Adding `~JITModuleAMDGPU` that calls `hipModuleUnload` (added to the driver function table as `module_unload`) plugs the leak end-to-end: the destructor of the owning `unique_ptr` held in `JITSession::modules` now runs the inverse of `add_module`. Verified with a per-process tracker over 100 init/reset cycles: VRAM growth drops from ~80 KB/iter to 0 across both the empty and field+kernel patterns.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
