### PR TITLE
[Streams] Use events for streams serialization on AMDGPU and CUDA

### DIFF
--- a/quadrants/runtime/amdgpu/kernel_launcher.cpp
+++ b/quadrants/runtime/amdgpu/kernel_launcher.cpp
@@ -151,9 +151,16 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
         i++;
       }
 
-      // Record an event on the default stream so pool streams can wait for the RuntimeContext / arg_buffer uploads
-      // (memcpy_host_to_device_async on `active_stream`) without stalling the CPU.  Pool streams are created with
-      // HIP_STREAM_NON_BLOCKING and do not implicitly synchronize with the default stream.
+      // Run all per-task adstack setup on active_stream before recording the fence event, so that
+      // publish_adstack_metadata's async H2D copies are covered by the event that pool streams wait on.
+      std::vector<int> grid_dims(i - group_start);
+      for (size_t j = group_start; j < i; j++) {
+        grid_dims[j - group_start] = prepare_task(j, offloaded_tasks[j]);
+      }
+
+      // Record an event on the default stream so pool streams can wait for the arg_buffer upload and any per-task
+      // metadata copies (memcpy_host_to_device_async on `active_stream`) without stalling the CPU.  Pool streams are
+      // created with HIP_STREAM_NON_BLOCKING and do not implicitly synchronize with the default stream.
       void *upload_event = nullptr;
       AMDGPUDriver::get_instance().event_create(&upload_event, 0x2 /*hipEventDisableTiming*/);
       AMDGPUDriver::get_instance().event_record(upload_event, active_stream);
@@ -172,10 +179,9 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
         }
         for (size_t j = group_start; j < i; j++) {
           const auto &t = offloaded_tasks[j];
-          int effective_grid_dim = prepare_task(j, t);
           AMDGPUContext::get_instance().set_stream(stream_by_id[t.stream_parallel_group_id]);
-          QD_TRACE("Launching kernel {}<<<{}, {}>>>", t.name, effective_grid_dim, t.block_dim);
-          amdgpu_module->launch(t.name, effective_grid_dim, t.block_dim, t.dynamic_shared_array_bytes,
+          QD_TRACE("Launching kernel {}<<<{}, {}>>>", t.name, grid_dims[j - group_start], t.block_dim);
+          amdgpu_module->launch(t.name, grid_dims[j - group_start], t.block_dim, t.dynamic_shared_array_bytes,
                                 {(void *)&context_pointer}, {arg_size});
         }
 

--- a/quadrants/runtime/amdgpu/kernel_launcher.cpp
+++ b/quadrants/runtime/amdgpu/kernel_launcher.cpp
@@ -179,8 +179,14 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
                                 {(void *)&context_pointer}, {arg_size});
         }
 
+        // Join: record an event on each pool stream and make the default stream wait, so subsequent serial work on
+        // active_stream orders after the parallel group without stalling the CPU.
         for (auto &[sid, s] : stream_by_id) {
-          AMDGPUDriver::get_instance().stream_synchronize(s);
+          void *done = nullptr;
+          AMDGPUDriver::get_instance().event_create(&done, 0x2 /*hipEventDisableTiming*/);
+          AMDGPUDriver::get_instance().event_record(done, s);
+          AMDGPUDriver::get_instance().stream_wait_event(active_stream, done, 0);
+          AMDGPUDriver::get_instance().event_destroy(done);
         }
       } catch (...) {
         for (auto &[sid, s] : stream_by_id) {

--- a/quadrants/runtime/amdgpu/kernel_launcher.cpp
+++ b/quadrants/runtime/amdgpu/kernel_launcher.cpp
@@ -151,10 +151,12 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
         i++;
       }
 
-      // Drain the default stream so the RuntimeContext / arg_buffer uploads (memcpy_host_to_device_async on
-      // `active_stream`) are visible to the pool streams.  Pool streams are created with HIP_STREAM_NON_BLOCKING, so
-      // they do not implicitly synchronize with the default stream.
-      AMDGPUDriver::get_instance().stream_synchronize(active_stream);
+      // Record an event on the default stream so pool streams can wait for the RuntimeContext / arg_buffer uploads
+      // (memcpy_host_to_device_async on `active_stream`) without stalling the CPU.  Pool streams are created with
+      // HIP_STREAM_NON_BLOCKING and do not implicitly synchronize with the default stream.
+      void *upload_event = nullptr;
+      AMDGPUDriver::get_instance().event_create(&upload_event, 0x2 /*hipEventDisableTiming*/);
+      AMDGPUDriver::get_instance().event_record(upload_event, active_stream);
 
       std::map<int, void *> stream_by_id;
       for (size_t j = group_start; j < i; j++) {
@@ -165,6 +167,9 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
       }
 
       try {
+        for (auto &[sid, s] : stream_by_id) {
+          AMDGPUDriver::get_instance().stream_wait_event(s, upload_event, 0);
+        }
         for (size_t j = group_start; j < i; j++) {
           const auto &t = offloaded_tasks[j];
           int effective_grid_dim = prepare_task(j, t);
@@ -181,12 +186,14 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
         for (auto &[sid, s] : stream_by_id) {
           AMDGPUContext::get_instance().release_stream(s);
         }
+        AMDGPUDriver::get_instance().event_destroy(upload_event);
         AMDGPUContext::get_instance().set_stream(active_stream);
         throw;
       }
       for (auto &[sid, s] : stream_by_id) {
         AMDGPUContext::get_instance().release_stream(s);
       }
+      AMDGPUDriver::get_instance().event_destroy(upload_event);
 
       AMDGPUContext::get_instance().set_stream(active_stream);
     }

--- a/quadrants/runtime/amdgpu/kernel_launcher.cpp
+++ b/quadrants/runtime/amdgpu/kernel_launcher.cpp
@@ -151,6 +151,11 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
         i++;
       }
 
+      // Drain the default stream so the RuntimeContext / arg_buffer uploads (memcpy_host_to_device_async on
+      // `active_stream`) are visible to the pool streams.  Pool streams are created with HIP_STREAM_NON_BLOCKING, so
+      // they do not implicitly synchronize with the default stream.
+      AMDGPUDriver::get_instance().stream_synchronize(active_stream);
+
       std::map<int, void *> stream_by_id;
       for (size_t j = group_start; j < i; j++) {
         int sid = offloaded_tasks[j].stream_parallel_group_id;

--- a/quadrants/runtime/cuda/kernel_launcher.cpp
+++ b/quadrants/runtime/cuda/kernel_launcher.cpp
@@ -191,8 +191,15 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
         i++;
       }
 
-      // Record an event on the default stream so pool streams can wait for the arg_buffer upload
-      // (memcpy_host_to_device_async on `active_stream`) without stalling the CPU.  Pool streams are
+      // Run all per-task adstack setup on active_stream before recording the fence event, so that
+      // publish_adstack_metadata's async H2D copies are covered by the event that pool streams wait on.
+      std::vector<int> grid_dims(i - group_start);
+      for (size_t j = group_start; j < i; j++) {
+        grid_dims[j - group_start] = prepare_task(j, offloaded_tasks[j]);
+      }
+
+      // Record an event on the default stream so pool streams can wait for the arg_buffer upload and any per-task
+      // metadata copies (memcpy_host_to_device_async on `active_stream`) without stalling the CPU.  Pool streams are
       // CU_STREAM_NON_BLOCKING and do not implicitly synchronize with the default stream.
       void *upload_event = nullptr;
       CUDADriver::get_instance().event_create(&upload_event, 0x2 /*CU_EVENT_DISABLE_TIMING*/);
@@ -212,10 +219,9 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
         }
         for (size_t j = group_start; j < i; j++) {
           const auto &t = offloaded_tasks[j];
-          int effective_grid_dim = prepare_task(j, t);
           CUDAContext::get_instance().set_stream(stream_by_id[t.stream_parallel_group_id]);
-          QD_TRACE("Launching kernel {}<<<{}, {}>>>", t.name, effective_grid_dim, t.block_dim);
-          cuda_module->launch(t.name, effective_grid_dim, t.block_dim, t.dynamic_shared_array_bytes,
+          QD_TRACE("Launching kernel {}<<<{}, {}>>>", t.name, grid_dims[j - group_start], t.block_dim);
+          cuda_module->launch(t.name, grid_dims[j - group_start], t.block_dim, t.dynamic_shared_array_bytes,
                               {&ctx.get_context()}, {});
         }
 

--- a/quadrants/runtime/cuda/kernel_launcher.cpp
+++ b/quadrants/runtime/cuda/kernel_launcher.cpp
@@ -219,8 +219,14 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
                               {&ctx.get_context()}, {});
         }
 
+        // Join: record an event on each pool stream and make the default stream wait, so subsequent serial work on
+        // active_stream orders after the parallel group without stalling the CPU.
         for (auto &[sid, s] : stream_by_id) {
-          CUDADriver::get_instance().stream_synchronize(s);
+          void *done = nullptr;
+          CUDADriver::get_instance().event_create(&done, 0x2 /*CU_EVENT_DISABLE_TIMING*/);
+          CUDADriver::get_instance().event_record(done, s);
+          CUDADriver::get_instance().stream_wait_event(active_stream, done, 0);
+          CUDADriver::get_instance().event_destroy(done);
         }
       } catch (...) {
         for (auto &[sid, s] : stream_by_id) {

--- a/quadrants/runtime/cuda/kernel_launcher.cpp
+++ b/quadrants/runtime/cuda/kernel_launcher.cpp
@@ -191,6 +191,11 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
         i++;
       }
 
+      // Drain the default stream so the arg_buffer upload (memcpy_host_to_device_async on `active_stream`) is visible
+      // to pool streams before they dereference `ctx.arg_buffer`.  Pool streams are CU_STREAM_NON_BLOCKING and do not
+      // implicitly synchronize with the default stream.
+      CUDADriver::get_instance().stream_synchronize(active_stream);
+
       std::map<int, void *> stream_by_id;
       for (size_t j = group_start; j < i; j++) {
         int sid = offloaded_tasks[j].stream_parallel_group_id;

--- a/quadrants/runtime/cuda/kernel_launcher.cpp
+++ b/quadrants/runtime/cuda/kernel_launcher.cpp
@@ -191,10 +191,12 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
         i++;
       }
 
-      // Drain the default stream so the arg_buffer upload (memcpy_host_to_device_async on `active_stream`) is visible
-      // to pool streams before they dereference `ctx.arg_buffer`.  Pool streams are CU_STREAM_NON_BLOCKING and do not
-      // implicitly synchronize with the default stream.
-      CUDADriver::get_instance().stream_synchronize(active_stream);
+      // Record an event on the default stream so pool streams can wait for the arg_buffer upload
+      // (memcpy_host_to_device_async on `active_stream`) without stalling the CPU.  Pool streams are
+      // CU_STREAM_NON_BLOCKING and do not implicitly synchronize with the default stream.
+      void *upload_event = nullptr;
+      CUDADriver::get_instance().event_create(&upload_event, 0x2 /*CU_EVENT_DISABLE_TIMING*/);
+      CUDADriver::get_instance().event_record(upload_event, active_stream);
 
       std::map<int, void *> stream_by_id;
       for (size_t j = group_start; j < i; j++) {
@@ -205,6 +207,9 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
       }
 
       try {
+        for (auto &[sid, s] : stream_by_id) {
+          CUDADriver::get_instance().stream_wait_event(s, upload_event, 0);
+        }
         for (size_t j = group_start; j < i; j++) {
           const auto &t = offloaded_tasks[j];
           int effective_grid_dim = prepare_task(j, t);
@@ -221,12 +226,14 @@ void KernelLauncher::launch_offloaded_tasks(LaunchContextBuilder &ctx,
         for (auto &[sid, s] : stream_by_id) {
           CUDAContext::get_instance().release_stream(s);
         }
+        CUDADriver::get_instance().event_destroy(upload_event);
         CUDAContext::get_instance().set_stream(active_stream);
         throw;
       }
       for (auto &[sid, s] : stream_by_id) {
         CUDAContext::get_instance().release_stream(s);
       }
+      CUDADriver::get_instance().event_destroy(upload_event);
 
       CUDAContext::get_instance().set_stream(active_stream);
     }


### PR DESCRIPTION
Pool streams are created with HIP_STREAM_NON_BLOCKING / CU_STREAM_NON_BLOCKING and do not implicitly synchronize with the default stream. The RuntimeContext and arg_buffer uploads (memcpy_host_to_device_async) happen on the default stream, so without an explicit sync the pool-stream kernels can read uninitialized device memory — manifesting as a null-pointer page fault on AMDGPU (address 0x0 in dmesg) and a sticky hipErrorIllegalAddress.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
