### PR TITLE
[SPIR-V] dispatch_max_reducers: register each task with the real kernel name

### DIFF
--- a/quadrants/runtime/gfx/adstack_max_reducer_launch.cpp
+++ b/quadrants/runtime/gfx/adstack_max_reducer_launch.cpp
@@ -95,7 +95,8 @@ uint64_t pack_max_reducer_key(uint32_t registry_id, int32_t stack_id, int32_t mo
 MaxReducerResultMap GfxRuntime::dispatch_max_reducers(LaunchContextBuilder &host_ctx,
                                                       DeviceAllocationGuard *args_buffer,
                                                       const std::unordered_map<int, DeviceAllocation> &ndarray_allocs,
-                                                      const std::vector<spirv::TaskAttributes> &task_attribs) {
+                                                      const std::vector<spirv::TaskAttributes> &task_attribs,
+                                                      const std::string &kernel_name) {
   MaxReducerResultMap result;
 
   // The shader builder requires `spirv_has_physical_storage_buffer` (PSB body-leaf reads through the kernel arg
@@ -138,8 +139,14 @@ MaxReducerResultMap GfxRuntime::dispatch_max_reducers(LaunchContextBuilder &host
         allocated_max_sizes.push_back(static_cast<int>(a.max_size_compile_time));
         size_exprs.push_back(a.size_expr);
       }
+      // Pass the real kernel name + task index so `register_adstack_sizing_info`'s content-stable hash distinguishes
+      // tasks across different kernels. An empty kernel_name would collide every SPIR-V task with the same
+      // task_id_in_kernel into one registry slot, polluting `try_max_reducer_cache_hit` lookups across unrelated
+      // kernels and causing the per-spec substitution to silently miss when the cached `(stack_id, mor_node_idx)` came
+      // from a different kernel - the un-substituted MaxOverRange then leaks into the sizer shader, whose PSB load
+      // pulls float bytes from a stale arg-buffer slot and trips the `kMaxSaneStridePerThread` cap.
       mutable_attribs.registry_id = cache->register_adstack_sizing_info(
-          static_cast<const void *>(&mutable_attribs), /*kernel_name=*/std::string{}, static_cast<int>(ti),
+          static_cast<const void *>(&mutable_attribs), kernel_name, static_cast<int>(ti),
           std::move(allocated_max_sizes), std::move(size_exprs));
     }
     const uint32_t registry_id = mutable_attribs.registry_id;

--- a/quadrants/runtime/gfx/runtime.cpp
+++ b/quadrants/runtime/gfx/runtime.cpp
@@ -553,7 +553,8 @@ void GfxRuntime::launch_kernel(KernelHandle handle, LaunchContextBuilder &host_c
                   [](const spirv::TaskAttributes &t) { return !t.ad_stack.max_reducer_specs.empty(); });
   quadrants::lang::MaxReducerResultMap max_reducer_results;
   if (any_max_reducer_task) {
-    max_reducer_results = dispatch_max_reducers(host_ctx, args_buffer.get(), any_arrays, task_attribs);
+    max_reducer_results = dispatch_max_reducers(host_ctx, args_buffer.get(), any_arrays, task_attribs,
+                                                ti_kernel->ti_kernel_attribs().name);
   }
 
   // Device-side adstack SizeExpr evaluation: every task with adstack allocas has its per-alloca `max_size` /

--- a/quadrants/runtime/gfx/runtime.h
+++ b/quadrants/runtime/gfx/runtime.h
@@ -189,7 +189,8 @@ class QD_DLL_EXPORT GfxRuntime {
       LaunchContextBuilder &host_ctx,
       DeviceAllocationGuard *args_buffer,
       const std::unordered_map<int, DeviceAllocation> &ndarray_allocs,
-      const std::vector<quadrants::lang::spirv::TaskAttributes> &task_attribs);
+      const std::vector<quadrants::lang::spirv::TaskAttributes> &task_attribs,
+      const std::string &kernel_name);
 
   void init_nonroot_buffers();
 

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -4871,6 +4871,50 @@ def test_max_reducer_dispatch_counts_advance_on_input_mutation():
     assert prog._get_max_reducer_dispatch_count() > pre_mutation
 
 
+@test_utils.test(arch=[qd.cuda, qd.amdgpu, qd.vulkan, qd.metal], require=qd.extension.adstack)
+def test_max_reducer_per_kernel_registry_id_isolation():
+    # Two `qd.template()` instantiations of the same kernel hash to distinct registry ids so the per-spec max-reducer
+    # cache keyed by `(registry_id, stack_id, mor_node_idx)` does not leak entries across them. GPU only: the max-
+    # reducer dispatch is GPU-specific.
+    #
+    # Internal details: a single `@qd.kernel` definition takes a `qd.template()` flag and selects between two distinct
+    # reverse-mode bodies that write to different loss fields. Each instantiation captures a `MaxOverRange` spec at the
+    # same `(stack_id, mor_node_idx)` coordinates because the bodies are structurally identical, and they share the same
+    # `arr` so a stale entry would pass the observation freshness check (same devalloc, same write gen). The dispatch-
+    # count delta on the second instantiation pins that the SPIR-V launcher registers each task with the real kernel
+    # name so the registry slot is unique per kernel handle.
+    arr = qd.ndarray(qd.i32, shape=(2,))
+    arr.from_numpy(np.array([0, 2], dtype=np.int32))
+
+    x = qd.field(qd.f32, shape=(2,), needs_grad=True)
+    loss_a = qd.field(qd.f32, shape=(), needs_grad=True)
+    loss_b = qd.field(qd.f32, shape=(), needs_grad=True)
+
+    @qd.kernel
+    def compute(a: qd.types.ndarray(dtype=qd.i32, ndim=1), flag: qd.template()):
+        for i in range(a.shape[0]):
+            accum = 0.0
+            for j in range(a[i]):
+                accum = accum + x[j] * x[j]
+            if qd.static(flag):
+                loss_a[None] += accum
+            else:
+                loss_b[None] += accum
+
+    prog = impl.get_runtime().prog
+    prog._reset_max_reducer_dispatch_count()
+
+    compute(arr, False)
+    compute.grad(arr, False)
+    qd.sync()
+    after_false = prog._get_max_reducer_dispatch_count()
+
+    compute(arr, True)
+    compute.grad(arr, True)
+    qd.sync()
+    assert prog._get_max_reducer_dispatch_count() > after_false
+
+
 @test_utils.test(require=qd.extension.adstack, cfg_optimization=False)
 def test_max_reducer_grammar_fallback():
     # Pins the recognizer's grammar gate. A reverse-mode kernel whose inner trip count is a compile-time constant (no


### PR DESCRIPTION
# [SPIR-V] `dispatch_max_reducers`: register each task with the real kernel name

> One-line plumbing fix. SPIR-V's `dispatch_max_reducers` was passing `kernel_name=""` to `register_adstack_sizing_info`, which was harmless before #671 turned that registration call into a content-stable hash of `(kernel_name, task_id_in_kernel)`. Under the hash, every SPIR-V task with the same task index across distinct kernels collapses onto one registry slot, polluting the per-spec `max_reducer_cache_` and surfacing as `Adstack sizer shader returned an implausibly large per-thread stride` on Apple Metal in Genesis-style reverse-mode workloads.

```diff
 mutable_attribs.registry_id = cache->register_adstack_sizing_info(
-    static_cast<const void *>(&mutable_attribs), /*kernel_name=*/std::string{}, static_cast<int>(ti),
+    static_cast<const void *>(&mutable_attribs), kernel_name, static_cast<int>(ti),
     std::move(allocated_max_sizes), std::move(size_exprs));
```

`kernel_name` is plumbed from `runtime.cpp::launch_kernel` (already on hand for `publish_adstack_metadata_spirv` one line below). LLVM path was always passing the real name; only the SPIR-V launcher needed fixing.

## Tests

`tests/python/test_adstack.py::test_max_reducer_per_kernel_registry_id_isolation` - two `qd.template()` instantiations of the same `@qd.kernel` produce identical adstack trees and identical `(stack_id, mor_node_idx)` coords; pre-fix the second instantiation's first-launch dispatch counter stays at 0 (cache-hits the first's entries via shared `registry_id`), post-fix it advances. Genesis-shaped failure is reproduced by `repro_metal_rigid_step.py` in the issue thread.