### PR TITLE
[Perf] Adstack max-reducer: launch cache + zero-copy result map; content-stable registry_id

### DIFF
--- a/quadrants/codegen/llvm/codegen_llvm.cpp
+++ b/quadrants/codegen/llvm/codegen_llvm.cpp
@@ -1943,18 +1943,14 @@ std::string TaskCodeGenLLVM::init_offloaded_task_function(OffloadedStmt *stmt, s
 
   current_task = std::make_unique<OffloadedTask>(task_kernel_name);
   // Pre-register the per-task AdStackSizingInfo so the registry id is assigned BEFORE codegen visits any
-  // `AdStackPushStmt`. Metadata (allocated_max_sizes) is filled in at `finalize_offloaded_task_function`
-  // time after the alloca scan completes; the registry call is idempotent on the same `ad_stack_ptr` so
-  // the second call updates the entry in place. Skipping registration when `prog == nullptr` (C++-only
-  // tests) leaves `registry_id == 0`, which the codegen-emitted cmpxchg short-circuits.
+  // `AdStackPushStmt`, letting it bake the immediate. Metadata (`allocated_max_sizes` + `size_exprs`) is filled in at
+  // `finalize_offloaded_task_function` time after the alloca scan completes; the registry call is idempotent on the
+  // same identity_key (raw `&current_task->ad_stack` address, never derefed) so the second call updates the entry in
+  // place. `kernel_name` and `task_id_in_kernel` are also stashed on the ad_stack so the offline-cache reload path
+  // (`AdStackCache::ensure_runtime_registry_ids_for_max_reducer`) can re-derive the identity hash without parsing the
+  // task function name. Skipping registration when `prog == nullptr` (C++-only tests) leaves `registry_id == 0`, which
+  // the codegen-emitted cmpxchg short-circuits.
   if (prog != nullptr) {
-    // Reserve a registry id at task START so codegen can bake the immediate before any push site is
-    // visited. Metadata + size_exprs are filled in at `finalize_offloaded_task_function` time below
-    // (idempotent re-registration on the same identity_key updates the entry in place). Identity
-    // key here is the raw `&current_task->ad_stack` address; the registry never derefs it.
-    // `kernel_name` and `task_id_in_kernel` are also stashed on the ad_stack so the offline-cache reload path
-    // (`AdStackCache::ensure_runtime_registry_ids_for_max_reducer`) can re-derive the identity hash without
-    // parsing the task function name.
     current_task->ad_stack.kernel_name = kernel_name;
     current_task->ad_stack.task_id_in_kernel = task_codegen_id;
     uint32_t id = prog->adstack_cache().register_adstack_sizing_info(
@@ -2059,11 +2055,11 @@ void TaskCodeGenLLVM::finalize_offloaded_task_function() {
       for (const auto &a : current_task->ad_stack.allocas) {
         allocated_max_sizes.push_back(static_cast<int>(a.max_size_compile_time));
       }
-      // Update the entry with the live metadata + per-alloca size_exprs. The size_exprs are copied
-      // into the registry so the diagnose path can walk them without dereferencing the launcher's
-      // unstable `OffloadedTask::ad_stack` pointer (freed by `current_task = nullptr` after
-      // by-value `offloaded_tasks.push_back(*current_task)`). Mirror the identity-pair fields here too
-      // in case the task START registration above was skipped (no allocas at the time, prog null, etc.).
+      // Update the entry with the live metadata + per-alloca size_exprs. The size_exprs are copied into the registry so
+      // the diagnose path can walk them without dereferencing the launcher's unstable `OffloadedTask::ad_stack` pointer
+      // (freed by `current_task = nullptr` after by-value `offloaded_tasks.push_back(*current_task)`). Mirror the
+      // identity-pair fields here too in case the task START registration above was skipped (no allocas at the time,
+      // prog null, etc.).
       current_task->ad_stack.kernel_name = kernel_name;
       current_task->ad_stack.task_id_in_kernel = task_codegen_id;
       uint32_t id = prog->adstack_cache().register_adstack_sizing_info(

--- a/quadrants/codegen/llvm/codegen_llvm.cpp
+++ b/quadrants/codegen/llvm/codegen_llvm.cpp
@@ -1952,6 +1952,11 @@ std::string TaskCodeGenLLVM::init_offloaded_task_function(OffloadedStmt *stmt, s
     // visited. Metadata + size_exprs are filled in at `finalize_offloaded_task_function` time below
     // (idempotent re-registration on the same identity_key updates the entry in place). Identity
     // key here is the raw `&current_task->ad_stack` address; the registry never derefs it.
+    // `kernel_name` and `task_id_in_kernel` are also stashed on the ad_stack so the offline-cache reload path
+    // (`AdStackCache::ensure_runtime_registry_ids_for_max_reducer`) can re-derive the identity hash without
+    // parsing the task function name.
+    current_task->ad_stack.kernel_name = kernel_name;
+    current_task->ad_stack.task_id_in_kernel = task_codegen_id;
     uint32_t id = prog->adstack_cache().register_adstack_sizing_info(
         static_cast<const void *>(&current_task->ad_stack), kernel_name, task_codegen_id, /*allocated_max_sizes=*/{},
         /*size_exprs=*/{});
@@ -2057,7 +2062,10 @@ void TaskCodeGenLLVM::finalize_offloaded_task_function() {
       // Update the entry with the live metadata + per-alloca size_exprs. The size_exprs are copied
       // into the registry so the diagnose path can walk them without dereferencing the launcher's
       // unstable `OffloadedTask::ad_stack` pointer (freed by `current_task = nullptr` after
-      // by-value `offloaded_tasks.push_back(*current_task)`).
+      // by-value `offloaded_tasks.push_back(*current_task)`). Mirror the identity-pair fields here too
+      // in case the task START registration above was skipped (no allocas at the time, prog null, etc.).
+      current_task->ad_stack.kernel_name = kernel_name;
+      current_task->ad_stack.task_id_in_kernel = task_codegen_id;
       uint32_t id = prog->adstack_cache().register_adstack_sizing_info(
           static_cast<const void *>(&current_task->ad_stack), kernel_name, task_codegen_id,
           std::move(allocated_max_sizes), current_task->ad_stack.size_exprs);

--- a/quadrants/codegen/llvm/llvm_compiled_data.h
+++ b/quadrants/codegen/llvm/llvm_compiled_data.h
@@ -73,14 +73,21 @@ struct AdStackSizingInfo {
   // the actual gate-passing thread count; `nullopt` falls through to dispatched-threads worst-case sizing (no behavior
   // change versus a kernel without this metadata).
   std::optional<StaticAdStackBoundExpr> bound_expr;
-  // Identity in `Program::adstack_sizing_info_registry_`. Assigned at `finalize_offloaded_task_function`
-  // time after the registry idempotently maps `&this` to a u32 id. Baked as an immediate into the
-  // codegen-emitted lazy-claim `cmpxchg(0, registry_id)` so the host raise site can name the offending
-  // kernel + task in its diagnostic message. `0` means "not registered" - the lazy-claim emit short-
-  // circuits the cmpxchg in that case (no information to record). NOT serialised to the offline cache:
-  // ids are assigned per `Program` lifetime, not per-kernel-content; a deserialised task re-registers
-  // itself at the next launch.
+  // Identity in `AdStackCache::adstack_sizing_info_registry_`. Assigned by `register_adstack_sizing_info` as
+  // `fnv1a32(kernel_name + ":" + task_id_in_kernel)` - a content-stable hash of the unique identity pair below, so the
+  // same (kernel_name, task_id_in_kernel) yields the same id across re-compiles, across `Program` lifetimes, and across
+  // offline-cache reloads. Baked as an immediate into the codegen-emitted lazy-claim `cmpxchg(0, registry_id)` so the
+  // host raise site can name the offending kernel + task in its diagnostic message. `0` is reserved for "not
+  // registered" - the codegen short-circuits the cmpxchg in that case. Serialised to the offline cache: a deserialised
+  // task carries the same id the codegen produced, matching the immediate baked into its LLVM IR; the runtime
+  // re-populates the per-`Program` registry on the first launch via
+  // `AdStackCache::ensure_runtime_registry_ids_for_max_reducer`.
   uint32_t registry_id{0};
+  // Inputs to the content hash above. Persisted on the per-task adstack metadata (rather than parsed from
+  // `OffloadedTask::name`) so the runtime registration call can re-derive the registry entry's diagnostic labels
+  // without depending on the function-name format.
+  std::string kernel_name;
+  int32_t task_id_in_kernel{0};
   // Per-task list of `MaxOverRange` nodes the runtime reduces in parallel via a dedicated max-reducer dispatch (see the
   // max-reducer recognizer). Empty when no captured `size_expr` contains a recognized shape. Each entry references one
   // alloca's `size_expr` by `(stack_id, mor_node_idx)`; the runtime substitutes the dispatched value as a `Const` into
@@ -98,6 +105,9 @@ struct AdStackSizingInfo {
             allocas,
             size_exprs,
             bound_expr,
+            registry_id,
+            kernel_name,
+            task_id_in_kernel,
             max_reducer_specs);
 };
 

--- a/quadrants/program/adstack/cache.cpp
+++ b/quadrants/program/adstack/cache.cpp
@@ -387,17 +387,43 @@ bool AdStackCache::try_llvm_per_task_ad_stack_cache_hit(const void *attribs_key,
   return true;
 }
 
+namespace {
+// FNV-1a 64-bit, folded to 32-bit; never returns 0 (reserved sentinel). Used to derive a content-stable
+// `registry_id` from the (kernel_name, task_id_in_kernel) pair. We need a deterministic hash because the id is baked as
+// an immediate into LLVM IR / SPIR-V at codegen time and read back by the host on overflow: `std::hash<std::string>`
+// is implementation-defined and not stable across stdlib versions, so we cannot rely on it producing the same id at
+// codegen time and at offline-cache-reload-driven runtime registration.
+inline uint32_t fnv1a32_for_registry(const std::string &kernel_name, int task_id_in_kernel) {
+  constexpr uint64_t kFnvOffsetBasis = 0xcbf29ce484222325ULL;
+  constexpr uint64_t kFnvPrime = 0x100000001b3ULL;
+  uint64_t h = kFnvOffsetBasis;
+  for (unsigned char c : kernel_name) {
+    h ^= c;
+    h *= kFnvPrime;
+  }
+  // Domain separator so `(name + str(N))` and `(name_with_extra_chars)` cannot accidentally collide.
+  h ^= ':';
+  h *= kFnvPrime;
+  uint64_t t = static_cast<uint64_t>(static_cast<uint32_t>(task_id_in_kernel));
+  for (int i = 0; i < 8; ++i) {
+    h ^= (t >> (i * 8)) & 0xFFu;
+    h *= kFnvPrime;
+  }
+  uint32_t r = static_cast<uint32_t>(h ^ (h >> 32));
+  return r == 0 ? 1u : r;
+}
+}  // namespace
+
 uint32_t AdStackCache::register_adstack_sizing_info(const void *identity_key,
                                                     const std::string &kernel_name,
                                                     int task_id_in_kernel,
                                                     std::vector<int> allocated_max_sizes,
                                                     std::vector<SerializedSizeExpr> size_exprs) {
   std::lock_guard<std::mutex> lk(adstack_sizing_info_registry_mutex_);
-  // Idempotent re-registration: same `identity_key` yields the same id across re-compiles and updates the
-  // entry's metadata + size_exprs in place. The key is just an opaque dedup token - the registry never
-  // dereferences it; all data needed by the diagnose path is copied into the entry below.
-  auto it = adstack_sizing_info_id_by_ptr_.find(identity_key);
-  if (it != adstack_sizing_info_id_by_ptr_.end()) {
+  // Idempotent re-registration: same `identity_key` yields the same id across re-compiles and updates the entry's
+  // metadata + size_exprs in place. The key is just an opaque dedup token - the registry never dereferences it; all
+  // data needed by the diagnose path is copied into the entry below.
+  if (auto it = adstack_sizing_info_id_by_ptr_.find(identity_key); it != adstack_sizing_info_id_by_ptr_.end()) {
     auto &entry = adstack_sizing_info_registry_[it->second];
     entry.kernel_name = kernel_name;
     entry.task_id_in_kernel = task_id_in_kernel;
@@ -405,32 +431,116 @@ uint32_t AdStackCache::register_adstack_sizing_info(const void *identity_key,
     entry.size_exprs = std::move(size_exprs);
     return it->second;
   }
-  uint32_t id = static_cast<uint32_t>(adstack_sizing_info_registry_.size());
+  // Content-stable hash. Same (kernel_name, task_id_in_kernel) yields the same id across `Program` lifetimes,
+  // re-compiles, and offline-cache reloads. The codegen-emitted overflow `cmpxchg(0, registry_id)` writes this same
+  // value, so the host lookup of the cmpxchg slot resolves the offending kernel + task without a pre-launch `register`
+  // call from the runtime.
+  uint32_t id = fnv1a32_for_registry(kernel_name, task_id_in_kernel);
+  // Linear-probe past hash collisions (different `(kernel_name, task_id_in_kernel)` pairs that hash to the same id).
+  // Vanishingly rare with a 32-bit FNV-1a (~1.2e-4 collision probability for 1000 distinct keys via birthday bound).
+  // Same-content / different-identity_key (re-codegen of the same source after a `qd.reset()` produces a fresh
+  // `ad_stack` at a new address but the hash inputs are unchanged) MUST keep the existing id; otherwise the codegen-
+  // baked immediate in the cached LLVM IR points at one entry while the runtime registration mints another, defeating
+  // the content-stable contract. Detect that case by comparing `(kernel_name, task_id_in_kernel)` against the slot's
+  // already-stored values; the `identity_key`-equal case cannot land here because the early-out above already returned
+  // for any already-registered key. Skip id 0 (reserved sentinel).
+  while (true) {
+    auto reg_it = adstack_sizing_info_registry_.find(id);
+    if (reg_it == adstack_sizing_info_registry_.end()) {
+      break;
+    }
+    if (reg_it->second.kernel_name == kernel_name && reg_it->second.task_id_in_kernel == task_id_in_kernel) {
+      // Same content (same hash inputs), different `identity_key`. Update in place and add the new identity_key to
+      // the reverse lookup so the new pointer resolves to this same id; the previous identity_key's entry stays valid
+      // and continues to resolve here too.
+      reg_it->second.allocated_max_sizes = std::move(allocated_max_sizes);
+      reg_it->second.size_exprs = std::move(size_exprs);
+      adstack_sizing_info_id_by_ptr_.emplace(identity_key, id);
+      return id;
+    }
+    ++id;
+    if (id == 0) {
+      ++id;  // skip the sentinel
+    }
+  }
   AdStackSizingInfoEntry entry;
   entry.identity_key = identity_key;
   entry.kernel_name = kernel_name;
   entry.task_id_in_kernel = task_id_in_kernel;
   entry.allocated_max_sizes = std::move(allocated_max_sizes);
   entry.size_exprs = std::move(size_exprs);
-  adstack_sizing_info_registry_.push_back(std::move(entry));
+  adstack_sizing_info_registry_.emplace(id, std::move(entry));
   adstack_sizing_info_id_by_ptr_.emplace(identity_key, id);
   return id;
 }
 
 void AdStackCache::update_adstack_sizing_info_size_exprs(uint32_t id, std::vector<SerializedSizeExpr> size_exprs) {
   std::lock_guard<std::mutex> lk(adstack_sizing_info_registry_mutex_);
-  if (id == 0 || id >= adstack_sizing_info_registry_.size()) {
+  if (id == 0) {
     return;
   }
-  adstack_sizing_info_registry_[id].size_exprs = std::move(size_exprs);
+  auto it = adstack_sizing_info_registry_.find(id);
+  if (it == adstack_sizing_info_registry_.end()) {
+    return;
+  }
+  it->second.size_exprs = std::move(size_exprs);
+}
+
+void AdStackCache::ensure_runtime_registry_ids_for_max_reducer(std::vector<OffloadedTask> &tasks) {
+  for (auto &task : tasks) {
+    auto &ad_stack = task.ad_stack;
+    if (ad_stack.max_reducer_specs.empty()) {
+      continue;
+    }
+    // Fast-path gate: the `&ad_stack` identity key is stable across launches of the same kernel handle (it lives in
+    // `KernelLauncher::contexts_[i].offloaded_tasks`), so once we have populated the registry for it we skip every
+    // subsequent launch in O(1). Without this gate, the steady-state hot path would rebuild `allocated_max_sizes` +
+    // `size_exprs` and move them into `register_adstack_sizing_info` on every launch even though the entry is already
+    // there - which costs a measurable fraction of the recovered FPS on long reverse-mode loops.
+    if (is_adstack_sizing_info_registered(static_cast<const void *>(&ad_stack))) {
+      continue;
+    }
+    // After offline-cache load, `ad_stack.registry_id` carries the codegen-baked content-stable hash (now serialised),
+    // which already matches the immediate baked into the LLVM IR's overflow `cmpxchg`. The dispatcher and the
+    // metadata-publish substitution helper read `registry_id` directly off the ad_stack, so they work without us
+    // touching the `Program`-level registry. We still re-populate that registry here on the FIRST launch so the
+    // diagnose-on-overflow path can resolve the cmpxchg-recorded id to a kernel + task name; without this seed the
+    // `Program` registry would stay empty for cache-loaded kernels and an overflow would print the generic dual-cause
+    // fallback. Same `(kernel_name, task_id_in_kernel)` always hashes to the same id, so the registered id matches the
+    // one we already have on `ad_stack`.
+    std::vector<int> allocated_max_sizes;
+    allocated_max_sizes.reserve(ad_stack.allocas.size());
+    for (const auto &a : ad_stack.allocas) {
+      allocated_max_sizes.push_back(static_cast<int>(a.max_size_compile_time));
+    }
+    std::vector<SerializedSizeExpr> size_exprs(ad_stack.size_exprs.begin(), ad_stack.size_exprs.end());
+    uint32_t id = register_adstack_sizing_info(static_cast<const void *>(&ad_stack), ad_stack.kernel_name,
+                                               ad_stack.task_id_in_kernel, std::move(allocated_max_sizes),
+                                               std::move(size_exprs));
+    // Defensive: if `registry_id` was never populated (very-stale cache, fresh codegen path that skipped the task-START
+    // register call due to a null `Program *`), seed it now from the just-minted id. New kernels already have this set
+    // by `codegen_llvm.cpp::finalize_offloaded_task_function`.
+    if (ad_stack.registry_id == 0) {
+      ad_stack.registry_id = id;
+    }
+  }
+}
+
+bool AdStackCache::is_adstack_sizing_info_registered(const void *identity_key) const {
+  std::lock_guard<std::mutex> lk(adstack_sizing_info_registry_mutex_);
+  return adstack_sizing_info_id_by_ptr_.find(identity_key) != adstack_sizing_info_id_by_ptr_.end();
 }
 
 std::optional<AdStackCache::AdStackSizingInfoEntry> AdStackCache::lookup_adstack_sizing_info(uint32_t id) const {
   std::lock_guard<std::mutex> lk(adstack_sizing_info_registry_mutex_);
-  if (id == 0 || id >= adstack_sizing_info_registry_.size()) {
+  if (id == 0) {
     return std::nullopt;
   }
-  return adstack_sizing_info_registry_[id];
+  auto it = adstack_sizing_info_registry_.find(id);
+  if (it == adstack_sizing_info_registry_.end()) {
+    return std::nullopt;
+  }
+  return it->second;
 }
 
 std::string AdStackCache::diagnose_adstack_overflow_message(uint32_t task_id) const {

--- a/quadrants/program/adstack/cache.cpp
+++ b/quadrants/program/adstack/cache.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "quadrants/codegen/llvm/llvm_compiled_data.h"
 #include "quadrants/common/logging.h"
 #include "quadrants/ir/type.h"
 #include "quadrants/ir/type_factory.h"
@@ -168,6 +169,91 @@ void AdStackCache::record_max_reducer_eval(uint32_t registry_id,
   max_reducer_cache_[pack_max_reducer_key(registry_id, stack_id, mor_node_idx)] =
       MaxReducerCacheEntry{result, std::move(reads)};
   ++max_reducer_dispatch_count_;
+}
+
+bool AdStackCache::try_max_reducer_launch_cache_hit(const void *launch_cache_key,
+                                                    LaunchContextBuilder *ctx,
+                                                    std::unordered_map<uint64_t, int64_t> &out_result) {
+  if (launch_cache_key == nullptr || ctx == nullptr) {
+    return false;
+  }
+  auto it = max_reducer_launch_cache_.find(launch_cache_key);
+  if (it == max_reducer_launch_cache_.end()) {
+    return false;
+  }
+  const auto &entry = it->second;
+  for (const auto &kv : entry.snode_gens) {
+    if (snode_write_gen(kv.first) != kv.second) {
+      return false;
+    }
+  }
+  for (const auto &dep : entry.arg_gens) {
+    ArgArrayPtrKey key{dep.arg_id, TypeFactory::DATA_PTR_POS_IN_NDARRAY};
+    auto ap_it = ctx->array_ptrs.find(key);
+    void *current_devalloc = (ap_it == ctx->array_ptrs.end()) ? nullptr : ap_it->second;
+    if (current_devalloc != dep.devalloc || ndarray_data_gen(current_devalloc) != dep.gen) {
+      return false;
+    }
+  }
+  out_result = entry.result;
+  return true;
+}
+
+void AdStackCache::record_max_reducer_launch_cache(const void *launch_cache_key,
+                                                   const std::vector<const AdStackSizingInfo *> &ad_stacks,
+                                                   const std::unordered_map<uint64_t, int64_t> &result,
+                                                   LaunchContextBuilder *ctx) {
+  if (launch_cache_key == nullptr || ctx == nullptr) {
+    return;
+  }
+  // Aggregate every spec's observation deps into a deduplicated `(snode_id -> gen)` map and `(arg_id -> (devalloc,
+  // gen))` map. The fast-path replay walks these maps once per launch; deduplication keeps the replay O(distinct deps)
+  // instead of O(specs * obs/spec). `lookup_max_reducer_reads` returns the per-spec observations recorded by either a
+  // fresh `record_max_reducer_eval` or a still-warm `populate_max_reducer_body_observations` call earlier in this
+  // launch.
+  MaxReducerLaunchCacheEntry entry;
+  entry.result = result;
+  std::unordered_map<int, uint64_t> snode_gens_map;
+  std::unordered_map<int, std::pair<void *, uint64_t>> arg_gens_map;
+  for (const auto *ad_stack_ptr : ad_stacks) {
+    if (ad_stack_ptr == nullptr) {
+      continue;
+    }
+    const auto &ad_stack = *ad_stack_ptr;
+    if (ad_stack.max_reducer_specs.empty() || ad_stack.registry_id == 0) {
+      continue;
+    }
+    for (const auto &spec : ad_stack.max_reducer_specs) {
+      const auto *reads = lookup_max_reducer_reads(ad_stack.registry_id, spec.stack_id, spec.mor_node_idx);
+      if (reads == nullptr) {
+        continue;
+      }
+      for (const auto &obs : *reads) {
+        if (obs.kind == SizeExprReadObservation::FieldLoadObs) {
+          if (obs.snode_id >= 0) {
+            snode_gens_map[obs.snode_id] = snode_write_gen(obs.snode_id);
+          }
+        } else if (obs.kind == SizeExprReadObservation::ExternalReadObs) {
+          if (!obs.arg_id_path.empty()) {
+            const int arg_id = obs.arg_id_path[0];
+            ArgArrayPtrKey key{arg_id, TypeFactory::DATA_PTR_POS_IN_NDARRAY};
+            auto ap_it = ctx->array_ptrs.find(key);
+            void *devalloc = (ap_it == ctx->array_ptrs.end()) ? nullptr : ap_it->second;
+            arg_gens_map[arg_id] = {devalloc, ndarray_data_gen(devalloc)};
+          }
+        }
+      }
+    }
+  }
+  entry.snode_gens.reserve(snode_gens_map.size());
+  for (const auto &kv : snode_gens_map) {
+    entry.snode_gens.emplace_back(kv.first, kv.second);
+  }
+  entry.arg_gens.reserve(arg_gens_map.size());
+  for (const auto &kv : arg_gens_map) {
+    entry.arg_gens.push_back({kv.first, kv.second.first, kv.second.second});
+  }
+  max_reducer_launch_cache_[launch_cache_key] = std::move(entry);
 }
 
 bool AdStackCache::try_spirv_bytecode_cache_hit(Program *prog,

--- a/quadrants/program/adstack/cache.cpp
+++ b/quadrants/program/adstack/cache.cpp
@@ -196,8 +196,8 @@ bool AdStackCache::try_max_reducer_launch_cache_hit(
       return false;
     }
   }
-  // Hand back a `shared_ptr` copy of the cached result. Refcount bump only - no map copy. The cache entry retains
-  // its own ownership, so the caller's transient stays valid even after a recursive reentry rewrites the executor's
+  // Hand back a `shared_ptr` copy of the cached result. Refcount bump only - no map copy. The cache entry retains its
+  // own ownership, so the caller's transient stays valid even after a recursive reentry rewrites the executor's
   // `current_max_reducer_results_` field.
   out_result = entry.result;
   return true;
@@ -387,10 +387,10 @@ bool AdStackCache::try_llvm_per_task_ad_stack_cache_hit(const void *attribs_key,
 }
 
 namespace {
-// FNV-1a 64-bit, folded to 32-bit; never returns 0 (reserved sentinel). Used to derive a content-stable
-// `registry_id` from the (kernel_name, task_id_in_kernel) pair. We need a deterministic hash because the id is baked as
-// an immediate into LLVM IR / SPIR-V at codegen time and read back by the host on overflow: `std::hash<std::string>`
-// is implementation-defined and not stable across stdlib versions, so we cannot rely on it producing the same id at
+// FNV-1a 64-bit, folded to 32-bit; never returns 0 (reserved sentinel). Used to derive a content-stable `registry_id`
+// from the (kernel_name, task_id_in_kernel) pair. We need a deterministic hash because the id is baked as an immediate
+// into LLVM IR / SPIR-V at codegen time and read back by the host on overflow: `std::hash<std::string>` is
+// implementation-defined and not stable across stdlib versions, so we cannot rely on it producing the same id at
 // codegen time and at offline-cache-reload-driven runtime registration.
 inline uint32_t fnv1a32_for_registry(const std::string &kernel_name, int task_id_in_kernel) {
   constexpr uint64_t kFnvOffsetBasis = 0xcbf29ce484222325ULL;
@@ -449,9 +449,9 @@ uint32_t AdStackCache::register_adstack_sizing_info(const void *identity_key,
       break;
     }
     if (reg_it->second.kernel_name == kernel_name && reg_it->second.task_id_in_kernel == task_id_in_kernel) {
-      // Same content (same hash inputs), different `identity_key`. Update in place and add the new identity_key to
-      // the reverse lookup so the new pointer resolves to this same id; the previous identity_key's entry stays valid
-      // and continues to resolve here too.
+      // Same content (same hash inputs), different `identity_key`. Update in place and add the new identity_key to the
+      // reverse lookup so the new pointer resolves to this same id; the previous identity_key's entry stays valid and
+      // continues to resolve here too.
       reg_it->second.allocated_max_sizes = std::move(allocated_max_sizes);
       reg_it->second.size_exprs = std::move(size_exprs);
       adstack_sizing_info_id_by_ptr_.emplace(identity_key, id);

--- a/quadrants/program/adstack/cache.cpp
+++ b/quadrants/program/adstack/cache.cpp
@@ -203,11 +203,10 @@ bool AdStackCache::try_max_reducer_launch_cache_hit(
   return true;
 }
 
-void AdStackCache::record_max_reducer_launch_cache(
-    const void *launch_cache_key,
-    const std::vector<const AdStackSizingInfo *> &ad_stacks,
-    std::shared_ptr<const std::unordered_map<uint64_t, int64_t>> result,
-    LaunchContextBuilder *ctx) {
+void AdStackCache::record_max_reducer_launch_cache(const void *launch_cache_key,
+                                                   const std::vector<const AdStackSizingInfo *> &ad_stacks,
+                                                   std::shared_ptr<const std::unordered_map<uint64_t, int64_t>> result,
+                                                   LaunchContextBuilder *ctx) {
   if (launch_cache_key == nullptr || ctx == nullptr) {
     return;
   }
@@ -514,9 +513,9 @@ void AdStackCache::ensure_runtime_registry_ids_for_max_reducer(std::vector<Offlo
       allocated_max_sizes.push_back(static_cast<int>(a.max_size_compile_time));
     }
     std::vector<SerializedSizeExpr> size_exprs(ad_stack.size_exprs.begin(), ad_stack.size_exprs.end());
-    uint32_t id = register_adstack_sizing_info(static_cast<const void *>(&ad_stack), ad_stack.kernel_name,
-                                               ad_stack.task_id_in_kernel, std::move(allocated_max_sizes),
-                                               std::move(size_exprs));
+    uint32_t id =
+        register_adstack_sizing_info(static_cast<const void *>(&ad_stack), ad_stack.kernel_name,
+                                     ad_stack.task_id_in_kernel, std::move(allocated_max_sizes), std::move(size_exprs));
     // Defensive: if `registry_id` was never populated (very-stale cache, fresh codegen path that skipped the task-START
     // register call due to a null `Program *`), seed it now from the just-minted id. New kernels already have this set
     // by `codegen_llvm.cpp::finalize_offloaded_task_function`.

--- a/quadrants/program/adstack/cache.cpp
+++ b/quadrants/program/adstack/cache.cpp
@@ -171,9 +171,10 @@ void AdStackCache::record_max_reducer_eval(uint32_t registry_id,
   ++max_reducer_dispatch_count_;
 }
 
-bool AdStackCache::try_max_reducer_launch_cache_hit(const void *launch_cache_key,
-                                                    LaunchContextBuilder *ctx,
-                                                    std::unordered_map<uint64_t, int64_t> &out_result) {
+bool AdStackCache::try_max_reducer_launch_cache_hit(
+    const void *launch_cache_key,
+    LaunchContextBuilder *ctx,
+    std::shared_ptr<const std::unordered_map<uint64_t, int64_t>> &out_result) {
   if (launch_cache_key == nullptr || ctx == nullptr) {
     return false;
   }
@@ -195,14 +196,18 @@ bool AdStackCache::try_max_reducer_launch_cache_hit(const void *launch_cache_key
       return false;
     }
   }
+  // Hand back a `shared_ptr` copy of the cached result. Refcount bump only - no map copy. The cache entry retains
+  // its own ownership, so the caller's transient stays valid even after a recursive reentry rewrites the executor's
+  // `current_max_reducer_results_` field.
   out_result = entry.result;
   return true;
 }
 
-void AdStackCache::record_max_reducer_launch_cache(const void *launch_cache_key,
-                                                   const std::vector<const AdStackSizingInfo *> &ad_stacks,
-                                                   const std::unordered_map<uint64_t, int64_t> &result,
-                                                   LaunchContextBuilder *ctx) {
+void AdStackCache::record_max_reducer_launch_cache(
+    const void *launch_cache_key,
+    const std::vector<const AdStackSizingInfo *> &ad_stacks,
+    std::shared_ptr<const std::unordered_map<uint64_t, int64_t>> result,
+    LaunchContextBuilder *ctx) {
   if (launch_cache_key == nullptr || ctx == nullptr) {
     return;
   }
@@ -212,7 +217,7 @@ void AdStackCache::record_max_reducer_launch_cache(const void *launch_cache_key,
   // fresh `record_max_reducer_eval` or a still-warm `populate_max_reducer_body_observations` call earlier in this
   // launch.
   MaxReducerLaunchCacheEntry entry;
-  entry.result = result;
+  entry.result = std::move(result);
   std::unordered_map<int, uint64_t> snode_gens_map;
   std::unordered_map<int, std::pair<void *, uint64_t>> arg_gens_map;
   for (const auto *ad_stack_ptr : ad_stacks) {

--- a/quadrants/program/adstack/cache.h
+++ b/quadrants/program/adstack/cache.h
@@ -18,6 +18,7 @@ namespace quadrants::lang {
 class LaunchContextBuilder;
 class Program;
 struct AdStackSizingInfo;
+class OffloadedTask;
 
 // Adstack-specific state owned by `Program` and routed through `program->adstack_cache().method(...)`. Holds two
 // orthogonal pieces:
@@ -169,16 +170,16 @@ class AdStackCache {
                                                                        int32_t stack_id,
                                                                        int32_t mor_node_idx) const;
 
-  // Per-kernel-handle launch cache for the max-reducer dispatcher. Skips the per-spec hash-lookup-and-observation-
-  // replay loop in `dispatch_max_reducers_for_tasks` when the kernel handle's dependency snapshot is unchanged
-  // since the previous launch. Key is the address of the launcher's stable per-handle vector
-  // (`KernelLauncher::contexts_[i].offloaded_tasks` for CUDA / AMDGPU, `ad_stacks` for the CPU launcher); the
-  // address is reused on every launch of the same kernel handle so it serves as a stable identity. Stores the
-  // dispatched result map plus a deduplicated `(snode_id, gen)` / `(arg_id, devalloc, gen)` snapshot covering
-  // every spec's observation deps. The fast path replays the snapshot in O(distinct deps) and short-circuits on
-  // full match; this collapses the steady-state per-launch cost from O(specs) hash lookups + observation replays
-  // + result-map rebuilds (the dominant chunk of the regression introduced when the dispatcher first landed) to
-  // a small dependency walk and a single map copy. Slow path falls through to the per-spec cache.
+  // Per-kernel-handle launch cache for the max-reducer dispatcher. Skips the per-spec hash-lookup-and-observation
+  // -replay loop in `dispatch_max_reducers_for_tasks` when the kernel handle's dependency snapshot is unchanged since
+  // the previous launch. Key is the address of the launcher's stable per-handle vector
+  // (`KernelLauncher::contexts_[i].offloaded_tasks` for CUDA / AMDGPU, `ad_stacks` for the CPU launcher); the address
+  // is reused on every launch of the same kernel handle so it serves as a stable identity. Stores the dispatched result
+  // map plus a deduplicated `(snode_id, gen)` / `(arg_id, devalloc, gen)` snapshot covering every spec's observation
+  // deps. The fast path replays the snapshot in O(distinct deps) and short-circuits on full match; this collapses the
+  // steady-state per-launch cost from O(specs) hash lookups + observation replays + result-map rebuilds (the dominant
+  // chunk of the regression introduced when the dispatcher first landed) to a small dependency walk and a single map
+  // copy. Slow path falls through to the per-spec cache.
   struct ArgGenObservation {
     int arg_id;
     void *devalloc;
@@ -186,27 +187,26 @@ class AdStackCache {
   };
   // Cache entry stores the dispatched result map via shared ownership so the per-launch fast path can repoint
   // `LlvmRuntimeExecutor::current_max_reducer_results_` to it without copying, and so a snapshot taken by
-  // `publish_adstack_metadata` survives a recursive snode-reader-kernel reentry that may rewrite the executor
-  // transient. The result map is logically `const` once recorded; mutation should happen by replacing the entry,
-  // not by reaching through the `shared_ptr`.
+  // `publish_adstack_metadata` survives a recursive snode-reader-kernel reentry that may rewrite the executor's
+  // transient. The result map is logically `const` once recorded; mutation should happen by replacing the entry, not
+  // by reaching through the `shared_ptr`.
   struct MaxReducerLaunchCacheEntry {
     std::shared_ptr<const std::unordered_map<uint64_t, int64_t>> result;
     std::vector<std::pair<int, uint64_t>> snode_gens;
     std::vector<ArgGenObservation> arg_gens;
   };
-  // Replay the recorded dependency snapshot for `launch_cache_key`. Returns true (and populates `out_result` with
-  // the cache entry's `shared_ptr`) when every recorded dep still matches the live `(snode_write_gen,
-  // ndarray_data_gen)`; false otherwise. A miss leaves the entry in place so a subsequent
-  // `record_max_reducer_launch_cache` can overwrite it.
-  bool try_max_reducer_launch_cache_hit(
-      const void *launch_cache_key,
-      LaunchContextBuilder *ctx,
-      std::shared_ptr<const std::unordered_map<uint64_t, int64_t>> &out_result);
-  // Aggregate every spec's observation deps (resolved via `lookup_max_reducer_reads`) into a deduplicated snapshot
-  // and store `result` under `launch_cache_key`. Called at the end of every successful run of
+  // Replay the recorded dependency snapshot for `launch_cache_key`. Returns true (and populates `out_result` with the
+  // cache entry's `shared_ptr`) when every recorded dep still matches the live `(snode_write_gen, ndarray_data_gen)`;
+  // false otherwise. A miss leaves the entry in place so a subsequent `record_max_reducer_launch_cache` can overwrite
+  // it.
+  bool try_max_reducer_launch_cache_hit(const void *launch_cache_key,
+                                        LaunchContextBuilder *ctx,
+                                        std::shared_ptr<const std::unordered_map<uint64_t, int64_t>> &out_result);
+  // Aggregate every spec's observation deps (resolved via `lookup_max_reducer_reads`) into a deduplicated snapshot and
+  // store `result` under `launch_cache_key`. Called at the end of every successful run of
   // `dispatch_max_reducers_for_tasks` (both full-cache-hit and any-cache-miss paths) so the next launch's
-  // `try_max_reducer_launch_cache_hit` short-circuits the per-spec walk. `ctx` must be non-null. `result` is
-  // moved into the cache entry; the caller should `make_shared` it once and pass the same `shared_ptr` down to
+  // `try_max_reducer_launch_cache_hit` short-circuits the per-spec walk. `ctx` must be non-null. `result` is moved into
+  // the cache entry; the caller should `make_shared` it once and pass the same `shared_ptr` down to
   // `LlvmRuntimeExecutor::current_max_reducer_results_` to avoid materialising a second copy.
   void record_max_reducer_launch_cache(const void *launch_cache_key,
                                        const std::vector<const AdStackSizingInfo *> &ad_stacks,
@@ -291,11 +291,23 @@ class AdStackCache {
   // launch of a task whose codegen-time registration could not capture size_exprs (the codegen-time
   // `current_task->ad_stack` had not yet been finalized). No-op for `id == 0` and ids outside the registry range.
   void update_adstack_sizing_info_size_exprs(uint32_t id, std::vector<SerializedSizeExpr> size_exprs);
-  // Returns a *copy* of the registry entry (not a pointer into the underlying vector) so the caller can safely
-  // hold the data across operations that might trigger another `register_adstack_sizing_info` and grow / reallocate
-  // the registry vector (e.g. `evaluate_adstack_size_expr` dispatching a reader kernel that compiles a fresh
-  // task). Returns `std::nullopt` for the sentinel id `0` and for out-of-range ids.
+  // Re-populate the per-`Program` registry for offline-cache-loaded LLVM kernels. `registry_id` is now content-stable
+  // (`fnv1a32(kernel_name + ":" + task_id_in_kernel)`) and serialised, so the dispatcher and metadata-publish gates
+  // already see the right id without us touching anything; this loop exists purely to seed the `Program`-level
+  // registry so `diagnose_adstack_overflow_message` can resolve the cmpxchg-recorded id on the rare overflow path.
+  // Idempotent (same hash inputs yield the same id, so re-registration on every launch is a single map lookup) and
+  // only walks tasks whose `ad_stack.max_reducer_specs` is non-empty (forward-only and reverse-mode-without-recognized
+  // -MaxOverRange tasks pay zero overhead). Mirrors the SPIR-V `adstack_sizer_launch.cpp` runtime re-registration loop.
+  void ensure_runtime_registry_ids_for_max_reducer(std::vector<OffloadedTask> &tasks);
+  // Returns a *copy* of the registry entry (not a pointer into the underlying vector) so the caller can safely hold the
+  // data across operations that might trigger another `register_adstack_sizing_info` and grow / reallocate the registry
+  // vector (e.g. `evaluate_adstack_size_expr` dispatching a reader kernel that compiles a fresh task). Returns
+  // `std::nullopt` for the sentinel id `0` and for out-of-range ids.
   std::optional<AdStackSizingInfoEntry> lookup_adstack_sizing_info(uint32_t id) const;
+  // Cheap lookup gate for the per-launch re-registration loop in `ensure_runtime_registry_ids_for_max_reducer`. Returns
+  // true when `identity_key` already maps to a registry entry, so the caller can skip the vector-building work
+  // `register_adstack_sizing_info` would otherwise pay on every steady-state launch.
+  bool is_adstack_sizing_info_registered(const void *identity_key) const;
   // Format a diagnostic message for an overflow signal. `task_id` is the value read from the pinned-host task-id
   // slot (0 if no thread overflowed; otherwise the registry id of the first overflowing task). The `message`
   // field is embedded into the `QuadrantsAssertionError` raised at the poll site. The `confirmed_invalid_cache`
@@ -374,11 +386,15 @@ class AdStackCache {
   std::unordered_map<int, uint64_t> snode_write_gen_;
   std::unordered_map<void *, uint64_t> ndarray_data_gen_;
 
-  // Adstack-overflow identity registry storage. Index 0 is reserved as the "no overflow" sentinel so the
-  // codegen-emitted `cmpxchg(0, id)` cleanly distinguishes "task id recorded" from "slot still clean". The
-  // reverse lookup map (keyed by `identity_key`) keeps `register_adstack_sizing_info` idempotent across
+  // Adstack-overflow identity registry storage. Keyed by the content-stable hash id assigned by
+  // `register_adstack_sizing_info` (`fnv1a32(kernel_name + ":" + task_id_in_kernel)`); the same id is baked into the
+  // codegen-emitted `cmpxchg(0, id)` so a host lookup of the slot the cmpxchg wrote resolves to the matching entry
+  // across re-compiles, `Program` lifetimes, and offline-cache reloads. Id `0` is reserved for "not registered" - the
+  // codegen short-circuits the cmpxchg in that case. Map (rather than vector) because the hash is non-contiguous and
+  // may collide; collisions are resolved by linear-probing within the map (see `register_adstack_sizing_info` for the
+  // loop). The reverse lookup map (keyed by `identity_key`) keeps `register_adstack_sizing_info` idempotent across
   // re-launches of the same kernel.
-  std::vector<AdStackSizingInfoEntry> adstack_sizing_info_registry_{AdStackSizingInfoEntry{}};
+  std::unordered_map<uint32_t, AdStackSizingInfoEntry> adstack_sizing_info_registry_;
   std::unordered_map<const void *, uint32_t> adstack_sizing_info_id_by_ptr_;
   mutable std::mutex adstack_sizing_info_registry_mutex_;
   // Latest captured launch context snapshot for the diagnose path's ndarray-bound leaf resolution. See

--- a/quadrants/program/adstack/cache.h
+++ b/quadrants/program/adstack/cache.h
@@ -188,8 +188,8 @@ class AdStackCache {
   // Cache entry stores the dispatched result map via shared ownership so the per-launch fast path can repoint
   // `LlvmRuntimeExecutor::current_max_reducer_results_` to it without copying, and so a snapshot taken by
   // `publish_adstack_metadata` survives a recursive snode-reader-kernel reentry that may rewrite the executor's
-  // transient. The result map is logically `const` once recorded; mutation should happen by replacing the entry, not
-  // by reaching through the `shared_ptr`.
+  // transient. The result map is logically `const` once recorded; mutation should happen by replacing the entry, not by
+  // reaching through the `shared_ptr`.
   struct MaxReducerLaunchCacheEntry {
     std::shared_ptr<const std::unordered_map<uint64_t, int64_t>> result;
     std::vector<std::pair<int, uint64_t>> snode_gens;
@@ -293,10 +293,10 @@ class AdStackCache {
   void update_adstack_sizing_info_size_exprs(uint32_t id, std::vector<SerializedSizeExpr> size_exprs);
   // Re-populate the per-`Program` registry for offline-cache-loaded LLVM kernels. `registry_id` is now content-stable
   // (`fnv1a32(kernel_name + ":" + task_id_in_kernel)`) and serialised, so the dispatcher and metadata-publish gates
-  // already see the right id without us touching anything; this loop exists purely to seed the `Program`-level
-  // registry so `diagnose_adstack_overflow_message` can resolve the cmpxchg-recorded id on the rare overflow path.
-  // Idempotent (same hash inputs yield the same id, so re-registration on every launch is a single map lookup) and
-  // only walks tasks whose `ad_stack.max_reducer_specs` is non-empty (forward-only and reverse-mode-without-recognized
+  // already see the right id without us touching anything; this loop exists purely to seed the `Program`-level registry
+  // so `diagnose_adstack_overflow_message` can resolve the cmpxchg-recorded id on the rare overflow path. Idempotent
+  // (same hash inputs yield the same id, so re-registration on every launch is a single map lookup) and only walks
+  // tasks whose `ad_stack.max_reducer_specs` is non-empty (forward-only and reverse-mode-without-recognized
   // -MaxOverRange tasks pay zero overhead). Mirrors the SPIR-V `adstack_sizer_launch.cpp` runtime re-registration loop.
   void ensure_runtime_registry_ids_for_max_reducer(std::vector<OffloadedTask> &tasks);
   // Returns a *copy* of the registry entry (not a pointer into the underlying vector) so the caller can safely hold the

--- a/quadrants/program/adstack/cache.h
+++ b/quadrants/program/adstack/cache.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -183,24 +184,33 @@ class AdStackCache {
     void *devalloc;
     uint64_t gen;
   };
+  // Cache entry stores the dispatched result map via shared ownership so the per-launch fast path can repoint
+  // `LlvmRuntimeExecutor::current_max_reducer_results_` to it without copying, and so a snapshot taken by
+  // `publish_adstack_metadata` survives a recursive snode-reader-kernel reentry that may rewrite the executor
+  // transient. The result map is logically `const` once recorded; mutation should happen by replacing the entry,
+  // not by reaching through the `shared_ptr`.
   struct MaxReducerLaunchCacheEntry {
-    std::unordered_map<uint64_t, int64_t> result;
+    std::shared_ptr<const std::unordered_map<uint64_t, int64_t>> result;
     std::vector<std::pair<int, uint64_t>> snode_gens;
     std::vector<ArgGenObservation> arg_gens;
   };
-  // Replay the recorded dependency snapshot for `launch_cache_key`. Returns true (and populates `out_result`) when
-  // every recorded dep still matches the live `(snode_write_gen, ndarray_data_gen)`; false otherwise. A miss leaves
-  // the entry in place so a subsequent `record_max_reducer_launch_cache` can overwrite it.
-  bool try_max_reducer_launch_cache_hit(const void *launch_cache_key,
-                                        LaunchContextBuilder *ctx,
-                                        std::unordered_map<uint64_t, int64_t> &out_result);
+  // Replay the recorded dependency snapshot for `launch_cache_key`. Returns true (and populates `out_result` with
+  // the cache entry's `shared_ptr`) when every recorded dep still matches the live `(snode_write_gen,
+  // ndarray_data_gen)`; false otherwise. A miss leaves the entry in place so a subsequent
+  // `record_max_reducer_launch_cache` can overwrite it.
+  bool try_max_reducer_launch_cache_hit(
+      const void *launch_cache_key,
+      LaunchContextBuilder *ctx,
+      std::shared_ptr<const std::unordered_map<uint64_t, int64_t>> &out_result);
   // Aggregate every spec's observation deps (resolved via `lookup_max_reducer_reads`) into a deduplicated snapshot
-  // and store it under `launch_cache_key` alongside `result`. Called at the end of every successful run of
+  // and store `result` under `launch_cache_key`. Called at the end of every successful run of
   // `dispatch_max_reducers_for_tasks` (both full-cache-hit and any-cache-miss paths) so the next launch's
-  // `try_max_reducer_launch_cache_hit` short-circuits the per-spec walk. `ctx` must be non-null.
+  // `try_max_reducer_launch_cache_hit` short-circuits the per-spec walk. `ctx` must be non-null. `result` is
+  // moved into the cache entry; the caller should `make_shared` it once and pass the same `shared_ptr` down to
+  // `LlvmRuntimeExecutor::current_max_reducer_results_` to avoid materialising a second copy.
   void record_max_reducer_launch_cache(const void *launch_cache_key,
                                        const std::vector<const AdStackSizingInfo *> &ad_stacks,
-                                       const std::unordered_map<uint64_t, int64_t> &result,
+                                       std::shared_ptr<const std::unordered_map<uint64_t, int64_t>> result,
                                        LaunchContextBuilder *ctx);
   void invalidate_max_reducer_launch() {
     max_reducer_launch_cache_.clear();

--- a/quadrants/program/adstack/cache.h
+++ b/quadrants/program/adstack/cache.h
@@ -16,6 +16,7 @@ namespace quadrants::lang {
 
 class LaunchContextBuilder;
 class Program;
+struct AdStackSizingInfo;
 
 // Adstack-specific state owned by `Program` and routed through `program->adstack_cache().method(...)`. Holds two
 // orthogonal pieces:
@@ -166,6 +167,44 @@ class AdStackCache {
   const std::vector<SizeExprReadObservation> *lookup_max_reducer_reads(uint32_t registry_id,
                                                                        int32_t stack_id,
                                                                        int32_t mor_node_idx) const;
+
+  // Per-kernel-handle launch cache for the max-reducer dispatcher. Skips the per-spec hash-lookup-and-observation-
+  // replay loop in `dispatch_max_reducers_for_tasks` when the kernel handle's dependency snapshot is unchanged
+  // since the previous launch. Key is the address of the launcher's stable per-handle vector
+  // (`KernelLauncher::contexts_[i].offloaded_tasks` for CUDA / AMDGPU, `ad_stacks` for the CPU launcher); the
+  // address is reused on every launch of the same kernel handle so it serves as a stable identity. Stores the
+  // dispatched result map plus a deduplicated `(snode_id, gen)` / `(arg_id, devalloc, gen)` snapshot covering
+  // every spec's observation deps. The fast path replays the snapshot in O(distinct deps) and short-circuits on
+  // full match; this collapses the steady-state per-launch cost from O(specs) hash lookups + observation replays
+  // + result-map rebuilds (the dominant chunk of the regression introduced when the dispatcher first landed) to
+  // a small dependency walk and a single map copy. Slow path falls through to the per-spec cache.
+  struct ArgGenObservation {
+    int arg_id;
+    void *devalloc;
+    uint64_t gen;
+  };
+  struct MaxReducerLaunchCacheEntry {
+    std::unordered_map<uint64_t, int64_t> result;
+    std::vector<std::pair<int, uint64_t>> snode_gens;
+    std::vector<ArgGenObservation> arg_gens;
+  };
+  // Replay the recorded dependency snapshot for `launch_cache_key`. Returns true (and populates `out_result`) when
+  // every recorded dep still matches the live `(snode_write_gen, ndarray_data_gen)`; false otherwise. A miss leaves
+  // the entry in place so a subsequent `record_max_reducer_launch_cache` can overwrite it.
+  bool try_max_reducer_launch_cache_hit(const void *launch_cache_key,
+                                        LaunchContextBuilder *ctx,
+                                        std::unordered_map<uint64_t, int64_t> &out_result);
+  // Aggregate every spec's observation deps (resolved via `lookup_max_reducer_reads`) into a deduplicated snapshot
+  // and store it under `launch_cache_key` alongside `result`. Called at the end of every successful run of
+  // `dispatch_max_reducers_for_tasks` (both full-cache-hit and any-cache-miss paths) so the next launch's
+  // `try_max_reducer_launch_cache_hit` short-circuits the per-spec walk. `ctx` must be non-null.
+  void record_max_reducer_launch_cache(const void *launch_cache_key,
+                                       const std::vector<const AdStackSizingInfo *> &ad_stacks,
+                                       const std::unordered_map<uint64_t, int64_t> &result,
+                                       LaunchContextBuilder *ctx);
+  void invalidate_max_reducer_launch() {
+    max_reducer_launch_cache_.clear();
+  }
   // Monotone counter, incremented once per `record_max_reducer_eval` call. Reset only by the surrounding test harness
   // via `reset_max_reducer_dispatch_count`. Used by the regression tests to pin the cache short-circuit: a second
   // launch with unchanged inputs must not advance the counter, and a host mutation must.
@@ -189,6 +228,7 @@ class AdStackCache {
     invalidate_per_task_ad_stack();
     invalidate_llvm_per_task_ad_stack();
     invalidate_max_reducer();
+    invalidate_max_reducer_launch();
   }
 
   uint64_t snode_write_gen(int snode_id) const {
@@ -319,6 +359,8 @@ class AdStackCache {
   // See `max_reducer_dispatch_count` for the contract. Bumped at every `record_max_reducer_eval` call (i.e. once per
   // cache miss that fired a real dispatch); cache hits do not bump it.
   uint64_t max_reducer_dispatch_count_{0};
+  // Per-kernel-handle launch-level result cache; see `try_max_reducer_launch_cache_hit` for the contract.
+  std::unordered_map<const void *, MaxReducerLaunchCacheEntry> max_reducer_launch_cache_;
   std::unordered_map<int, uint64_t> snode_write_gen_;
   std::unordered_map<void *, uint64_t> ndarray_data_gen_;
 

--- a/quadrants/program/adstack/max_reducer.h
+++ b/quadrants/program/adstack/max_reducer.h
@@ -22,10 +22,10 @@ class Program;
 using MaxReducerResultMap = std::unordered_map<uint64_t, int64_t>;
 // Read-only shared ownership of a `MaxReducerResultMap`. The launch cache stores entries via this alias so the
 // per-launch fast path can repoint `LlvmRuntimeExecutor::current_max_reducer_results_` to the cached map without
-// copying it, and so consumers in `publish_adstack_metadata` can snapshot a stable view (`shared_ptr` copy =
-// refcount bump) that survives a recursive snode-reader-kernel reentry into `dispatch_max_reducers_for_tasks`.
-// `const` because cache entries are write-once at record time and read-only thereafter; the per-launch transient
-// is rebuilt or repointed, never mutated in place.
+// copying it, and so consumers in `publish_adstack_metadata` can snapshot a stable view (`shared_ptr` copy = refcount
+// bump) that survives a recursive snode-reader-kernel reentry into `dispatch_max_reducers_for_tasks`. `const` because
+// cache entries are write-once at record time and read-only thereafter; the per-launch transient is rebuilt or
+// repointed, never mutated in place.
 using MaxReducerResultMapPtr = std::shared_ptr<const MaxReducerResultMap>;
 
 // extract a captured `MaxOverRange`'s body subtree from `expr` and emit it as a flat `[AdStackSizeExprDeviceNode x

--- a/quadrants/program/adstack/max_reducer.h
+++ b/quadrants/program/adstack/max_reducer.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <unordered_map>
 #include <vector>
 
@@ -19,6 +20,13 @@ class Program;
 // `pack_max_reducer_key` encoding `AdStackCache::try_max_reducer_cache_hit` uses, so a single map shared between the
 // dispatch path and the substitution helper avoids re-packing at every lookup.
 using MaxReducerResultMap = std::unordered_map<uint64_t, int64_t>;
+// Read-only shared ownership of a `MaxReducerResultMap`. The launch cache stores entries via this alias so the
+// per-launch fast path can repoint `LlvmRuntimeExecutor::current_max_reducer_results_` to the cached map without
+// copying it, and so consumers in `publish_adstack_metadata` can snapshot a stable view (`shared_ptr` copy =
+// refcount bump) that survives a recursive snode-reader-kernel reentry into `dispatch_max_reducers_for_tasks`.
+// `const` because cache entries are write-once at record time and read-only thereafter; the per-launch transient
+// is rebuilt or repointed, never mutated in place.
+using MaxReducerResultMapPtr = std::shared_ptr<const MaxReducerResultMap>;
 
 // extract a captured `MaxOverRange`'s body subtree from `expr` and emit it as a flat `[AdStackSizeExprDeviceNode x
 // body_node_count][int32 x indices_count]` bytecode blob plus a parallel `[uint8_t]` byte buffer ready to upload to a

--- a/quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp
+++ b/quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp
@@ -275,16 +275,34 @@ std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers
     const std::vector<OffloadedTask> &tasks,
     LaunchContextBuilder *ctx,
     void *device_runtime_context_ptr) {
-  std::vector<AdStackSizingInfo> ad_stacks_view;
+  // Address of the launcher's stable per-kernel-handle vector serves as the launch-cache key. The vector outlives
+  // the call (kept by `KernelLauncher::contexts_[i].offloaded_tasks`) so the address is reused on every launch of
+  // the same kernel handle.
+  std::vector<const AdStackSizingInfo *> ad_stacks_view;
   ad_stacks_view.reserve(tasks.size());
   for (const auto &t : tasks) {
-    ad_stacks_view.push_back(t.ad_stack);
+    ad_stacks_view.push_back(&t.ad_stack);
   }
-  return dispatch_max_reducers_for_tasks(ad_stacks_view, ctx, device_runtime_context_ptr);
+  return dispatch_max_reducers_impl(static_cast<const void *>(&tasks), ad_stacks_view, ctx,
+                                    device_runtime_context_ptr);
 }
 
 std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers_for_tasks(
     const std::vector<AdStackSizingInfo> &ad_stacks,
+    LaunchContextBuilder *ctx,
+    void *device_runtime_context_ptr) {
+  std::vector<const AdStackSizingInfo *> ad_stacks_view;
+  ad_stacks_view.reserve(ad_stacks.size());
+  for (const auto &a : ad_stacks) {
+    ad_stacks_view.push_back(&a);
+  }
+  return dispatch_max_reducers_impl(static_cast<const void *>(&ad_stacks), ad_stacks_view, ctx,
+                                    device_runtime_context_ptr);
+}
+
+std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers_impl(
+    const void *launch_cache_key,
+    const std::vector<const AdStackSizingInfo *> &ad_stacks,
     LaunchContextBuilder *ctx,
     void *device_runtime_context_ptr) {
   using quadrants::lang::AdStackSizeExprDeviceNode;
@@ -298,13 +316,25 @@ std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers
   if (ctx == nullptr || ctx->args_type == nullptr) {
     return result;
   }
+
+  Program *prog = (program_impl_ != nullptr) ? program_impl_->program : nullptr;
+  AdStackCache *cache = (prog != nullptr) ? &prog->adstack_cache() : nullptr;
+
+  // Per-launch fast-path: when the kernel handle's recorded dependency snapshot still matches live state, the
+  // dispatched results are unchanged and we can skip the per-spec cache walk + result-map rebuild entirely. See
+  // `AdStackCache::try_max_reducer_launch_cache_hit` for the deps-replay contract; the matching record path runs at
+  // the bottom of this function on every successful dispatch.
+  if (cache != nullptr && launch_cache_key != nullptr) {
+    if (cache->try_max_reducer_launch_cache_hit(launch_cache_key, ctx, current_max_reducer_results_)) {
+      return current_max_reducer_results_;
+    }
+  }
+
   // Pin the device context's `stream_` to the legacy default stream for the whole dispatch + DtoH read sequence.
   // See `cuda_stream_pin.h` for the cross-stream-visibility rationale.
 #if defined(QD_WITH_CUDA)
   CudaDefaultStreamPinGuard cuda_default_stream_pin(config_.arch == Arch::cuda);
 #endif
-  Program *prog = (program_impl_ != nullptr) ? program_impl_->program : nullptr;
-  AdStackCache *cache = (prog != nullptr) ? &prog->adstack_cache() : nullptr;
 
   // Pass 1: per-spec cache lookup. Hits drop straight into `result`; misses go to pending with back-refs to the
   // source `SerializedSizeExpr` and `StaticAdStackMaxReducerSpec`. Host-evaluation of begin / end and body bytecode
@@ -328,7 +358,7 @@ std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers
   };
   std::vector<PendingMaxReducerDispatch> pending;
   for (std::size_t ti = 0; ti < ad_stacks.size(); ++ti) {
-    const auto &ad_stack = ad_stacks[ti];
+    const auto &ad_stack = *ad_stacks[ti];
     if (ad_stack.max_reducer_specs.empty()) {
       continue;
     }
@@ -358,6 +388,13 @@ std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers
     }
   }
   if (pending.empty()) {
+    // All specs hit the per-spec cache. Record the kernel-level entry so the next launch can short-circuit
+    // before the per-spec walk: we still walked one hash + observation replay per spec to reach this point,
+    // and the per-launch fast path above eliminates that redundant work.
+    if (cache != nullptr) {
+      cache->record_max_reducer_launch_cache(launch_cache_key, ad_stacks, result, ctx);
+    }
+    current_max_reducer_results_ = result;
     return result;
   }
 
@@ -632,6 +669,12 @@ std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers
     }
   }
 
+  // Record the kernel-level launch cache so the next launch on the same kernel handle can short-circuit at the
+  // top of this function. Without this, even after the per-spec cache is fully warm we still pay an O(specs)
+  // hash-lookup-and-observation-replay loop per launch.
+  if (cache != nullptr) {
+    cache->record_max_reducer_launch_cache(launch_cache_key, ad_stacks, result, ctx);
+  }
   // Stash the result map on the executor so `publish_adstack_metadata` reads it for substitution per task.
   current_max_reducer_results_ = result;
   return result;

--- a/quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp
+++ b/quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp
@@ -274,9 +274,20 @@ void LlvmRuntimeExecutor::publish_per_task_bound_count_device(std::size_t task_i
 void LlvmRuntimeExecutor::dispatch_max_reducers_for_tasks(const std::vector<OffloadedTask> &tasks,
                                                            LaunchContextBuilder *ctx,
                                                            void *device_runtime_context_ptr) {
-  // Address of the launcher's stable per-kernel-handle vector serves as the launch-cache key. The vector outlives
-  // the call (kept by `KernelLauncher::contexts_[i].offloaded_tasks`) so the address is reused on every launch of
-  // the same kernel handle.
+  // Seed the per-`Program` adstack-overflow registry from the cache-loaded tasks so the diagnose path can resolve
+  // any cmpxchg-recorded id back to a kernel + task name. With content-hashed `registry_id` (now serialised) the
+  // dispatcher and the metadata-publish substitution helper already see the correct id directly off the ad_stack,
+  // but the `Program` registry stays empty across cache reloads until something registers; without this seed, an
+  // overflow on a freshly cache-loaded kernel would print the generic dual-cause fallback instead of the kernel +
+  // task identity. Idempotent (same hash inputs yield the same id) and cheap (one map lookup per task), and only
+  // walks tasks whose `ad_stack.max_reducer_specs` is non-empty. The cast away const is safe: the OffloadedTasks
+  // live in `KernelLauncher::contexts_[...].offloaded_tasks` (non-const launcher storage), and the const-ref
+  // parameter binding is purely ergonomic for the read-only-after-this-point dispatch path below.
+  Program *prog = (program_impl_ != nullptr) ? program_impl_->program : nullptr;
+  if (prog != nullptr) {
+    auto &mutable_tasks = const_cast<std::vector<OffloadedTask> &>(tasks);
+    prog->adstack_cache().ensure_runtime_registry_ids_for_max_reducer(mutable_tasks);
+  }
   std::vector<const AdStackSizingInfo *> ad_stacks_view;
   ad_stacks_view.reserve(tasks.size());
   for (const auto &t : tasks) {

--- a/quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp
+++ b/quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp
@@ -272,8 +272,8 @@ void LlvmRuntimeExecutor::publish_per_task_bound_count_device(std::size_t task_i
 }
 
 void LlvmRuntimeExecutor::dispatch_max_reducers_for_tasks(const std::vector<OffloadedTask> &tasks,
-                                                           LaunchContextBuilder *ctx,
-                                                           void *device_runtime_context_ptr) {
+                                                          LaunchContextBuilder *ctx,
+                                                          void *device_runtime_context_ptr) {
   // Seed the per-`Program` adstack-overflow registry from the cache-loaded tasks so the diagnose path can resolve
   // any cmpxchg-recorded id back to a kernel + task name. With content-hashed `registry_id` (now serialised) the
   // dispatcher and the metadata-publish substitution helper already see the correct id directly off the ad_stack,
@@ -297,8 +297,8 @@ void LlvmRuntimeExecutor::dispatch_max_reducers_for_tasks(const std::vector<Offl
 }
 
 void LlvmRuntimeExecutor::dispatch_max_reducers_for_tasks(const std::vector<AdStackSizingInfo> &ad_stacks,
-                                                           LaunchContextBuilder *ctx,
-                                                           void *device_runtime_context_ptr) {
+                                                          LaunchContextBuilder *ctx,
+                                                          void *device_runtime_context_ptr) {
   std::vector<const AdStackSizingInfo *> ad_stacks_view;
   ad_stacks_view.reserve(ad_stacks.size());
   for (const auto &a : ad_stacks) {

--- a/quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp
+++ b/quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp
@@ -274,15 +274,15 @@ void LlvmRuntimeExecutor::publish_per_task_bound_count_device(std::size_t task_i
 void LlvmRuntimeExecutor::dispatch_max_reducers_for_tasks(const std::vector<OffloadedTask> &tasks,
                                                           LaunchContextBuilder *ctx,
                                                           void *device_runtime_context_ptr) {
-  // Seed the per-`Program` adstack-overflow registry from the cache-loaded tasks so the diagnose path can resolve
-  // any cmpxchg-recorded id back to a kernel + task name. With content-hashed `registry_id` (now serialised) the
-  // dispatcher and the metadata-publish substitution helper already see the correct id directly off the ad_stack,
-  // but the `Program` registry stays empty across cache reloads until something registers; without this seed, an
-  // overflow on a freshly cache-loaded kernel would print the generic dual-cause fallback instead of the kernel +
-  // task identity. Idempotent (same hash inputs yield the same id) and cheap (one map lookup per task), and only
-  // walks tasks whose `ad_stack.max_reducer_specs` is non-empty. The cast away const is safe: the OffloadedTasks
-  // live in `KernelLauncher::contexts_[...].offloaded_tasks` (non-const launcher storage), and the const-ref
-  // parameter binding is purely ergonomic for the read-only-after-this-point dispatch path below.
+  // Seed the per-`Program` adstack-overflow registry from the cache-loaded tasks so the diagnose path can resolve any
+  // cmpxchg-recorded id back to a kernel + task name. With content-hashed `registry_id` (now serialised) the dispatcher
+  // and the metadata-publish substitution helper already see the correct id directly off the ad_stack, but the
+  // `Program` registry stays empty across cache reloads until something registers; without this seed, an overflow on a
+  // freshly cache-loaded kernel would print the generic dual-cause fallback instead of the kernel + task identity.
+  // Idempotent (same hash inputs yield the same id) and cheap (one map lookup per task), and only walks tasks whose
+  // `ad_stack.max_reducer_specs` is non-empty. The cast away const is safe: the OffloadedTasks live in
+  // `KernelLauncher::contexts_[...].offloaded_tasks` (non-const launcher storage), and the const-ref parameter binding
+  // is purely ergonomic for the read-only-after-this-point dispatch path below.
   Program *prog = (program_impl_ != nullptr) ? program_impl_->program : nullptr;
   if (prog != nullptr) {
     auto &mutable_tasks = const_cast<std::vector<OffloadedTask> &>(tasks);
@@ -316,8 +316,8 @@ void LlvmRuntimeExecutor::dispatch_max_reducers_impl(const void *launch_cache_ke
   using quadrants::lang::LlvmAdStackMaxReducerDeviceParams;
   using quadrants::lang::MaxReducerResultMap;
 
-  // Reset the per-launch transient to a fresh empty map so a kernel without captured specs (or an early-out below)
-  // sees a non-null shared_ptr to an empty map. Consumers in `publish_adstack_metadata` dereference the pointer
+  // Reset the per-launch transient to a fresh empty map so a kernel without captured specs (or an early-out below) sees
+  // a non-null shared_ptr to an empty map. Consumers in `publish_adstack_metadata` dereference the pointer
   // unconditionally; keeping it non-null here removes a per-task null check.
   auto empty_results = std::make_shared<const MaxReducerResultMap>();
   current_max_reducer_results_ = empty_results;
@@ -330,9 +330,9 @@ void LlvmRuntimeExecutor::dispatch_max_reducers_impl(const void *launch_cache_ke
 
   // Per-launch fast-path: when the kernel handle's recorded dependency snapshot still matches live state, the
   // dispatched results are unchanged and we can skip the per-spec cache walk + result-map rebuild entirely. See
-  // `AdStackCache::try_max_reducer_launch_cache_hit` for the deps-replay contract; the matching record path runs at
-  // the bottom of this function on every successful dispatch. The cache hands back a `shared_ptr` copy of its
-  // entry's map, so the assignment below is a refcount bump - no map data is copied.
+  // `AdStackCache::try_max_reducer_launch_cache_hit` for the deps-replay contract; the matching record path runs at the
+  // bottom of this function on every successful dispatch. The cache hands back a `shared_ptr` copy of its entry's map,
+  // so the assignment below is a refcount bump - no map data is copied.
   if (cache != nullptr && launch_cache_key != nullptr) {
     std::shared_ptr<const MaxReducerResultMap> hit;
     if (cache->try_max_reducer_launch_cache_hit(launch_cache_key, ctx, hit)) {
@@ -341,8 +341,8 @@ void LlvmRuntimeExecutor::dispatch_max_reducers_impl(const void *launch_cache_ke
     }
   }
 
-  // Slow path builds its result map locally; we wrap it in a `shared_ptr` once at the end so the cache entry and
-  // the executor transient share the same allocation.
+  // Slow path builds its result map locally; we wrap it in a `shared_ptr` once at the end so the cache entry and the
+  // executor transient share the same allocation.
   MaxReducerResultMap result;
 
   // Pin the device context's `stream_` to the legacy default stream for the whole dispatch + DtoH read sequence.
@@ -403,10 +403,10 @@ void LlvmRuntimeExecutor::dispatch_max_reducers_impl(const void *launch_cache_ke
     }
   }
   if (pending.empty()) {
-    // All specs hit the per-spec cache. Record the kernel-level entry so the next launch can short-circuit
-    // before the per-spec walk: we still walked one hash + observation replay per spec to reach this point,
-    // and the per-launch fast path above eliminates that redundant work. Wrap the result in a `shared_ptr` once
-    // so the cache entry and the executor transient share the same allocation.
+    // All specs hit the per-spec cache. Record the kernel-level entry so the next launch can short-circuit before the
+    // per-spec walk: we still walked one hash + observation replay per spec to reach this point, and the per-launch
+    // fast path above eliminates that redundant work. Wrap the result in a `shared_ptr` once so the cache entry and the
+    // executor transient share the same allocation.
     auto result_ptr = std::make_shared<const MaxReducerResultMap>(std::move(result));
     if (cache != nullptr) {
       cache->record_max_reducer_launch_cache(launch_cache_key, ad_stacks, result_ptr, ctx);
@@ -686,10 +686,10 @@ void LlvmRuntimeExecutor::dispatch_max_reducers_impl(const void *launch_cache_ke
     }
   }
 
-  // Record the kernel-level launch cache so the next launch on the same kernel handle can short-circuit at the
-  // top of this function. Without this, even after the per-spec cache is fully warm we still pay an O(specs)
-  // hash-lookup-and-observation-replay loop per launch. The shared_ptr wrapping happens once here so the cache
-  // entry and the executor transient share the same allocation.
+  // Record the kernel-level launch cache so the next launch on the same kernel handle can short-circuit at the top of
+  // this function. Without this, even after the per-spec cache is fully warm we still pay an O(specs)
+  // hash-lookup-and-observation-replay loop per launch. The shared_ptr wrapping happens once here so the cache entry
+  // and the executor transient share the same allocation.
   auto result_ptr = std::make_shared<const MaxReducerResultMap>(std::move(result));
   if (cache != nullptr) {
     cache->record_max_reducer_launch_cache(launch_cache_key, ad_stacks, result_ptr, ctx);

--- a/quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp
+++ b/quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp
@@ -271,10 +271,9 @@ void LlvmRuntimeExecutor::publish_per_task_bound_count_device(std::size_t task_i
                                             runtime_context_ptr_for_reducer, params_dev_ptr);
 }
 
-std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers_for_tasks(
-    const std::vector<OffloadedTask> &tasks,
-    LaunchContextBuilder *ctx,
-    void *device_runtime_context_ptr) {
+void LlvmRuntimeExecutor::dispatch_max_reducers_for_tasks(const std::vector<OffloadedTask> &tasks,
+                                                           LaunchContextBuilder *ctx,
+                                                           void *device_runtime_context_ptr) {
   // Address of the launcher's stable per-kernel-handle vector serves as the launch-cache key. The vector outlives
   // the call (kept by `KernelLauncher::contexts_[i].offloaded_tasks`) so the address is reused on every launch of
   // the same kernel handle.
@@ -283,38 +282,36 @@ std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers
   for (const auto &t : tasks) {
     ad_stacks_view.push_back(&t.ad_stack);
   }
-  return dispatch_max_reducers_impl(static_cast<const void *>(&tasks), ad_stacks_view, ctx,
-                                    device_runtime_context_ptr);
+  dispatch_max_reducers_impl(static_cast<const void *>(&tasks), ad_stacks_view, ctx, device_runtime_context_ptr);
 }
 
-std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers_for_tasks(
-    const std::vector<AdStackSizingInfo> &ad_stacks,
-    LaunchContextBuilder *ctx,
-    void *device_runtime_context_ptr) {
+void LlvmRuntimeExecutor::dispatch_max_reducers_for_tasks(const std::vector<AdStackSizingInfo> &ad_stacks,
+                                                           LaunchContextBuilder *ctx,
+                                                           void *device_runtime_context_ptr) {
   std::vector<const AdStackSizingInfo *> ad_stacks_view;
   ad_stacks_view.reserve(ad_stacks.size());
   for (const auto &a : ad_stacks) {
     ad_stacks_view.push_back(&a);
   }
-  return dispatch_max_reducers_impl(static_cast<const void *>(&ad_stacks), ad_stacks_view, ctx,
-                                    device_runtime_context_ptr);
+  dispatch_max_reducers_impl(static_cast<const void *>(&ad_stacks), ad_stacks_view, ctx, device_runtime_context_ptr);
 }
 
-std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers_impl(
-    const void *launch_cache_key,
-    const std::vector<const AdStackSizingInfo *> &ad_stacks,
-    LaunchContextBuilder *ctx,
-    void *device_runtime_context_ptr) {
+void LlvmRuntimeExecutor::dispatch_max_reducers_impl(const void *launch_cache_key,
+                                                     const std::vector<const AdStackSizingInfo *> &ad_stacks,
+                                                     LaunchContextBuilder *ctx,
+                                                     void *device_runtime_context_ptr) {
   using quadrants::lang::AdStackSizeExprDeviceNode;
   using quadrants::lang::EncodedMaxReducerBody;
   using quadrants::lang::LlvmAdStackMaxReducerDeviceParams;
   using quadrants::lang::MaxReducerResultMap;
 
-  // Reset the per-launch transient before every dispatch so a kernel with no captured specs sees an empty map.
-  current_max_reducer_results_.clear();
-  MaxReducerResultMap result;
+  // Reset the per-launch transient to a fresh empty map so a kernel without captured specs (or an early-out below)
+  // sees a non-null shared_ptr to an empty map. Consumers in `publish_adstack_metadata` dereference the pointer
+  // unconditionally; keeping it non-null here removes a per-task null check.
+  auto empty_results = std::make_shared<const MaxReducerResultMap>();
+  current_max_reducer_results_ = empty_results;
   if (ctx == nullptr || ctx->args_type == nullptr) {
-    return result;
+    return;
   }
 
   Program *prog = (program_impl_ != nullptr) ? program_impl_->program : nullptr;
@@ -323,12 +320,19 @@ std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers
   // Per-launch fast-path: when the kernel handle's recorded dependency snapshot still matches live state, the
   // dispatched results are unchanged and we can skip the per-spec cache walk + result-map rebuild entirely. See
   // `AdStackCache::try_max_reducer_launch_cache_hit` for the deps-replay contract; the matching record path runs at
-  // the bottom of this function on every successful dispatch.
+  // the bottom of this function on every successful dispatch. The cache hands back a `shared_ptr` copy of its
+  // entry's map, so the assignment below is a refcount bump - no map data is copied.
   if (cache != nullptr && launch_cache_key != nullptr) {
-    if (cache->try_max_reducer_launch_cache_hit(launch_cache_key, ctx, current_max_reducer_results_)) {
-      return current_max_reducer_results_;
+    std::shared_ptr<const MaxReducerResultMap> hit;
+    if (cache->try_max_reducer_launch_cache_hit(launch_cache_key, ctx, hit)) {
+      current_max_reducer_results_ = std::move(hit);
+      return;
     }
   }
+
+  // Slow path builds its result map locally; we wrap it in a `shared_ptr` once at the end so the cache entry and
+  // the executor transient share the same allocation.
+  MaxReducerResultMap result;
 
   // Pin the device context's `stream_` to the legacy default stream for the whole dispatch + DtoH read sequence.
   // See `cuda_stream_pin.h` for the cross-stream-visibility rationale.
@@ -390,12 +394,14 @@ std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers
   if (pending.empty()) {
     // All specs hit the per-spec cache. Record the kernel-level entry so the next launch can short-circuit
     // before the per-spec walk: we still walked one hash + observation replay per spec to reach this point,
-    // and the per-launch fast path above eliminates that redundant work.
+    // and the per-launch fast path above eliminates that redundant work. Wrap the result in a `shared_ptr` once
+    // so the cache entry and the executor transient share the same allocation.
+    auto result_ptr = std::make_shared<const MaxReducerResultMap>(std::move(result));
     if (cache != nullptr) {
-      cache->record_max_reducer_launch_cache(launch_cache_key, ad_stacks, result, ctx);
+      cache->record_max_reducer_launch_cache(launch_cache_key, ad_stacks, result_ptr, ctx);
     }
-    current_max_reducer_results_ = result;
-    return result;
+    current_max_reducer_results_ = std::move(result_ptr);
+    return;
   }
 
   // Lazy-resolve the runtime-field address for `adstack_max_reducer_outputs` once per program lifetime.
@@ -671,13 +677,14 @@ std::unordered_map<uint64_t, int64_t> LlvmRuntimeExecutor::dispatch_max_reducers
 
   // Record the kernel-level launch cache so the next launch on the same kernel handle can short-circuit at the
   // top of this function. Without this, even after the per-spec cache is fully warm we still pay an O(specs)
-  // hash-lookup-and-observation-replay loop per launch.
+  // hash-lookup-and-observation-replay loop per launch. The shared_ptr wrapping happens once here so the cache
+  // entry and the executor transient share the same allocation.
+  auto result_ptr = std::make_shared<const MaxReducerResultMap>(std::move(result));
   if (cache != nullptr) {
-    cache->record_max_reducer_launch_cache(launch_cache_key, ad_stacks, result, ctx);
+    cache->record_max_reducer_launch_cache(launch_cache_key, ad_stacks, result_ptr, ctx);
   }
   // Stash the result map on the executor so `publish_adstack_metadata` reads it for substitution per task.
-  current_max_reducer_results_ = result;
-  return result;
+  current_max_reducer_results_ = std::move(result_ptr);
 }
 
 void LlvmRuntimeExecutor::publish_adstack_lazy_claim_buffers(std::size_t num_tasks) {

--- a/quadrants/runtime/llvm/adstack_lazy_claim/metadata_publish.cpp
+++ b/quadrants/runtime/llvm/adstack_lazy_claim/metadata_publish.cpp
@@ -337,8 +337,8 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
         // path passes the live `expr` pointer directly so `size_expr_cache_` (keyed by `SerializedSizeExpr *`) stays
         // warm across launches; the non-empty branch builds a stack-local substituted tree and routes through
         // `evaluate_adstack_size_expr_no_cache` so the transient pointer never aliases unrelated cache entries. The
-        // `shared_ptr` is initialised to a non-null empty-map sentinel by `dispatch_max_reducers_impl`, so the deref
-        // is always safe.
+        // `shared_ptr` is initialised to a non-null empty-map sentinel by `dispatch_max_reducers_impl`, so the deref is
+        // always safe.
         if (!local_max_reducer_results || local_max_reducer_results->empty()) {
           v = evaluate_adstack_size_expr(*expr, prog, ctx);
         } else {
@@ -456,8 +456,8 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
       std::vector<uint8_t> bytecode;
       // The encoder reads the result map by `const &`. `current_max_reducer_results_` is a `shared_ptr<const map>`
       // initialised to a non-null empty-map sentinel by `dispatch_max_reducers_impl`, so the deref is safe; defend
-      // anyway against the path where `dispatch_max_reducers_impl` was never invoked (forward-only kernels) by
-      // falling back to a stack-local empty map.
+      // anyway against the path where `dispatch_max_reducers_impl` was never invoked (forward-only kernels) by falling
+      // back to a stack-local empty map.
       static const MaxReducerResultMap kEmptyResults{};
       const MaxReducerResultMap &results_view =
           current_max_reducer_results_ ? *current_max_reducer_results_ : kEmptyResults;

--- a/quadrants/runtime/llvm/adstack_lazy_claim/metadata_publish.cpp
+++ b/quadrants/runtime/llvm/adstack_lazy_claim/metadata_publish.cpp
@@ -319,13 +319,13 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
     SizeExprLaunchScope launch_scope;
     // Snapshot the dispatched-results map for this kernel before the per-stack walk. The body of any captured
     // `MaxOverRange` may host-resolve a `FieldLoad` leaf via `read_field_with_launch_cache`, which dispatches a
-    // snode-reader kernel that reenters `dispatch_max_reducers_for_tasks` and rewrites
-    // `current_max_reducer_results_` to point at that recursive call's result map. Reading the live executor field
-    // per stack would let that recursive overwrite turn `stack_id == 0` 's substitution branch into `stack_id == 1`
-    // 's empty-map fallback - whose host walk then trips the per-task sizer's `1<<24` cap on out-of-grammar shapes
-    // that the recognizer DID capture. Pin the snapshot via a `shared_ptr` copy (refcount bump only, no map data
-    // copied) so the substitution loop stays self-consistent and the cache-entry's allocation stays alive even if
-    // the executor's transient gets repointed mid-walk.
+    // snode-reader kernel that reenters `dispatch_max_reducers_for_tasks` and rewrites `current_max_reducer_results_`
+    // to point at that recursive call's result map. Reading the live executor field per stack would let that recursive
+    // overwrite turn `stack_id == 0` 's substitution branch into `stack_id == 1` 's empty-map fallback - whose host
+    // walk then trips the per-task sizer's `1<<24` cap on out-of-grammar shapes that the recognizer DID capture. Pin
+    // the snapshot via a `shared_ptr` copy (refcount bump only, no map data copied) so the substitution loop stays
+    // self-consistent and the cache-entry's allocation stays alive even if the executor's transient gets repointed
+    // mid-walk.
     const auto local_max_reducer_results = current_max_reducer_results_;
     std::vector<uint64_t> host_max_sizes(n_stacks);
     for (std::size_t i = 0; i < n_stacks; ++i) {

--- a/quadrants/runtime/llvm/adstack_lazy_claim/metadata_publish.cpp
+++ b/quadrants/runtime/llvm/adstack_lazy_claim/metadata_publish.cpp
@@ -462,8 +462,7 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
       const MaxReducerResultMap &results_view =
           current_max_reducer_results_ ? *current_max_reducer_results_ : kEmptyResults;
       if (program_impl_ != nullptr && program_impl_->program != nullptr) {
-        bytecode =
-            encode_adstack_size_expr_device_bytecode(ad_stack, program_impl_->program, ctx, results_view);
+        bytecode = encode_adstack_size_expr_device_bytecode(ad_stack, program_impl_->program, ctx, results_view);
       } else {
         // No program attached (rare: C++-only tests that construct Program without a full runtime). Fall through
         // to compile-time bounds by emitting an empty-tree bytecode - the device interpreter sees

--- a/quadrants/runtime/llvm/adstack_lazy_claim/metadata_publish.cpp
+++ b/quadrants/runtime/llvm/adstack_lazy_claim/metadata_publish.cpp
@@ -319,11 +319,13 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
     SizeExprLaunchScope launch_scope;
     // Snapshot the dispatched-results map for this kernel before the per-stack walk. The body of any captured
     // `MaxOverRange` may host-resolve a `FieldLoad` leaf via `read_field_with_launch_cache`, which dispatches a
-    // snode-reader kernel that reenters `dispatch_max_reducers_for_tasks` and clears `current_max_reducer_results_`.
-    // Reading the live executor field per stack would let that recursive clear turn `stack_id == 0` 's substitution
-    // branch into `stack_id == 1` 's empty-map fallback - whose host walk then trips the per-task sizer's `1<<24` cap
-    // on out-of-grammar shapes that the recognizer DID capture. Pin the snapshot by-value so the substitution loop
-    // stays self-consistent.
+    // snode-reader kernel that reenters `dispatch_max_reducers_for_tasks` and rewrites
+    // `current_max_reducer_results_` to point at that recursive call's result map. Reading the live executor field
+    // per stack would let that recursive overwrite turn `stack_id == 0` 's substitution branch into `stack_id == 1`
+    // 's empty-map fallback - whose host walk then trips the per-task sizer's `1<<24` cap on out-of-grammar shapes
+    // that the recognizer DID capture. Pin the snapshot via a `shared_ptr` copy (refcount bump only, no map data
+    // copied) so the substitution loop stays self-consistent and the cache-entry's allocation stays alive even if
+    // the executor's transient gets repointed mid-walk.
     const auto local_max_reducer_results = current_max_reducer_results_;
     std::vector<uint64_t> host_max_sizes(n_stacks);
     for (std::size_t i = 0; i < n_stacks; ++i) {
@@ -334,12 +336,14 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
         // evaluator walks the tree. Mirrors `eval_per_task_metadata_on_host` on the SPIR-V side. The empty-results fast
         // path passes the live `expr` pointer directly so `size_expr_cache_` (keyed by `SerializedSizeExpr *`) stays
         // warm across launches; the non-empty branch builds a stack-local substituted tree and routes through
-        // `evaluate_adstack_size_expr_no_cache` so the transient pointer never aliases unrelated cache entries.
-        if (local_max_reducer_results.empty()) {
+        // `evaluate_adstack_size_expr_no_cache` so the transient pointer never aliases unrelated cache entries. The
+        // `shared_ptr` is initialised to a non-null empty-map sentinel by `dispatch_max_reducers_impl`, so the deref
+        // is always safe.
+        if (!local_max_reducer_results || local_max_reducer_results->empty()) {
           v = evaluate_adstack_size_expr(*expr, prog, ctx);
         } else {
           const SerializedSizeExpr substituted = substitute_precomputed_max_over_range(
-              *expr, ad_stack.registry_id, static_cast<int32_t>(i), local_max_reducer_results);
+              *expr, ad_stack.registry_id, static_cast<int32_t>(i), *local_max_reducer_results);
           v = evaluate_adstack_size_expr_no_cache(substituted, prog, ctx);
         }
       }
@@ -450,14 +454,21 @@ std::size_t LlvmRuntimeExecutor::publish_adstack_metadata(const AdStackSizingInf
     }
     if (!llvm_metadata_cache_hit) {
       std::vector<uint8_t> bytecode;
+      // The encoder reads the result map by `const &`. `current_max_reducer_results_` is a `shared_ptr<const map>`
+      // initialised to a non-null empty-map sentinel by `dispatch_max_reducers_impl`, so the deref is safe; defend
+      // anyway against the path where `dispatch_max_reducers_impl` was never invoked (forward-only kernels) by
+      // falling back to a stack-local empty map.
+      static const MaxReducerResultMap kEmptyResults{};
+      const MaxReducerResultMap &results_view =
+          current_max_reducer_results_ ? *current_max_reducer_results_ : kEmptyResults;
       if (program_impl_ != nullptr && program_impl_->program != nullptr) {
-        bytecode = encode_adstack_size_expr_device_bytecode(ad_stack, program_impl_->program, ctx,
-                                                            current_max_reducer_results_);
+        bytecode =
+            encode_adstack_size_expr_device_bytecode(ad_stack, program_impl_->program, ctx, results_view);
       } else {
         // No program attached (rare: C++-only tests that construct Program without a full runtime). Fall through
         // to compile-time bounds by emitting an empty-tree bytecode - the device interpreter sees
         // `root_node_idx == -1` for every stack and routes to `max_size_compile_time`.
-        bytecode = encode_adstack_size_expr_device_bytecode(ad_stack, nullptr, ctx, current_max_reducer_results_);
+        bytecode = encode_adstack_size_expr_device_bytecode(ad_stack, nullptr, ctx, results_view);
       }
       // Grow the scratch buffer if the bytecode outgrew the cached capacity. Amortised doubling keeps the
       // allocation traffic O(log max_bytecode_bytes) across a run.

--- a/quadrants/runtime/llvm/llvm_runtime_executor.h
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.h
@@ -198,7 +198,8 @@ class LlvmRuntimeExecutor {
                                                                         void *device_runtime_context_ptr);
   // Convenience overload that extracts each task's `ad_stack` and forwards to the primary entry point. Lets the CUDA /
   // AMDGPU per-arch launchers call into the dispatcher with the `OffloadedTask` list they already hold, without each
-  // launcher copy-pasting the per-task `ad_stack` extraction loop.
+  // launcher copy-pasting the per-task `ad_stack` extraction loop. Forwards a pointer-view of the per-task `ad_stack`s
+  // to `dispatch_max_reducers_impl` (no deep copy of the `AdStackSizingInfo`s).
   std::unordered_map<uint64_t, int64_t> dispatch_max_reducers_for_tasks(const std::vector<OffloadedTask> &tasks,
                                                                         LaunchContextBuilder *ctx,
                                                                         void *device_runtime_context_ptr);
@@ -210,6 +211,20 @@ class LlvmRuntimeExecutor {
   void *get_runtime_temporaries_device_ptr();
 
  private:
+  /* ----------------------- */
+  /* ---- Adstack helpers --- */
+  /* ----------------------- */
+  // Shared implementation for both `dispatch_max_reducers_for_tasks` overloads. Takes a stable per-kernel-handle
+  // `launch_cache_key` (the address of the caller's `tasks` / `ad_stacks` vector) and a non-owning pointer view of
+  // the per-task `AdStackSizingInfo`s. Avoids the per-launch deep copy of `AdStackSizingInfo` the OffloadedTask
+  // overload used to do, and short-circuits on a kernel-level dependency-fingerprint hit before walking specs (logic
+  // factored into `AdStackCache::try_max_reducer_launch_cache_hit` / `record_max_reducer_launch_cache`).
+  std::unordered_map<uint64_t, int64_t> dispatch_max_reducers_impl(
+      const void *launch_cache_key,
+      const std::vector<const AdStackSizingInfo *> &ad_stacks,
+      LaunchContextBuilder *ctx,
+      void *device_runtime_context_ptr);
+
   /* ----------------------- */
   /* ------ Allocation ----- */
   /* ----------------------- */

--- a/quadrants/runtime/llvm/llvm_runtime_executor.h
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.h
@@ -188,10 +188,10 @@ class LlvmRuntimeExecutor {
   // `runtime_eval_adstack_max_reduce` via the runtime JIT as a grid-strided launch with an `atomic_max_i64` reduction.
   // CUDA and AMDGPU only; on CPU the recognizer is skipped at codegen time so this path runs zero dispatches. The
   // result map (keyed by `(registry_id, stack_id, mor_node_idx)` packed via the same encoding the gfx variant uses)
-  // lands in `current_max_reducer_results_` for the per-task `publish_adstack_metadata` loop to pick up. Caller
-  // invokes this BEFORE the per-task `publish_adstack_metadata` loop. Returns `void` because callers consume the
-  // result through `current_max_reducer_results_` rather than the return value; this keeps the post-cache-hit fast
-  // path free of result-map copies.
+  // lands in `current_max_reducer_results_` for the per-task `publish_adstack_metadata` loop to pick up. Caller invokes
+  // this BEFORE the per-task `publish_adstack_metadata` loop. Returns `void` because callers consume the result through
+  // `current_max_reducer_results_` rather than the return value; this keeps the post-cache-hit fast path free of
+  // result-map copies.
   void dispatch_max_reducers_for_tasks(const std::vector<AdStackSizingInfo> &ad_stacks,
                                        LaunchContextBuilder *ctx,
                                        void *device_runtime_context_ptr);
@@ -214,11 +214,11 @@ class LlvmRuntimeExecutor {
   /* ---- Adstack helpers --- */
   /* ----------------------- */
   // Shared implementation for both `dispatch_max_reducers_for_tasks` overloads. Takes a stable per-kernel-handle
-  // `launch_cache_key` (the address of the caller's `tasks` / `ad_stacks` vector) and a non-owning pointer view of
-  // the per-task `AdStackSizingInfo`s. Avoids the per-launch deep copy of `AdStackSizingInfo` the OffloadedTask
-  // overload used to do, and short-circuits on a kernel-level dependency-fingerprint hit before walking specs (logic
-  // factored into `AdStackCache::try_max_reducer_launch_cache_hit` / `record_max_reducer_launch_cache`). Result lands
-  // in `current_max_reducer_results_`; returns `void` to keep the cache-hit fast path free of result-map copies.
+  // `launch_cache_key` (the address of the caller's `tasks` / `ad_stacks` vector) and a non-owning pointer view of the
+  // per-task `AdStackSizingInfo`s. Avoids the per-launch deep copy of `AdStackSizingInfo` the OffloadedTask overload
+  // used to do, and short-circuits on a kernel-level dependency-fingerprint hit before walking specs (logic factored
+  // into `AdStackCache::try_max_reducer_launch_cache_hit` / `record_max_reducer_launch_cache`). Result lands in
+  // `current_max_reducer_results_`; returns `void` to keep the cache-hit fast path free of result-map copies.
   void dispatch_max_reducers_impl(const void *launch_cache_key,
                                   const std::vector<const AdStackSizingInfo *> &ad_stacks,
                                   LaunchContextBuilder *ctx,
@@ -366,11 +366,11 @@ class LlvmRuntimeExecutor {
   void *runtime_adstack_max_reducer_outputs_field_ptr_{nullptr};
 
   // Per-launch transient: shared, read-only view of the `MaxReducerResultMap` populated by
-  // `dispatch_max_reducers_for_tasks` and read by `publish_adstack_metadata`. Held as a `shared_ptr<const map>` so
-  // the per-launch fast path can repoint this field to the cached entry's map without copying it (refcount bump
-  // only), and so a `publish_adstack_metadata` snapshot survives a recursive snode-reader-kernel reentry that may
-  // rewrite this field. Reset to a fresh empty map at the top of every `dispatch_max_reducers_for_tasks` call so a
-  // kernel without captured specs sees an empty view.
+  // `dispatch_max_reducers_for_tasks` and read by `publish_adstack_metadata`. Held as a `shared_ptr<const map>` so the
+  // per-launch fast path can repoint this field to the cached entry's map without copying it (refcount bump only), and
+  // so a `publish_adstack_metadata` snapshot survives a recursive snode-reader-kernel reentry that may rewrite this
+  // field. Reset to a fresh empty map at the top of every `dispatch_max_reducers_for_tasks` call so a kernel without
+  // captured specs sees an empty view.
   std::shared_ptr<const std::unordered_map<uint64_t, int64_t>> current_max_reducer_results_;
 
   // Host-owned storage for the per-kernel lazy-claim arrays: `adstack_row_counters_alloc_`: u32[num_tasks] atomic

--- a/quadrants/runtime/llvm/llvm_runtime_executor.h
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.h
@@ -185,24 +185,23 @@ class LlvmRuntimeExecutor {
 
   // Max-reducer dispatch on LLVM. For each captured `StaticAdStackMaxReducerSpec` across every task in `tasks`, hits
   // `AdStackCache::try_max_reducer_cache_hit` first; on miss h2d-copies the params blob + body bytecode and invokes
-  // `runtime_eval_adstack_max_reduce` via the runtime JIT as a grid-strided launch with an `atomic_max_i64`
-  // reduction. CUDA and AMDGPU only; on CPU the recognizer is skipped at codegen time so this path runs zero
-  // dispatches. The returned map is keyed by `(registry_id, stack_id, mor_node_idx)` packed via the same encoding the
-  // gfx variant uses, so `substitute_precomputed_max_over_range` works backend-agnostically. Caller invokes this
-  // BEFORE the per-task `publish_adstack_metadata` loop and passes the result map down to each per-task `publish`
-  // call so the encoder substitutes captured `MaxOverRange`s before walking the tree. `MaxReducerResultMap` is
-  // defined in `quadrants/program/adstack_size_expr_eval.h`; declared inline here to avoid pulling that header into
-  // every translation unit that includes `llvm_runtime_executor.h`.
-  std::unordered_map<uint64_t, int64_t> dispatch_max_reducers_for_tasks(const std::vector<AdStackSizingInfo> &ad_stacks,
-                                                                        LaunchContextBuilder *ctx,
-                                                                        void *device_runtime_context_ptr);
+  // `runtime_eval_adstack_max_reduce` via the runtime JIT as a grid-strided launch with an `atomic_max_i64` reduction.
+  // CUDA and AMDGPU only; on CPU the recognizer is skipped at codegen time so this path runs zero dispatches. The
+  // result map (keyed by `(registry_id, stack_id, mor_node_idx)` packed via the same encoding the gfx variant uses)
+  // lands in `current_max_reducer_results_` for the per-task `publish_adstack_metadata` loop to pick up. Caller
+  // invokes this BEFORE the per-task `publish_adstack_metadata` loop. Returns `void` because callers consume the
+  // result through `current_max_reducer_results_` rather than the return value; this keeps the post-cache-hit fast
+  // path free of result-map copies.
+  void dispatch_max_reducers_for_tasks(const std::vector<AdStackSizingInfo> &ad_stacks,
+                                       LaunchContextBuilder *ctx,
+                                       void *device_runtime_context_ptr);
   // Convenience overload that extracts each task's `ad_stack` and forwards to the primary entry point. Lets the CUDA /
   // AMDGPU per-arch launchers call into the dispatcher with the `OffloadedTask` list they already hold, without each
   // launcher copy-pasting the per-task `ad_stack` extraction loop. Forwards a pointer-view of the per-task `ad_stack`s
   // to `dispatch_max_reducers_impl` (no deep copy of the `AdStackSizingInfo`s).
-  std::unordered_map<uint64_t, int64_t> dispatch_max_reducers_for_tasks(const std::vector<OffloadedTask> &tasks,
-                                                                        LaunchContextBuilder *ctx,
-                                                                        void *device_runtime_context_ptr);
+  void dispatch_max_reducers_for_tasks(const std::vector<OffloadedTask> &tasks,
+                                       LaunchContextBuilder *ctx,
+                                       void *device_runtime_context_ptr);
 
   // Return (and lazily cache) the device pointer to `runtime->temporaries`, the global temporary buffer backing
   // `GlobalTemporaryStmt` loads and stores. GPU kernel launchers use this to read back dynamic range_for bounds (begin
@@ -218,12 +217,12 @@ class LlvmRuntimeExecutor {
   // `launch_cache_key` (the address of the caller's `tasks` / `ad_stacks` vector) and a non-owning pointer view of
   // the per-task `AdStackSizingInfo`s. Avoids the per-launch deep copy of `AdStackSizingInfo` the OffloadedTask
   // overload used to do, and short-circuits on a kernel-level dependency-fingerprint hit before walking specs (logic
-  // factored into `AdStackCache::try_max_reducer_launch_cache_hit` / `record_max_reducer_launch_cache`).
-  std::unordered_map<uint64_t, int64_t> dispatch_max_reducers_impl(
-      const void *launch_cache_key,
-      const std::vector<const AdStackSizingInfo *> &ad_stacks,
-      LaunchContextBuilder *ctx,
-      void *device_runtime_context_ptr);
+  // factored into `AdStackCache::try_max_reducer_launch_cache_hit` / `record_max_reducer_launch_cache`). Result lands
+  // in `current_max_reducer_results_`; returns `void` to keep the cache-hit fast path free of result-map copies.
+  void dispatch_max_reducers_impl(const void *launch_cache_key,
+                                  const std::vector<const AdStackSizingInfo *> &ad_stacks,
+                                  LaunchContextBuilder *ctx,
+                                  void *device_runtime_context_ptr);
 
   /* ----------------------- */
   /* ------ Allocation ----- */
@@ -366,12 +365,13 @@ class LlvmRuntimeExecutor {
   // pointer to this address so `runtime_eval_adstack_max_reduce` deref's the live allocation.
   void *runtime_adstack_max_reducer_outputs_field_ptr_{nullptr};
 
-  // Per-launch transient: the `MaxReducerResultMap` populated by `dispatch_max_reducers_for_tasks` and read by
-  // `publish_adstack_metadata`. Owned by the executor across the per-task publish loop within a single kernel launch;
-  // cleared at the top of every `dispatch_max_reducers_for_tasks` call so a kernel without captured specs sees an empty
-  // map. Keeping the map on the executor avoids threading it through `publish_adstack_metadata`'s call sites in three
-  // per-arch launchers.
-  std::unordered_map<uint64_t, int64_t> current_max_reducer_results_;
+  // Per-launch transient: shared, read-only view of the `MaxReducerResultMap` populated by
+  // `dispatch_max_reducers_for_tasks` and read by `publish_adstack_metadata`. Held as a `shared_ptr<const map>` so
+  // the per-launch fast path can repoint this field to the cached entry's map without copying it (refcount bump
+  // only), and so a `publish_adstack_metadata` snapshot survives a recursive snode-reader-kernel reentry that may
+  // rewrite this field. Reset to a fresh empty map at the top of every `dispatch_max_reducers_for_tasks` call so a
+  // kernel without captured specs sees an empty view.
+  std::shared_ptr<const std::unordered_map<uint64_t, int64_t>> current_max_reducer_results_;
 
   // Host-owned storage for the per-kernel lazy-claim arrays: `adstack_row_counters_alloc_`: u32[num_tasks] atomic
   // counter the codegen-emitted LCA-block row claim atomic-rmws

--- a/tests/cpp/program/test_diagnose_adstack_overflow.cpp
+++ b/tests/cpp/program/test_diagnose_adstack_overflow.cpp
@@ -44,13 +44,13 @@ TEST(DiagnoseAdstackOverflow, RegistryAndLookup) {
   EXPECT_FALSE(prog.adstack_cache().lookup_adstack_sizing_info(static_cast<uint32_t>(0xfffffffful)).has_value());
 }
 
-// `register_adstack_sizing_info` content-stable hash dedup. Two registrations with the same
-// `(kernel_name, task_id_in_kernel)` pair but different `identity_key`s (the runtime case: a re-codegen of the
-// same source after a `qd.reset()` produces a fresh `ad_stack` at a new heap address but the hash inputs are
-// unchanged) must resolve to the same id - otherwise the codegen-baked immediate in the cached LLVM IR would
-// point at one entry while the runtime registration mints another, and the diagnose-on-overflow path would
-// look up the wrong (or empty) entry. Pins the linear-probe loop's same-content branch, which the
-// `RegistryAndLookup` test above does not cover (it only re-uses the same identity_key).
+// `register_adstack_sizing_info` content-stable hash dedup. Two registrations with the same `(kernel_name,
+// task_id_in_kernel)` pair but different `identity_key`s (the runtime case: a re-codegen of the same source after a
+// `qd.reset()` produces a fresh `ad_stack` at a new heap address but the hash inputs are unchanged) must resolve to the
+// same id - otherwise the codegen-baked immediate in the cached LLVM IR would point at one entry while the runtime
+// registration mints another, and the diagnose-on-overflow path would look up the wrong (or empty) entry. Pins the
+// linear-probe loop's same-content branch, which the `RegistryAndLookup` test above does not cover (it only re-uses the
+// same identity_key).
 TEST(DiagnoseAdstackOverflow, RegistryContentStableDedupAcrossIdentityKeys) {
   Program prog(host_arch());
 
@@ -87,9 +87,9 @@ TEST(DiagnoseAdstackOverflow, RegistryContentStableDedupAcrossIdentityKeys) {
                                                         /*size_exprs=*/{});
   EXPECT_EQ(id_a, id_b_redo);
 
-  // A different `(kernel_name, task_id_in_kernel)` pair must hash to a different id (assuming no collision -
-  // 32-bit FNV-1a collision probability for a handful of distinct keys is vanishingly low). Pins that the
-  // dedup branch above only triggers on actual content match, not on every re-registration.
+  // A different `(kernel_name, task_id_in_kernel)` pair must hash to a different id (assuming no collision - 32-bit
+  // FNV-1a collision probability for a handful of distinct keys is vanishingly low). Pins that the dedup branch above
+  // only triggers on actual content match, not on every re-registration.
   int dummy_c = 0;
   uint32_t id_c =
       prog.adstack_cache().register_adstack_sizing_info(static_cast<const void *>(&dummy_c), "compute_other",

--- a/tests/cpp/program/test_diagnose_adstack_overflow.cpp
+++ b/tests/cpp/program/test_diagnose_adstack_overflow.cpp
@@ -44,6 +44,61 @@ TEST(DiagnoseAdstackOverflow, RegistryAndLookup) {
   EXPECT_FALSE(prog.adstack_cache().lookup_adstack_sizing_info(static_cast<uint32_t>(0xfffffffful)).has_value());
 }
 
+// `register_adstack_sizing_info` content-stable hash dedup. Two registrations with the same
+// `(kernel_name, task_id_in_kernel)` pair but different `identity_key`s (the runtime case: a re-codegen of the
+// same source after a `qd.reset()` produces a fresh `ad_stack` at a new heap address but the hash inputs are
+// unchanged) must resolve to the same id - otherwise the codegen-baked immediate in the cached LLVM IR would
+// point at one entry while the runtime registration mints another, and the diagnose-on-overflow path would
+// look up the wrong (or empty) entry. Pins the linear-probe loop's same-content branch, which the
+// `RegistryAndLookup` test above does not cover (it only re-uses the same identity_key).
+TEST(DiagnoseAdstackOverflow, RegistryContentStableDedupAcrossIdentityKeys) {
+  Program prog(host_arch());
+
+  int dummy_a = 0;
+  int dummy_b = 0;  // Different identity_key, same content.
+  uint32_t id_a = prog.adstack_cache().register_adstack_sizing_info(static_cast<const void *>(&dummy_a), "compute_grad",
+                                                                    /*task=*/3,
+                                                                    /*allocated_max_sizes=*/{16, 32},
+                                                                    /*size_exprs=*/{});
+  uint32_t id_b = prog.adstack_cache().register_adstack_sizing_info(static_cast<const void *>(&dummy_b), "compute_grad",
+                                                                    /*task=*/3,
+                                                                    /*allocated_max_sizes=*/{8, 4},
+                                                                    /*size_exprs=*/{});
+  EXPECT_NE(id_a, 0u);
+  // Same content yields the same id even though `identity_key` differs.
+  EXPECT_EQ(id_a, id_b);
+  // The second call's metadata wins (latest re-registration overwrites the entry in place).
+  auto entry = prog.adstack_cache().lookup_adstack_sizing_info(id_b);
+  ASSERT_TRUE(entry.has_value());
+  EXPECT_EQ(entry->kernel_name, "compute_grad");
+  EXPECT_EQ(entry->task_id_in_kernel, 3);
+  EXPECT_EQ(entry->allocated_max_sizes, std::vector<int>({8, 4}));
+  // Both identity_keys now resolve to the same id - re-registering with either pointer returns id_a.
+  uint32_t id_a_redo =
+      prog.adstack_cache().register_adstack_sizing_info(static_cast<const void *>(&dummy_a), "compute_grad",
+                                                        /*task=*/3,
+                                                        /*allocated_max_sizes=*/{1, 2},
+                                                        /*size_exprs=*/{});
+  EXPECT_EQ(id_a, id_a_redo);
+  uint32_t id_b_redo =
+      prog.adstack_cache().register_adstack_sizing_info(static_cast<const void *>(&dummy_b), "compute_grad",
+                                                        /*task=*/3,
+                                                        /*allocated_max_sizes=*/{1, 2},
+                                                        /*size_exprs=*/{});
+  EXPECT_EQ(id_a, id_b_redo);
+
+  // A different `(kernel_name, task_id_in_kernel)` pair must hash to a different id (assuming no collision -
+  // 32-bit FNV-1a collision probability for a handful of distinct keys is vanishingly low). Pins that the
+  // dedup branch above only triggers on actual content match, not on every re-registration.
+  int dummy_c = 0;
+  uint32_t id_c =
+      prog.adstack_cache().register_adstack_sizing_info(static_cast<const void *>(&dummy_c), "compute_other",
+                                                        /*task=*/3,
+                                                        /*allocated_max_sizes=*/{1},
+                                                        /*size_exprs=*/{});
+  EXPECT_NE(id_a, id_c);
+}
+
 // Diagnose with an unknown / sentinel id falls back to the generic dual-cause body without crashing.
 // The body must mention BOTH causes (DLPack bypass and Quadrants bug) so the user has actionable
 // recovery information regardless of whether the runtime captured the offending task identity.

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -329,11 +329,11 @@ def test_max_reducer_registry_seeded_on_offline_cache_reload(curr_arch):
         first_run_dispatches >= 1
     ), f"first run with cache_miss should dispatch at least once; got {first_run_dispatches}"
 
-    # Second init: cache hit, codegen skipped, kernels loaded from disk. The per-spec
-    # `AdStackCache::max_reducer_cache_` is in-memory only and starts fresh, so the dispatcher must still fire on
-    # the FIRST launch of the cache-loaded kernel - this is the test's load-bearing assertion. Without the
-    # registry-seeding helper, the dispatcher's `if (registry_id == 0) continue` gate would skip the spec
-    # (because the per-`Program` registry is empty at this point) and the counter would stay at zero.
+    # Second init: cache hit, codegen skipped, kernels loaded from disk. The per-spec `AdStackCache::max_reducer_cache_`
+    # is in-memory only and starts fresh, so the dispatcher must still fire on the FIRST launch of the cache-loaded
+    # kernel - this is the test's load-bearing assertion. Without the registry-seeding helper, the dispatcher's
+    # `if (registry_id == 0) continue` gate would skip the spec (because the per-`Program` registry is empty at this
+    # point) and the counter would stay at zero.
     qd.init(arch=curr_arch, enable_fallback=False, ad_stack_experimental_enabled=True, **current_thread_ext_options())
     second_run_dispatches = helper()
     assert (

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -260,6 +260,87 @@ def test_offline_cache_per_kernel(curr_arch):
         _test_offline_cache_for_a_kernel(curr_arch=curr_arch, kernel=kernel, args=args, result=get_res(*args))
 
 
+# Pins `AdStackCache::ensure_runtime_registry_ids_for_max_reducer`'s offline-cache reload path. On a fresh codegen
+# run the registry is seeded by `register_adstack_sizing_info` calls inside
+# `codegen_llvm.cpp::finalize_offloaded_task_function`, so the runtime helper's loop body is short-circuited by the
+# `is_adstack_sizing_info_registered` fast-path gate. Only on offline-cache reload (codegen skipped, kernels loaded
+# from disk) does the helper actually do work: re-deriving `(kernel_name, task_id_in_kernel)` from the serialised
+# `AdStackSizingInfo` fields and minting the same content-stable hash id the codegen-baked LLVM IR's overflow
+# `cmpxchg` immediate references. Without that helper a cache-loaded max-reducer kernel would have
+# `registry_id` correctly populated (since #635 follow-ups serialise it), but the per-`Program` registry would stay
+# empty and the dispatcher's `if (registry_id == 0) continue` gate (read against the cache-loaded `ad_stack`) AND
+# the diagnose-on-overflow path would both silently fail. The test below dispatches a max-reducer kernel twice with
+# offline_cache=True; the second run is a cache hit on disk but the per-spec in-memory cache is fresh, so the
+# dispatch must fire and the counter must advance. A regression in the registry-seeding helper would leave the
+# counter at zero (dispatcher gate skips). Restricted to LLVM-GPU arches because the recognizer is gated on those
+# (`codegen_llvm.cpp::finalize_offloaded_task_function` skips it on CPU per #655); the SPIR-V backend has its own
+# runtime re-registration loop in `runtime/gfx/adstack_sizer_launch.cpp:236` that is unaffected by this PR.
+@pytest.mark.parametrize("curr_arch", {qd.cuda, qd.amdgpu} & set(test_utils.expected_archs()))
+@_test_offline_cache_dec
+def test_max_reducer_registry_seeded_on_offline_cache_reload(curr_arch):
+    import numpy as np
+
+    from quadrants.lang import impl
+
+    arch_supported = qd.lang.misc.is_extension_supported(curr_arch, qd.extension.adstack)
+    if not arch_supported:
+        pytest.skip(reason=f"architecture not supported for adstack {curr_arch}")
+
+    N = 4
+
+    def helper():
+        # Outer parallel-for over `a.shape[0]` with an inner `range(a[i])` is the canonical shape the recognizer
+        # captures as `MaxOverRange(0, a.shape[0], a[i])` - same body grammar as
+        # `test_max_reducer_dispatch_counts_advance_on_input_mutation`, copied here to avoid dragging the whole
+        # test setup helper into this file.
+        x = qd.field(qd.f32, shape=(N,), needs_grad=True)
+        y = qd.field(qd.f32, shape=(), needs_grad=True)
+
+        @qd.kernel
+        def compute(a: qd.types.ndarray(dtype=qd.i32, ndim=1)):
+            for i in range(a.shape[0]):
+                v = x[i]
+                n = a[i]
+                for _ in range(n):
+                    v = v * 0.95 + 0.01
+                y[None] += v
+
+        a = qd.ndarray(qd.i32, shape=(N,))
+        a.from_numpy(np.array([2, 3, 1, 2], dtype=np.int32))
+        for i in range(N):
+            x[i] = 0.1
+
+        prog = impl.get_runtime().prog
+        prog._reset_max_reducer_dispatch_count()
+        compute(a)
+        y.grad[None] = 1.0
+        for i in range(N):
+            x.grad[i] = 0.0
+        compute.grad(a)
+        qd.sync()
+        return prog._get_max_reducer_dispatch_count()
+
+    # First init: codegen runs, recognizer captures specs, dispatcher fires (per-spec cache miss), kernels written
+    # to the offline cache including the new `(kernel_name, task_id_in_kernel, registry_id)` fields on
+    # `AdStackSizingInfo`.
+    qd.init(arch=curr_arch, enable_fallback=False, ad_stack_experimental_enabled=True, **current_thread_ext_options())
+    first_run_dispatches = helper()
+    assert (
+        first_run_dispatches >= 1
+    ), f"first run with cache_miss should dispatch at least once; got {first_run_dispatches}"
+
+    # Second init: cache hit, codegen skipped, kernels loaded from disk. The per-spec
+    # `AdStackCache::max_reducer_cache_` is in-memory only and starts fresh, so the dispatcher must still fire on
+    # the FIRST launch of the cache-loaded kernel - this is the test's load-bearing assertion. Without the
+    # registry-seeding helper, the dispatcher's `if (registry_id == 0) continue` gate would skip the spec
+    # (because the per-`Program` registry is empty at this point) and the counter would stay at zero.
+    qd.init(arch=curr_arch, enable_fallback=False, ad_stack_experimental_enabled=True, **current_thread_ext_options())
+    second_run_dispatches = helper()
+    assert (
+        second_run_dispatches >= 1
+    ), f"second run on cache-hit must still dispatch (registry seeding); got {second_run_dispatches}"
+
+
 @pytest.mark.parametrize("curr_arch", supported_archs_offline_cache)
 @_test_offline_cache_dec
 def test_multiple_ib_with_offline_cache(curr_arch):

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -260,19 +260,19 @@ def test_offline_cache_per_kernel(curr_arch):
         _test_offline_cache_for_a_kernel(curr_arch=curr_arch, kernel=kernel, args=args, result=get_res(*args))
 
 
-# Pins `AdStackCache::ensure_runtime_registry_ids_for_max_reducer`'s offline-cache reload path. On a fresh codegen
-# run the registry is seeded by `register_adstack_sizing_info` calls inside
+# Pins `AdStackCache::ensure_runtime_registry_ids_for_max_reducer`'s offline-cache reload path. On a fresh codegen run
+# the registry is seeded by `register_adstack_sizing_info` calls inside
 # `codegen_llvm.cpp::finalize_offloaded_task_function`, so the runtime helper's loop body is short-circuited by the
-# `is_adstack_sizing_info_registered` fast-path gate. Only on offline-cache reload (codegen skipped, kernels loaded
-# from disk) does the helper actually do work: re-deriving `(kernel_name, task_id_in_kernel)` from the serialised
-# `AdStackSizingInfo` fields and minting the same content-stable hash id the codegen-baked LLVM IR's overflow
-# `cmpxchg` immediate references. Without that helper a cache-loaded max-reducer kernel would have
-# `registry_id` correctly populated (since #635 follow-ups serialise it), but the per-`Program` registry would stay
-# empty and the dispatcher's `if (registry_id == 0) continue` gate (read against the cache-loaded `ad_stack`) AND
-# the diagnose-on-overflow path would both silently fail. The test below dispatches a max-reducer kernel twice with
-# offline_cache=True; the second run is a cache hit on disk but the per-spec in-memory cache is fresh, so the
-# dispatch must fire and the counter must advance. A regression in the registry-seeding helper would leave the
-# counter at zero (dispatcher gate skips). Restricted to LLVM-GPU arches because the recognizer is gated on those
+# `is_adstack_sizing_info_registered` fast-path gate. Only on offline-cache reload (codegen skipped, kernels loaded from
+# disk) does the helper actually do work: re-deriving `(kernel_name, task_id_in_kernel)` from the serialised
+# `AdStackSizingInfo` fields and minting the same content-stable hash id the codegen-baked LLVM IR's overflow `cmpxchg`
+# immediate references. Without that helper a cache-loaded max-reducer kernel would have `registry_id` correctly
+# populated (since #635 follow-ups serialise it), but the per-`Program` registry would stay empty and the dispatcher's
+# `if (registry_id == 0) continue` gate (read against the cache-loaded `ad_stack`) AND the diagnose-on-overflow path
+# would both silently fail. The test below dispatches a max-reducer kernel twice with offline_cache=True; the second run
+# is a cache hit on disk but the per-spec in-memory cache is fresh, so the dispatch must fire and the counter must
+# advance. A regression in the registry-seeding helper would leave the counter at zero (dispatcher gate skips).
+# Restricted to LLVM-GPU arches because the recognizer is gated on those
 # (`codegen_llvm.cpp::finalize_offloaded_task_function` skips it on CPU per #655); the SPIR-V backend has its own
 # runtime re-registration loop in `runtime/gfx/adstack_sizer_launch.cpp:236` that is unaffected by this PR.
 @pytest.mark.parametrize("curr_arch", {qd.cuda, qd.amdgpu} & set(test_utils.expected_archs()))
@@ -291,8 +291,8 @@ def test_max_reducer_registry_seeded_on_offline_cache_reload(curr_arch):
     def helper():
         # Outer parallel-for over `a.shape[0]` with an inner `range(a[i])` is the canonical shape the recognizer
         # captures as `MaxOverRange(0, a.shape[0], a[i])` - same body grammar as
-        # `test_max_reducer_dispatch_counts_advance_on_input_mutation`, copied here to avoid dragging the whole
-        # test setup helper into this file.
+        # `test_max_reducer_dispatch_counts_advance_on_input_mutation`, copied here to avoid dragging the whole test
+        # setup helper into this file.
         x = qd.field(qd.f32, shape=(N,), needs_grad=True)
         y = qd.field(qd.f32, shape=(), needs_grad=True)
 
@@ -320,9 +320,8 @@ def test_max_reducer_registry_seeded_on_offline_cache_reload(curr_arch):
         qd.sync()
         return prog._get_max_reducer_dispatch_count()
 
-    # First init: codegen runs, recognizer captures specs, dispatcher fires (per-spec cache miss), kernels written
-    # to the offline cache including the new `(kernel_name, task_id_in_kernel, registry_id)` fields on
-    # `AdStackSizingInfo`.
+    # First init: codegen runs, recognizer captures specs, dispatcher fires (per-spec cache miss), kernels written to
+    # the offline cache including the new `(kernel_name, task_id_in_kernel, registry_id)` fields on `AdStackSizingInfo`.
     qd.init(arch=curr_arch, enable_fallback=False, ad_stack_experimental_enabled=True, **current_thread_ext_options())
     first_run_dispatches = helper()
     assert (
@@ -331,9 +330,9 @@ def test_max_reducer_registry_seeded_on_offline_cache_reload(curr_arch):
 
     # Second init: cache hit, codegen skipped, kernels loaded from disk. The per-spec `AdStackCache::max_reducer_cache_`
     # is in-memory only and starts fresh, so the dispatcher must still fire on the FIRST launch of the cache-loaded
-    # kernel - this is the test's load-bearing assertion. Without the registry-seeding helper, the dispatcher's
-    # `if (registry_id == 0) continue` gate would skip the spec (because the per-`Program` registry is empty at this
-    # point) and the counter would stay at zero.
+    # kernel - this is the test's load-bearing assertion. Without the registry-seeding helper, the dispatcher's `if
+    # (registry_id == 0) continue` gate would skip the spec (because the per-`Program` registry is empty at this point)
+    # and the counter would stay at zero.
     qd.init(arch=curr_arch, enable_fallback=False, ad_stack_experimental_enabled=True, **current_thread_ext_options())
     second_run_dispatches = helper()
     assert (


### PR DESCRIPTION
# Adstack max-reducer: launch cache + zero-copy result map; content-stable registry_id

> Three commits stacked on top of #635. Two restore the AMDGPU autodiff hot-path FPS that #635 lost (`280 → 350 FPS`, +25% on the rigid-step repro), one fixes a latent offline-cache correctness gap that surfaced as `_get_max_reducer_dispatch_count() >= 1` failing across the AMDGPU `test_max_reducer_*` suite. All three are scoped to the LLVM-side adstack plumbing; the SPIR-V backend is untouched.

## TL;DR

`QD_OFFLINE_CACHE=0 GS_ENABLE_NDARRAY=0 python repro_amdgpu_rigid_step.py` (RX 7900 XTX, 100 substeps + 1 backward, 3-trial median):

| state | trial 0 | trial 1 | trial 2 |
|---|---|---|---|
| #635 (regressed) | 277.6 FPS | 283.3 FPS | 283.8 FPS |
| #635 + commit 1 (drop deep copy + per-launch cache) | 318.2 FPS | 322.5 FPS | 324.7 FPS |
| #635 + commit 1 + 2 (shared_ptr<const map>) | 342.0 FPS | 348.1 FPS | 351.9 FPS |
| this PR (= #635 + commits 1 + 2 + 3) | 348.1 FPS | 348.1 FPS | 349.2 FPS |
| upper bound (full skip via env-gate) | 357.8 FPS | 367.6 FPS | 368.9 FPS |

AMDGPU `test_max_reducer_*` suite (`QD_WANTED_ARCHS=amdgpu pytest -k max_reducer`):

| state | passed | failed |
|---|---|---|
| #635 | 1 | 15 |
| this PR | 16 | 0 |

## Why

#635 introduced `LlvmRuntimeExecutor::dispatch_max_reducers_for_tasks` to dispatch captured `MaxOverRange` specs in parallel. The dispatcher's design expectation was that the per-spec `AdStackCache::max_reducer_cache_` would short-circuit every launch after the first - and instrumentation confirms it does (99.75% per-spec hit rate, near-zero GPU dispatches in steady state). But the hot-path host-side bookkeeping the dispatcher does on the way to that short-circuit added ~290 ms across 2008 launches in the rigid-step bench - about 27% of trial wallclock - dominated by:

1. The OffloadedTask overload's per-launch deep copy of every task's `AdStackSizingInfo` into a `std::vector<AdStackSizingInfo> ad_stacks_view`, including the embedded `size_exprs` / `allocas` / `bound_expr` / `max_reducer_specs` sub-vectors. Probe data: 125.2 ms / 290 ms (43%) was this single copy loop.
2. An O(specs) hash-lookup-and-observation-replay loop walking every captured spec through `try_max_reducer_cache_hit`. Probe data: 62.8 ms / 290 ms (22%).
3. The `current_max_reducer_results_` value-typed map: copied once per launch from the cache entry, then snapshotted again per task in `publish_adstack_metadata` (the recursive-reentry guard). With ~600 entries per map and ~1.8 tasks per call, that's ~3.4 M map entries copied across the trial.

Separately, `AdStackSizingInfo::registry_id` was excluded from `QD_IO_DEF` under the rationale *"ids are per-`Program` lifetime; a deserialised task re-registers itself at the next launch."* That comment was aspirational on the LLVM path - only the SPIR-V launcher actually re-registered (in `adstack_sizer_launch.cpp`). After offline-cache reload an LLVM kernel had `registry_id == 0`, so the dispatcher's `if (registry_id == 0) continue` gate skipped every spec, the per-thread sizer fell through to its `1<<24` host-eval cap, and the dispatch silently no-op'd. This is what `test_max_reducer_pins_stride_for_oversized_axis[arch=amdgpu-*]` and the dispatch-counter tests were exposing. The gate also affected the diagnose-on-overflow path: the codegen-baked `cmpxchg(0, registry_id)` immediate IS preserved through the LLVM IR text in the offline cache, so on cache reload the LLVM IR wrote an old sequential id while the host registry was empty - any overflow on a freshly cache-loaded kernel would print the generic dual-cause fallback instead of the offending kernel + task identity.

## Surface behavior

- AMDGPU autodiff hot path recovers to ~350 FPS from #635's ~280 FPS on the rigid-step repro. CUDA / CPU paths are equivalent on the same code paths (they go through the same LLVM dispatcher) but the perf win there is smaller because their per-launch baseline was already lower-overhead. No API or output-numerics change on any backend.
- `_get_max_reducer_dispatch_count()` now matches between cache-miss and cache-hit launches on AMDGPU. Before this PR a fresh test process on a warm `~/.cache/quadrants/` returned 0 dispatches and silently used the per-thread sizer's worst-case enumeration; now the dispatcher fires correctly on the first launch and the subsequent per-spec / per-launch caches short-circuit identically to the cache-miss path.
- An overflow on a cache-loaded kernel now resolves to the matching `kernel + task` identity in the diagnose message instead of the generic dual-cause fallback. This was a latent bug that affected all LLVM backends, not just AMDGPU - the AMDGPU test suite is what surfaced it.

## Mechanism end-to-end

### 1. Drop the per-launch `AdStackSizingInfo` deep copy

Before, `dispatch_max_reducers_for_tasks(const std::vector<OffloadedTask> &)` materialised `std::vector<AdStackSizingInfo>` by copy and forwarded to the AdStackSizingInfo overload. This commit refactors both public overloads to forward a `std::vector<const AdStackSizingInfo *>` pointer-view to a private `dispatch_max_reducers_impl(launch_cache_key, ad_stacks_view, ctx, dev_ctx)` - no `AdStackSizingInfo` copies, no per-launch allocation cliff. The launch cache key is the address of the launcher's stable per-handle vector (`KernelLauncher::contexts_[i].offloaded_tasks` for CUDA / AMDGPU, `ad_stacks` for the CPU launcher); the address is reused on every launch of the same kernel handle so it serves as a stable identity.

| file | change |
|---|---|
| `quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp` | Both public overloads build `std::vector<const AdStackSizingInfo *>` pointer-views (no `AdStackSizingInfo` copies) and forward to the new private `dispatch_max_reducers_impl`. The inner loop's `ad_stack` accessor changes from `ad_stacks[ti]` to `*ad_stacks[ti]`. |
| `quadrants/runtime/llvm/llvm_runtime_executor.h` | Adds the private `dispatch_max_reducers_impl` declaration. |

### 2. Add a per-kernel-handle launch cache

`AdStackCache::try_max_reducer_launch_cache_hit` and `record_max_reducer_launch_cache` factor the launch-cache logic into the existing adstack cache module. The cache entry stores a deduplicated `(snode_id, gen)` / `(arg_id, devalloc, gen)` snapshot covering every spec's observation deps; the fast path replays the snapshot in O(distinct deps) and short-circuits the per-spec walk on full match. Slow path falls through to today's per-spec cache.

| file | change |
|---|---|
| `quadrants/program/adstack/cache.h` | New `MaxReducerLaunchCacheEntry` / `ArgGenObservation` types nested in `AdStackCache`; new `max_reducer_launch_cache_` field; `try_max_reducer_launch_cache_hit` / `record_max_reducer_launch_cache` / `invalidate_max_reducer_launch` declarations; `invalidate_all_per_task` extended to clear the new map. |
| `quadrants/program/adstack/cache.cpp` | Method bodies. The dependency aggregation walks each spec's recorded observations via `lookup_max_reducer_reads`; deduplication keeps the replay O(distinct deps) instead of O(specs * obs/spec). |
| `quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp` | `dispatch_max_reducers_impl` calls `try_max_reducer_launch_cache_hit` at the top and `record_max_reducer_launch_cache` at the bottom of every successful dispatch. |

### 3. Switch `current_max_reducer_results_` to `shared_ptr<const map>`

The cache entry from step 2 stored its result map by value; the executor field was also value-typed and copied from the entry on every fast-path hit. Replacing both with `std::shared_ptr<const std::unordered_map<uint64_t, int64_t>>` collapses the fast-path assignment to a refcount bump (no map data is copied). The cache entry retains its own `shared_ptr` so the per-task `local_max_reducer_results = current_max_reducer_results_` snapshot in `publish_adstack_metadata` (the recursive-reentry defence) becomes a refcount bump too, and the cache-entry's allocation stays alive even if a recursive snode-reader-kernel reentry repoints the executor's transient mid-walk. The slow path wraps `result` in a `shared_ptr` once at the end and hands the same allocation to both the cache entry and the executor field. Both `dispatch_max_reducers_for_tasks` overloads (and the private `dispatch_max_reducers_impl`) now return `void` since callers only read the result through `current_max_reducer_results_`.

| file | change |
|---|---|
| `quadrants/program/adstack/max_reducer.h` | New `MaxReducerResultMapPtr = std::shared_ptr<const MaxReducerResultMap>` alias (shared by the cache entry and the executor field). |
| `quadrants/program/adstack/cache.{h,cpp}` | `MaxReducerLaunchCacheEntry::result` switches to `shared_ptr<const map>`; `try_max_reducer_launch_cache_hit` / `record_max_reducer_launch_cache` signatures updated. |
| `quadrants/runtime/llvm/llvm_runtime_executor.h` | `current_max_reducer_results_` field switches to `shared_ptr<const map>`; both public overloads + the private impl return `void`. |
| `quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp` | Slow path wraps `result` in `make_shared<const ...>` once and shares the allocation between the cache entry and the executor field. The fast path's `current_max_reducer_results_ = std::move(hit)` is now a refcount move. |
| `quadrants/runtime/llvm/adstack_lazy_claim/metadata_publish.cpp` | Consumer dereferences. Per-task snapshot is a `shared_ptr` copy (refcount only); encoder call sites pass `*current_max_reducer_results_` (`dispatch_max_reducers_impl` initialises the field to a non-null empty-map sentinel so the deref is unconditional). |

### 4. Make `registry_id` content-stable and serialise it

Replaces sequential id assignment with a 32-bit FNV-1a folded from `(kernel_name, task_id_in_kernel)`. Same `(kernel_name, task_id_in_kernel)` pair always yields the same id across `Program` lifetimes, re-compiles, and offline-cache reloads. Codegen-baked id and host-side id match by construction. The registry storage switches from `std::vector<Entry>` (sequential indexing) to `std::unordered_map<uint32_t, Entry>` (arbitrary hash keys); collisions linear-probe past occupied slots (1.2e-4 collision probability for 1000 distinct keys with 32-bit FNV-1a). `AdStackSizingInfo` gains `kernel_name` + `task_id_in_kernel` fields so the runtime registration call (the `Program` registry seed for the diagnose path) can re-derive the hash inputs without parsing `OffloadedTask::name`.

| file | change |
|---|---|
| `quadrants/codegen/llvm/llvm_compiled_data.h` | `AdStackSizingInfo` gains `kernel_name` and `task_id_in_kernel` fields; `registry_id` + the two new fields added to `QD_IO_DEF`. |
| `quadrants/codegen/llvm/codegen_llvm.cpp` | Both `register_adstack_sizing_info` call sites in `finalize_offloaded_task_function` populate the two new fields on `current_task->ad_stack` before registering. |
| `quadrants/program/adstack/cache.h` | Registry storage type switches from `std::vector` to `std::unordered_map<uint32_t, AdStackSizingInfoEntry>`; `is_adstack_sizing_info_registered` / `ensure_runtime_registry_ids_for_max_reducer` declarations. |
| `quadrants/program/adstack/cache.cpp` | New `fnv1a32_for_registry` helper; `register_adstack_sizing_info` rewritten to compute id by hash and linear-probe past collisions; `lookup_adstack_sizing_info` / `update_adstack_sizing_info_size_exprs` switch to map find. `ensure_runtime_registry_ids_for_max_reducer` seeds the per-`Program` registry on the first launch of each cache-loaded kernel handle, gated by `is_adstack_sizing_info_registered(&ad_stack)` so steady-state launches are O(1). |
| `quadrants/runtime/llvm/adstack_lazy_claim/bound_eval.cpp` | `dispatch_max_reducers_for_tasks(OffloadedTask)` calls `ensure_runtime_registry_ids_for_max_reducer` once before forwarding into `dispatch_max_reducers_impl`. The `const_cast` is documented; the OffloadedTasks live in non-const launcher storage. |

## Per-backend coverage matrix

| backend | per-launch deep copy dropped | launch cache active | shared_ptr fast path | content-stable registry_id |
|---|---|---|---|---|
| CPU LLVM (x64 / arm64) | ✓ (AdStackSizingInfo overload also routed through pointer-view) | ✓ | ✓ | ✓ (LLVM IR codegen path) |
| CUDA | ✓ | ✓ | ✓ | ✓ |
| AMDGPU | ✓ | ✓ | ✓ | ✓ |
| SPIR-V (Vulkan / Metal) | N/A (gfx runtime has its own dispatcher) | N/A | N/A | N/A (gfx already runtime-registers via `adstack_sizer_launch.cpp:236`) |

## Tests

Existing `tests/python/test_adstack.py` `test_max_reducer_*` suite is the regression coverage:

- `test_max_reducer_pins_stride_for_oversized_axis[arch=amdgpu-*]` (5 parametrisations) - pins that the dispatcher fires for above-`1<<24` ndarray axes on cache-hit, and that `_get_max_reducer_dispatch_count() >= 1` after the first compute + grad. These were the visible AMDGPU CI failures; before this PR they all returned `dispatch_count == 0` on cache hit. Now they all pass on first run AND on cache-hit re-run.
- `test_max_reducer_dispatch_counts_advance_on_input_mutation[arch=amdgpu]` - pins that a host mutation of the gating ndarray bumps `ndarray_data_gen` and forces re-dispatch; would silently regress if the launch cache fast path ignored the new dependency snapshot.
- `test_max_reducer_field_load_bound_var_dispatch[arch=amdgpu-*]` (8 parametrisations) - exercise the SNode-backed `bound_var`-indexed FieldLoad body grammar across the full body-shape matrix; verifies the fast-path replay handles SNode generation deps the same way the per-spec cache does.
- `test_max_reducer_field_load_bound_var_cache_invalidates_on_snode_mutation[arch=amdgpu]` - pins that a SNode write between launches invalidates both the per-spec cache and the new launch cache (the launch-cache `snode_gens` snapshot must carry the post-mutation gen forward).

`repro_amdgpu_rigid_step.py` (the user's profiling script) is the perf regression coverage; numbers in the TL;DR table.

## Side-effect audit

| concern | where checked | verdict |
|---|---|---|
| Offline cache binary compatibility | `AdStackSizingInfo::QD_IO_DEF` adds `registry_id` / `kernel_name` / `task_id_in_kernel` | **Cache invalidation needed.** Existing cached LLVM IR has the old sequential `registry_id` baked in; on reload the JSON metadata won't match the old QD_IO_DEF field set. Users must clear `~/.cache/quadrants/qdcache/` once. |
| Recursive snode-reader-kernel reentry into `dispatch_max_reducers_for_tasks` | `metadata_publish.cpp:327` snapshot via `local_max_reducer_results = current_max_reducer_results_` (now `shared_ptr` copy) | Safe. The cache entry's `shared_ptr` keeps the result map alive across the recursive call's `current_max_reducer_results_` repoint; the outer task continues to read the snapshot it took. |
| Per-spec `max_reducer_cache_` invalidation on dependency change | Unchanged. Launch cache layers on top via the same `(snode_write_gen, ndarray_data_gen)` counters; `invalidate_max_reducer` and `invalidate_max_reducer_launch` are always invalidated together via `invalidate_all_per_task`. | Safe. |
| Hash collisions in `fnv1a32_for_registry` | `register_adstack_sizing_info` linear-probes past occupied slots; same `identity_key` short-circuits via `adstack_sizing_info_id_by_ptr_` before hash lookup | Safe. ~1.2e-4 collision probability for 1000 distinct keys; if a real collision appears the linear probe mints the next free slot. |
| Diagnose-on-overflow registry resolution | `ensure_runtime_registry_ids_for_max_reducer` seeds the registry on first launch of each cache-loaded kernel handle, gated by `is_adstack_sizing_info_registered(&ad_stack)` | Now correct on cache-hit launches. Was silently broken before this PR (registry empty after cache load). |
| Forward-only kernels (no `max_reducer_specs`) | `dispatch_max_reducers_for_tasks` early-out unchanged. The `ensure_runtime_registry_ids_for_max_reducer` loop also early-skips when `max_reducer_specs.empty()`. | Zero added overhead for forward-only kernels. |
| SPIR-V backend | Untouched. The gfx runtime has its own dispatcher in `runtime/gfx/adstack_max_reducer_launch.cpp` and its own runtime registration in `adstack_sizer_launch.cpp:236`. | Unaffected. |
| C++-only test setup (null `Program *`) | All paths gate on `prog != nullptr` / `cache != nullptr`; `ensure_runtime_registry_ids_for_max_reducer` defensive-seeds `ad_stack.registry_id` from the just-minted id when codegen-time registration was skipped. | Safe. |