### PR TITLE
[AMDGPU] Hoist rand-state buffer to process lifetime

### DIFF
--- a/quadrants/runtime/llvm/CMakeLists.txt
+++ b/quadrants/runtime/llvm/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(llvm_runtime)
 target_sources(llvm_runtime
   PRIVATE
     llvm_runtime_executor.cpp
+    persistent_rand_state_buffer.cpp
     adstack_lazy_claim/bound_eval.cpp
     adstack_lazy_claim/metadata_publish.cpp
     adstack_lazy_claim/heap_grow.cpp

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -11,6 +11,7 @@
 
 #include "quadrants/rhi/common/host_memory_pool.h"
 #include "quadrants/runtime/llvm/llvm_offline_cache.h"
+#include "quadrants/runtime/llvm/persistent_rand_state_buffer.h"
 #include "quadrants/rhi/cpu/cpu_device.h"
 #include "quadrants/rhi/cuda/cuda_device.h"
 #include "quadrants/platform/cuda/detect_cuda.h"
@@ -703,20 +704,38 @@ void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler, uint
 
   size_t runtime_objects_prealloc_size = 0;
   void *runtime_objects_prealloc_buffer = nullptr;
+  // Process-lifetime device pointer for the per-thread RandState array on
+  // GPU backends. Hoisted out of the per-init runtime-objects preallocation
+  // to avoid the ~400 MiB per-cycle hipMalloc/hipFree pair, which under
+  // multi-process contention was a major contributor to AMDGPU
+  // HSA_STATUS_ERROR_OUT_OF_RESOURCES. nullptr on CPU (rand-states are still
+  // bumped from `runtime_objects_chunk` there). See
+  // `persistent_rand_state_buffer.h` for the lifetime contract.
+  void *external_rand_states_buffer = nullptr;
   if (config_.arch == Arch::cuda || config_.arch == Arch::amdgpu) {
 #if defined(QD_WITH_CUDA) || defined(QD_WITH_AMDGPU)
     auto [temp_result_alloc, res] = llvm_device()->allocate_memory_unique({sizeof(uint64_t)});
     QD_ERROR_IF(res != RhiResult::success, "Failed to allocate memory for `runtime_get_memory_requirements`");
     void *temp_result_ptr = llvm_device()->get_memory_addr(*temp_result_alloc);
 
-    runtime_jit->call<void *, int32_t, int32_t>("runtime_get_memory_requirements", temp_result_ptr, num_rand_states,
-                                                /*use_preallocated_buffer=*/1);
+    runtime_jit->call<void *, int32_t>("runtime_get_rand_states_buffer_size", temp_result_ptr, num_rand_states);
+    size_t rand_states_buffer_size = size_t(fetch_result<uint64_t>(0, (uint64_t *)temp_result_ptr));
+    if (rand_states_buffer_size > 0) {
+      external_rand_states_buffer =
+          PersistentRandStateBuffer::get_instance().get_or_grow(config_.arch, rand_states_buffer_size);
+    }
+
+    runtime_jit->call<void *, int32_t, int32_t, int32_t>("runtime_get_memory_requirements", temp_result_ptr,
+                                                          num_rand_states,
+                                                          /*use_preallocated_buffer=*/1,
+                                                          /*external_rand_states_buffer=*/1);
     runtime_objects_prealloc_size = size_t(fetch_result<uint64_t>(0, (uint64_t *)temp_result_ptr));
     temp_result_alloc.reset();
     size_t result_buffer_size = sizeof(uint64) * quadrants_result_buffer_entries;
 
-    QD_TRACE("Allocating device memory {:.2f} MB",
-             1.0 * (runtime_objects_prealloc_size + result_buffer_size) / (1UL << 20));
+    QD_TRACE("Allocating device memory {:.2f} MB (rand-states excluded: {:.2f} MB held in PersistentRandStateBuffer)",
+             1.0 * (runtime_objects_prealloc_size + result_buffer_size) / (1UL << 20),
+             1.0 * rand_states_buffer_size / (1UL << 20));
 
     runtime_objects_prealloc_buffer =
         preallocate_memory(iroundup(runtime_objects_prealloc_size + result_buffer_size, quadrants_page_size),
@@ -734,10 +753,10 @@ void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler, uint
   QD_TRACE("Launching runtime_initialize");
 
   auto *host_memory_pool = &HostMemoryPool::get_instance();
-  runtime_jit->call<void *, void *, std::size_t, void *, int, void *, void *, void *>(
+  runtime_jit->call<void *, void *, std::size_t, void *, int, void *, void *, void *, void *>(
       "runtime_initialize", *result_buffer_ptr, host_memory_pool, runtime_objects_prealloc_size,
       runtime_objects_prealloc_buffer, num_rand_states, (void *)&host_allocate_aligned, (void *)std::printf,
-      (void *)std::vsnprintf);
+      (void *)std::vsnprintf, external_rand_states_buffer);
 
   QD_TRACE("LLVMRuntime initialized (excluding `root`)");
   llvm_runtime_ = fetch_result<void *>(quadrants_result_buffer_ret_value_id, *result_buffer_ptr);

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -704,13 +704,10 @@ void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler, uint
 
   size_t runtime_objects_prealloc_size = 0;
   void *runtime_objects_prealloc_buffer = nullptr;
-  // Process-lifetime device pointer for the per-thread RandState array on
-  // GPU backends. Hoisted out of the per-init runtime-objects preallocation
-  // to avoid the ~400 MiB per-cycle hipMalloc/hipFree pair, which under
-  // multi-process contention was a major contributor to AMDGPU
-  // HSA_STATUS_ERROR_OUT_OF_RESOURCES. nullptr on CPU (rand-states are still
-  // bumped from `runtime_objects_chunk` there). See
-  // `persistent_rand_state_buffer.h` for the lifetime contract.
+  // Process-lifetime device pointer for the per-thread RandState array on GPU backends. Hoisted out of the per-init
+  // runtime-objects preallocation to avoid the ~400 MiB per-cycle hipMalloc/hipFree pair, which under multi-process
+  // contention was a major contributor to AMDGPU HSA_STATUS_ERROR_OUT_OF_RESOURCES. nullptr on CPU (rand-states are
+  // still bumped from `runtime_objects_chunk` there). See `persistent_rand_state_buffer.h` for the lifetime contract.
   void *external_rand_states_buffer = nullptr;
   if (config_.arch == Arch::cuda || config_.arch == Arch::amdgpu) {
 #if defined(QD_WITH_CUDA) || defined(QD_WITH_AMDGPU)
@@ -726,9 +723,9 @@ void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler, uint
     }
 
     runtime_jit->call<void *, int32_t, int32_t, int32_t>("runtime_get_memory_requirements", temp_result_ptr,
-                                                          num_rand_states,
-                                                          /*use_preallocated_buffer=*/1,
-                                                          /*external_rand_states_buffer=*/1);
+                                                         num_rand_states,
+                                                         /*use_preallocated_buffer=*/1,
+                                                         /*external_rand_states_buffer=*/1);
     runtime_objects_prealloc_size = size_t(fetch_result<uint64_t>(0, (uint64_t *)temp_result_ptr));
     temp_result_alloc.reset();
     size_t result_buffer_size = sizeof(uint64) * quadrants_result_buffer_entries;

--- a/quadrants/runtime/llvm/persistent_rand_state_buffer.cpp
+++ b/quadrants/runtime/llvm/persistent_rand_state_buffer.cpp
@@ -13,9 +13,8 @@
 namespace quadrants::lang {
 
 PersistentRandStateBuffer &PersistentRandStateBuffer::get_instance() {
-  // Heap-allocated and intentionally leaked: the singleton owns a raw HIP/CUDA
-  // driver allocation, and freeing it at static-destructor time would race
-  // the driver context's own teardown. Same pattern used by the AMDGPU
+  // Heap-allocated and intentionally leaked: the singleton owns a raw HIP/CUDA driver allocation, and freeing it at
+  // static-destructor time would race the driver context's own teardown. Same pattern used by the AMDGPU
   // persistent-runtime-JIT cache.
   static auto *instance = new PersistentRandStateBuffer();
   return *instance;
@@ -33,8 +32,8 @@ void *PersistentRandStateBuffer::get_or_grow(Arch arch, std::size_t bytes_requir
     return buffer_;
   }
 
-  // Free the prior (smaller) allocation before growing. This is the only
-  // free path; on process exit the singleton is leaked deliberately.
+  // Free the prior (smaller) allocation before growing. This is the only free path; on process exit the singleton is
+  // leaked deliberately.
   if (buffer_ != nullptr) {
     if (arch == Arch::cuda) {
 #if defined(QD_WITH_CUDA)

--- a/quadrants/runtime/llvm/persistent_rand_state_buffer.cpp
+++ b/quadrants/runtime/llvm/persistent_rand_state_buffer.cpp
@@ -1,0 +1,79 @@
+#include "quadrants/runtime/llvm/persistent_rand_state_buffer.h"
+
+#include "quadrants/util/lang_util.h"
+
+#if defined(QD_WITH_CUDA)
+#include "quadrants/rhi/cuda/cuda_driver.h"
+#endif
+
+#if defined(QD_WITH_AMDGPU)
+#include "quadrants/rhi/amdgpu/amdgpu_driver.h"
+#endif
+
+namespace quadrants::lang {
+
+PersistentRandStateBuffer &PersistentRandStateBuffer::get_instance() {
+  // Heap-allocated and intentionally leaked: the singleton owns a raw HIP/CUDA
+  // driver allocation, and freeing it at static-destructor time would race
+  // the driver context's own teardown. Same pattern used by the AMDGPU
+  // persistent-runtime-JIT cache.
+  static auto *instance = new PersistentRandStateBuffer();
+  return *instance;
+}
+
+void *PersistentRandStateBuffer::get_or_grow(Arch arch, std::size_t bytes_required) {
+  std::lock_guard<std::mutex> guard(mu_);
+
+  if (buffer_ != nullptr && arch_ != arch) {
+    QD_ERROR("PersistentRandStateBuffer was initialised for arch={} but is now requested for arch={}", arch_name(arch_),
+             arch_name(arch));
+  }
+
+  if (buffer_ != nullptr && size_ >= bytes_required) {
+    return buffer_;
+  }
+
+  // Free the prior (smaller) allocation before growing. This is the only
+  // free path; on process exit the singleton is leaked deliberately.
+  if (buffer_ != nullptr) {
+    if (arch == Arch::cuda) {
+#if defined(QD_WITH_CUDA)
+      CUDADriver::get_instance().mem_free(buffer_);
+#endif
+    } else if (arch == Arch::amdgpu) {
+#if defined(QD_WITH_AMDGPU)
+      AMDGPUDriver::get_instance().mem_free(buffer_);
+#endif
+    }
+    buffer_ = nullptr;
+    size_ = 0;
+  }
+
+  void *ptr = nullptr;
+  if (arch == Arch::cuda) {
+#if defined(QD_WITH_CUDA)
+    CUDADriver::get_instance().malloc(&ptr, bytes_required);
+#else
+    QD_NOT_IMPLEMENTED;
+#endif
+  } else if (arch == Arch::amdgpu) {
+#if defined(QD_WITH_AMDGPU)
+    AMDGPUDriver::get_instance().malloc(&ptr, bytes_required);
+#else
+    QD_NOT_IMPLEMENTED;
+#endif
+  } else {
+    QD_ERROR("PersistentRandStateBuffer is only valid for CUDA / AMDGPU");
+  }
+
+  if (ptr == nullptr) {
+    QD_ERROR("PersistentRandStateBuffer allocation of {} B failed", bytes_required);
+  }
+
+  buffer_ = ptr;
+  size_ = bytes_required;
+  arch_ = arch;
+  return buffer_;
+}
+
+}  // namespace quadrants::lang

--- a/quadrants/runtime/llvm/persistent_rand_state_buffer.h
+++ b/quadrants/runtime/llvm/persistent_rand_state_buffer.h
@@ -1,0 +1,57 @@
+// Process-lifetime device-memory buffer for the LLVM runtime's per-thread
+// random-state array.
+//
+// Background: prior to this, every `qd.init()` -> `materialize_runtime`
+// preallocated `sizeof(RandState) * saturating_grid_dim * max_block_dim` bytes
+// of device memory (~480 MiB at default config) as part of the runtime-objects
+// preallocation, and freed it on `qd.reset()`. Under multi-process
+// pytest-xdist contention this realloc churn was a major contributor to
+// `HSA_STATUS_ERROR_OUT_OF_RESOURCES` on AMDGPU. Bisection on the C++ omnibus
+// reproducer (see `experiments/launch_oor_repro/`) showed that removing the
+// per-cycle ~400 MiB realloc was sufficient to push the failure threshold
+// past the workload that real `pytest -n 8` exercises. RandState contents
+// depend only on `(num_states, starting_seed)`, both of which are typically
+// stable across `qd.init`/`qd.reset` cycles in a worker, so reusing the
+// buffer changes no observable behavior.
+//
+// This module owns one device allocation per process. It grows monotonically
+// (never shrinks, never frees on its own) and is intentionally leaked on
+// process exit, the same shape used by the AMDGPU persistent-runtime-JIT
+// cache: freeing driver memory at static-destructor time would race the GPU
+// driver context's own teardown.
+
+#pragma once
+
+#include <cstddef>
+#include <mutex>
+
+#include "quadrants/rhi/arch.h"
+
+namespace quadrants::lang {
+
+class PersistentRandStateBuffer {
+ public:
+  static PersistentRandStateBuffer &get_instance();
+
+  // Returns a device pointer with at least `bytes_required` bytes available.
+  // Grows monotonically: subsequent calls with a smaller `bytes_required`
+  // return the same (larger) buffer. Allocation goes directly through the
+  // CUDA / AMDGPU driver (`cuMemAlloc` / `hipMalloc`), bypassing
+  // `LlvmDevice` and `DeviceMemoryPool` so the lifetime is independent of
+  // any `LlvmRuntimeExecutor`.
+  //
+  // Thread-safe.
+  void *get_or_grow(Arch arch, std::size_t bytes_required);
+
+ private:
+  PersistentRandStateBuffer() = default;
+  PersistentRandStateBuffer(const PersistentRandStateBuffer &) = delete;
+  PersistentRandStateBuffer &operator=(const PersistentRandStateBuffer &) = delete;
+
+  std::mutex mu_;
+  void *buffer_{nullptr};
+  std::size_t size_{0};
+  Arch arch_{Arch::x64};
+};
+
+}  // namespace quadrants::lang

--- a/quadrants/runtime/llvm/persistent_rand_state_buffer.h
+++ b/quadrants/runtime/llvm/persistent_rand_state_buffer.h
@@ -1,24 +1,17 @@
-// Process-lifetime device-memory buffer for the LLVM runtime's per-thread
-// random-state array.
+// Process-lifetime device-memory buffer for the LLVM runtime's per-thread random-state array.
 //
-// Background: prior to this, every `qd.init()` -> `materialize_runtime`
-// preallocated `sizeof(RandState) * saturating_grid_dim * max_block_dim` bytes
-// of device memory (~480 MiB at default config) as part of the runtime-objects
-// preallocation, and freed it on `qd.reset()`. Under multi-process
-// pytest-xdist contention this realloc churn was a major contributor to
-// `HSA_STATUS_ERROR_OUT_OF_RESOURCES` on AMDGPU. Bisection on the C++ omnibus
-// reproducer (see `experiments/launch_oor_repro/`) showed that removing the
-// per-cycle ~400 MiB realloc was sufficient to push the failure threshold
-// past the workload that real `pytest -n 8` exercises. RandState contents
-// depend only on `(num_states, starting_seed)`, both of which are typically
-// stable across `qd.init`/`qd.reset` cycles in a worker, so reusing the
-// buffer changes no observable behavior.
+// Background: prior to this, every `qd.init()` -> `materialize_runtime` preallocated `sizeof(RandState) *
+// saturating_grid_dim * max_block_dim` bytes of device memory (~480 MiB at default config) as part of the
+// runtime-objects preallocation, and freed it on `qd.reset()`. Under multi-process pytest-xdist contention this
+// realloc churn was a major contributor to `HSA_STATUS_ERROR_OUT_OF_RESOURCES` on AMDGPU. Bisection on the C++ omnibus
+// reproducer (see `experiments/launch_oor_repro/`) showed that removing the per-cycle ~400 MiB realloc was sufficient
+// to push the failure threshold past the workload that real `pytest -n 8` exercises. RandState contents depend only
+// on `(num_states, starting_seed)`, both of which are typically stable across `qd.init`/`qd.reset` cycles in a worker,
+// so reusing the buffer changes no observable behavior.
 //
-// This module owns one device allocation per process. It grows monotonically
-// (never shrinks, never frees on its own) and is intentionally leaked on
-// process exit, the same shape used by the AMDGPU persistent-runtime-JIT
-// cache: freeing driver memory at static-destructor time would race the GPU
-// driver context's own teardown.
+// This module owns one device allocation per process. It grows monotonically (never shrinks, never frees on its own)
+// and is intentionally leaked on process exit, the same shape used by the AMDGPU persistent-runtime-JIT cache: freeing
+// driver memory at static-destructor time would race the GPU driver context's own teardown.
 
 #pragma once
 
@@ -33,12 +26,10 @@ class PersistentRandStateBuffer {
  public:
   static PersistentRandStateBuffer &get_instance();
 
-  // Returns a device pointer with at least `bytes_required` bytes available.
-  // Grows monotonically: subsequent calls with a smaller `bytes_required`
-  // return the same (larger) buffer. Allocation goes directly through the
-  // CUDA / AMDGPU driver (`cuMemAlloc` / `hipMalloc`), bypassing
-  // `LlvmDevice` and `DeviceMemoryPool` so the lifetime is independent of
-  // any `LlvmRuntimeExecutor`.
+  // Returns a device pointer with at least `bytes_required` bytes available. Grows monotonically: subsequent calls
+  // with a smaller `bytes_required` return the same (larger) buffer. Allocation goes directly through the CUDA /
+  // AMDGPU driver (`cuMemAlloc` / `hipMalloc`), bypassing `LlvmDevice` and `DeviceMemoryPool` so the lifetime is
+  // independent of any `LlvmRuntimeExecutor`.
   //
   // Thread-safe.
   void *get_or_grow(Arch arch, std::size_t bytes_required);

--- a/quadrants/runtime/llvm/runtime_module/runtime.cpp
+++ b/quadrants/runtime/llvm/runtime_module/runtime.cpp
@@ -750,11 +750,10 @@ void runtime_memory_allocate_aligned(LLVMRuntime *runtime, std::size_t size, std
 // [ON HOST] CPU backend
 // [ON DEVICE] CUDA/AMDGPU backend
 //
-// `external_rand_states_buffer` is set to non-zero by the GPU host launcher
-// when the rand-states buffer is provided by `PersistentRandStateBuffer`
-// (process-lifetime, host-side singleton) rather than carved out of the
-// per-init runtime-objects preallocation. The CPU path still leaves it 0
-// (rand-states are bumped from `runtime_objects_chunk` in `runtime_initialize`).
+// `external_rand_states_buffer` is set to non-zero by the GPU host launcher when the rand-states buffer is provided
+// by `PersistentRandStateBuffer` (process-lifetime, host-side singleton) rather than carved out of the per-init
+// runtime-objects preallocation. The CPU path still leaves it 0 (rand-states are bumped from `runtime_objects_chunk`
+// in `runtime_initialize`).
 void runtime_get_memory_requirements(Ptr result_buffer,
                                      i32 num_rand_states,
                                      i32 use_preallocated_buffer,
@@ -777,9 +776,8 @@ void runtime_get_memory_requirements(Ptr result_buffer,
 // [ON HOST] CPU backend
 // [ON DEVICE] CUDA/AMDGPU backend
 //
-// Returns the byte size the rand-states buffer would consume if allocated
-// in-line in `runtime_objects_chunk`. The host calls this to size the
-// process-lifetime allocation owned by `PersistentRandStateBuffer`.
+// Returns the byte size the rand-states buffer would consume if allocated in-line in `runtime_objects_chunk`. The
+// host calls this to size the process-lifetime allocation owned by `PersistentRandStateBuffer`.
 void runtime_get_rand_states_buffer_size(Ptr result_buffer, i32 num_rand_states) {
   i64 size = quadrants::iroundup(i64(sizeof(RandState)) * num_rand_states, quadrants_page_size);
   reinterpret_cast<i64 *>(result_buffer)[0] = size;
@@ -788,11 +786,11 @@ void runtime_get_rand_states_buffer_size(Ptr result_buffer, i32 num_rand_states)
 // External API
 // [ON HOST] CPU backend
 // [ON DEVICE] CUDA/AMDGPU backend
-// `external_rand_states_buffer` is non-null when the host has provided a
-// process-lifetime rand-states allocation (via `PersistentRandStateBuffer`).
-// In that case `runtime->rand_states` is bound to that pointer and no
-// rand-states bytes are bumped out of `runtime_objects_chunk`. The CPU
-// path passes nullptr and falls through to the in-chunk allocation.
+//
+// `external_rand_states_buffer` is non-null when the host has provided a process-lifetime rand-states allocation (via
+// `PersistentRandStateBuffer`). In that case `runtime->rand_states` is bound to that pointer and no rand-states bytes
+// are bumped out of `runtime_objects_chunk`. The CPU path passes nullptr and falls through to the in-chunk
+// allocation.
 void runtime_initialize(Ptr result_buffer,
                         Ptr memory_pool,
                         std::size_t preallocated_size,  // Non-zero means use the preallocated buffer

--- a/quadrants/runtime/llvm/runtime_module/runtime.cpp
+++ b/quadrants/runtime/llvm/runtime_module/runtime.cpp
@@ -749,7 +749,16 @@ void runtime_memory_allocate_aligned(LLVMRuntime *runtime, std::size_t size, std
 // External API
 // [ON HOST] CPU backend
 // [ON DEVICE] CUDA/AMDGPU backend
-void runtime_get_memory_requirements(Ptr result_buffer, i32 num_rand_states, i32 use_preallocated_buffer) {
+//
+// `external_rand_states_buffer` is set to non-zero by the GPU host launcher
+// when the rand-states buffer is provided by `PersistentRandStateBuffer`
+// (process-lifetime, host-side singleton) rather than carved out of the
+// per-init runtime-objects preallocation. The CPU path still leaves it 0
+// (rand-states are bumped from `runtime_objects_chunk` in `runtime_initialize`).
+void runtime_get_memory_requirements(Ptr result_buffer,
+                                     i32 num_rand_states,
+                                     i32 use_preallocated_buffer,
+                                     i32 external_rand_states_buffer) {
   i64 size = 0;
 
   if (use_preallocated_buffer) {
@@ -757,7 +766,9 @@ void runtime_get_memory_requirements(Ptr result_buffer, i32 num_rand_states, i32
   }
 
   size += quadrants::iroundup(i64(quadrants_global_tmp_buffer_size), quadrants_page_size);
-  size += quadrants::iroundup(i64(sizeof(RandState)) * num_rand_states, quadrants_page_size);
+  if (!external_rand_states_buffer) {
+    size += quadrants::iroundup(i64(sizeof(RandState)) * num_rand_states, quadrants_page_size);
+  }
 
   reinterpret_cast<i64 *>(result_buffer)[0] = size;
 }
@@ -765,6 +776,23 @@ void runtime_get_memory_requirements(Ptr result_buffer, i32 num_rand_states, i32
 // External API
 // [ON HOST] CPU backend
 // [ON DEVICE] CUDA/AMDGPU backend
+//
+// Returns the byte size the rand-states buffer would consume if allocated
+// in-line in `runtime_objects_chunk`. The host calls this to size the
+// process-lifetime allocation owned by `PersistentRandStateBuffer`.
+void runtime_get_rand_states_buffer_size(Ptr result_buffer, i32 num_rand_states) {
+  i64 size = quadrants::iroundup(i64(sizeof(RandState)) * num_rand_states, quadrants_page_size);
+  reinterpret_cast<i64 *>(result_buffer)[0] = size;
+}
+
+// External API
+// [ON HOST] CPU backend
+// [ON DEVICE] CUDA/AMDGPU backend
+// `external_rand_states_buffer` is non-null when the host has provided a
+// process-lifetime rand-states allocation (via `PersistentRandStateBuffer`).
+// In that case `runtime->rand_states` is bound to that pointer and no
+// rand-states bytes are bumped out of `runtime_objects_chunk`. The CPU
+// path passes nullptr and falls through to the in-chunk allocation.
 void runtime_initialize(Ptr result_buffer,
                         Ptr memory_pool,
                         std::size_t preallocated_size,  // Non-zero means use the preallocated buffer
@@ -772,7 +800,8 @@ void runtime_initialize(Ptr result_buffer,
                         i32 num_rand_states,
                         void *_host_allocator,
                         void *_host_printf,
-                        void *_host_vsnprintf) {
+                        void *_host_vsnprintf,
+                        Ptr external_rand_states_buffer) {
   // bootstrap
   auto host_allocator = (host_allocator_type)_host_allocator;
   auto host_printf = (host_printf_type)_host_printf;
@@ -808,8 +837,12 @@ void runtime_initialize(Ptr result_buffer,
                                                         quadrants_global_tmp_buffer_size, quadrants_page_size);
 
   runtime->num_rand_states = num_rand_states;
-  runtime->rand_states = (RandState *)runtime->allocate_aligned(
-      runtime->runtime_objects_chunk, sizeof(RandState) * runtime->num_rand_states, quadrants_page_size);
+  if (external_rand_states_buffer != nullptr) {
+    runtime->rand_states = (RandState *)external_rand_states_buffer;
+  } else {
+    runtime->rand_states = (RandState *)runtime->allocate_aligned(
+        runtime->runtime_objects_chunk, sizeof(RandState) * runtime->num_rand_states, quadrants_page_size);
+  }
 }
 
 void runtime_initialize_memory(LLVMRuntime *runtime, std::size_t preallocated_size, Ptr preallocated_buffer) {


### PR DESCRIPTION
Per `qd.init()` materialize_runtime allocates ~480 MiB of device memory for the per-thread RandState array (sizeof(RandState) * saturating_grid_dim * max_block_dim, ~19456 * 1024 * 24 B at default config), and frees it on `qd.reset()`. Under multi-process pytest-xdist contention this per-cycle hipMalloc/hipFree pair is a major contributor to AMDGPU `HSA_STATUS_ERROR_OUT_OF_RESOURCES` failures (see perso_hugh/doc/amdgpu_test_suite_oom_followup.md). RandState contents only depend on (num_states, starting_seed); both are stable across init/reset cycles for a given worker, so reusing the buffer changes no observable behavior.

This change introduces `PersistentRandStateBuffer`, a process-lifetime singleton that owns one device allocation (via `cuMemAlloc` / `hipMalloc` directly, bypassing `LlvmDevice` / `DeviceMemoryPool` so its lifetime is independent of any `LlvmRuntimeExecutor`). The buffer grows monotonically; it is intentionally leaked at process exit (matching the AMDGPU persistent-runtime-JIT cache pattern), since freeing driver memory at static-destructor time would race the GPU driver context's own teardown.

`runtime_initialize` and `runtime_get_memory_requirements` each gain one trailing parameter so the host launcher can pass the process-lifetime buffer pointer / signal that the rand-states bytes should not be carved out of `runtime_objects_chunk`. CPU path is byte-identical (passes nullptr / 0). A new
`runtime_get_rand_states_buffer_size` helper returns the page-aligned byte size to size the persistent allocation host-side.

Bisection on the C++ omnibus reproducer
(`experiments/launch_oor_repro/omnibus_repro.cpp`) showed that removing the per-cycle ~400 MiB realloc was sufficient to push the failure threshold past the workload that real `pytest -n 8` exercises.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
