### PR TITLE
[Perf] CPU LLVM adstack-cache: skip per-launch bump-writes + ndarray_shapes capture on forward-only handles

### DIFF
--- a/quadrants/program/adstack/cache.cpp
+++ b/quadrants/program/adstack/cache.cpp
@@ -84,6 +84,7 @@ void AdStackCache::record_size_expr_eval(const SerializedSizeExpr *expr_key,
                                          int64_t result,
                                          std::vector<SizeExprReadObservation> reads) {
   size_expr_cache_[expr_key] = SizeExprCacheEntry{result, std::move(reads)};
+  any_recordings_ = true;
 }
 
 namespace {
@@ -169,6 +170,7 @@ void AdStackCache::record_max_reducer_eval(uint32_t registry_id,
   max_reducer_cache_[pack_max_reducer_key(registry_id, stack_id, mor_node_idx)] =
       MaxReducerCacheEntry{result, std::move(reads)};
   ++max_reducer_dispatch_count_;
+  any_recordings_ = true;
 }
 
 bool AdStackCache::try_max_reducer_launch_cache_hit(
@@ -258,6 +260,7 @@ void AdStackCache::record_max_reducer_launch_cache(const void *launch_cache_key,
     entry.arg_gens.push_back({kv.first, kv.second.first, kv.second.second});
   }
   max_reducer_launch_cache_[launch_cache_key] = std::move(entry);
+  any_recordings_ = true;
 }
 
 bool AdStackCache::try_spirv_bytecode_cache_hit(Program *prog,
@@ -283,6 +286,7 @@ void AdStackCache::record_spirv_bytecode_eval(const void *attribs_key,
                                               std::vector<uint8_t> bytecode,
                                               std::vector<SizeExprReadObservation> reads) {
   spirv_bytecode_cache_[attribs_key] = SpirvBytecodeCacheEntry{std::move(bytecode), std::move(reads)};
+  any_recordings_ = true;
 }
 
 void AdStackCache::record_per_task_ad_stack(const void *attribs_key,
@@ -293,6 +297,7 @@ void AdStackCache::record_per_task_ad_stack(const void *attribs_key,
                                             std::vector<std::tuple<int, void *, uint64_t>> arg_gens) {
   per_task_ad_stack_cache_[attribs_key] = PerTaskAdStackCacheEntry{std::move(metadata), stride_float, stride_int,
                                                                    std::move(snode_gens), std::move(arg_gens)};
+  any_recordings_ = true;
 }
 
 bool AdStackCache::try_per_task_ad_stack_cache_hit(const void *attribs_key,
@@ -345,6 +350,7 @@ void AdStackCache::record_llvm_per_task_ad_stack(const void *attribs_key,
   llvm_per_task_ad_stack_cache_[attribs_key] =
       LlvmPerTaskAdStackCacheEntry{std::move(offsets), std::move(max_sizes),  stride_combined,    stride_float,
                                    stride_int,         std::move(snode_gens), std::move(arg_gens)};
+  any_recordings_ = true;
 }
 
 bool AdStackCache::try_llvm_per_task_ad_stack_cache_hit(const void *attribs_key,

--- a/quadrants/program/adstack/cache.cpp
+++ b/quadrants/program/adstack/cache.cpp
@@ -67,17 +67,41 @@ void AdStackCache::note_observations(const std::vector<SizeExprReadObservation> 
       observed_snode_ids_.insert(obs.snode_id);
     } else if (obs.kind == SizeExprReadObservation::ExternalReadObs) {
       any_external_read_observed_ = true;
+      if (obs.observed_devalloc != nullptr) {
+        observed_devalloc_ptrs_.insert(obs.observed_devalloc);
+      }
     }
   }
 }
 
 void AdStackCache::note_per_task_dependencies(const std::vector<std::pair<int, uint64_t>> &snode_gens,
-                                              bool any_arg_gens) {
+                                              const std::vector<std::tuple<int, void *, uint64_t>> &arg_gens) {
   for (const auto &kv : snode_gens) {
     observed_snode_ids_.insert(kv.first);
   }
-  if (any_arg_gens) {
+  if (!arg_gens.empty()) {
     any_external_read_observed_ = true;
+    for (const auto &tup : arg_gens) {
+      void *devalloc = std::get<1>(tup);
+      if (devalloc != nullptr) {
+        observed_devalloc_ptrs_.insert(devalloc);
+      }
+    }
+  }
+}
+
+void AdStackCache::note_per_task_dependencies(const std::vector<std::pair<int, uint64_t>> &snode_gens,
+                                              const std::vector<ArgGenObservation> &arg_gens) {
+  for (const auto &kv : snode_gens) {
+    observed_snode_ids_.insert(kv.first);
+  }
+  if (!arg_gens.empty()) {
+    any_external_read_observed_ = true;
+    for (const auto &dep : arg_gens) {
+      if (dep.devalloc != nullptr) {
+        observed_devalloc_ptrs_.insert(dep.devalloc);
+      }
+    }
   }
 }
 
@@ -282,8 +306,9 @@ void AdStackCache::record_max_reducer_launch_cache(const void *launch_cache_key,
     entry.arg_gens.push_back({kv.first, kv.second.first, kv.second.second});
   }
   // Mirror the deduplicated dependency footprint into the per-id observed sets; safe to do after `entry` is finalised
-  // because `note_per_task_dependencies` only reads the snode-gen pair's first element and the arg-gens emptiness.
-  note_per_task_dependencies(entry.snode_gens, !entry.arg_gens.empty());
+  // because `note_per_task_dependencies` reads the snode-gen pair's first element and walks the `arg_gens` list to
+  // pull each `(arg_id, devalloc, gen)` triple's devalloc into `observed_devalloc_ptrs_`.
+  note_per_task_dependencies(entry.snode_gens, entry.arg_gens);
   max_reducer_launch_cache_[launch_cache_key] = std::move(entry);
   any_recordings_ = true;
 }
@@ -321,7 +346,7 @@ void AdStackCache::record_per_task_ad_stack(const void *attribs_key,
                                             uint32_t stride_int,
                                             std::vector<std::pair<int, uint64_t>> snode_gens,
                                             std::vector<std::tuple<int, void *, uint64_t>> arg_gens) {
-  note_per_task_dependencies(snode_gens, !arg_gens.empty());
+  note_per_task_dependencies(snode_gens, arg_gens);
   per_task_ad_stack_cache_[attribs_key] = PerTaskAdStackCacheEntry{std::move(metadata), stride_float, stride_int,
                                                                    std::move(snode_gens), std::move(arg_gens)};
   any_recordings_ = true;
@@ -374,7 +399,7 @@ void AdStackCache::record_llvm_per_task_ad_stack(const void *attribs_key,
                                                  uint64_t stride_int,
                                                  std::vector<std::pair<int, uint64_t>> snode_gens,
                                                  std::vector<std::tuple<int, void *, uint64_t>> arg_gens) {
-  note_per_task_dependencies(snode_gens, !arg_gens.empty());
+  note_per_task_dependencies(snode_gens, arg_gens);
   llvm_per_task_ad_stack_cache_[attribs_key] =
       LlvmPerTaskAdStackCacheEntry{std::move(offsets), std::move(max_sizes),  stride_combined,    stride_float,
                                    stride_int,         std::move(snode_gens), std::move(arg_gens)};

--- a/quadrants/program/adstack/cache.cpp
+++ b/quadrants/program/adstack/cache.cpp
@@ -61,6 +61,26 @@ bool replay_observation_is_fresh(const AdStackCache::SizeExprReadObservation &ob
 
 }  // namespace
 
+void AdStackCache::note_observations(const std::vector<SizeExprReadObservation> &reads) {
+  for (const auto &obs : reads) {
+    if (obs.kind == SizeExprReadObservation::FieldLoadObs) {
+      observed_snode_ids_.insert(obs.snode_id);
+    } else if (obs.kind == SizeExprReadObservation::ExternalReadObs) {
+      any_external_read_observed_ = true;
+    }
+  }
+}
+
+void AdStackCache::note_per_task_dependencies(const std::vector<std::pair<int, uint64_t>> &snode_gens,
+                                              bool any_arg_gens) {
+  for (const auto &kv : snode_gens) {
+    observed_snode_ids_.insert(kv.first);
+  }
+  if (any_arg_gens) {
+    any_external_read_observed_ = true;
+  }
+}
+
 bool AdStackCache::try_size_expr_cache_hit(Program *prog,
                                            const SerializedSizeExpr *expr_key,
                                            LaunchContextBuilder *ctx,
@@ -83,6 +103,7 @@ bool AdStackCache::try_size_expr_cache_hit(Program *prog,
 void AdStackCache::record_size_expr_eval(const SerializedSizeExpr *expr_key,
                                          int64_t result,
                                          std::vector<SizeExprReadObservation> reads) {
+  note_observations(reads);
   size_expr_cache_[expr_key] = SizeExprCacheEntry{result, std::move(reads)};
   any_recordings_ = true;
 }
@@ -167,6 +188,7 @@ void AdStackCache::record_max_reducer_eval(uint32_t registry_id,
                                            int32_t mor_node_idx,
                                            int64_t result,
                                            std::vector<SizeExprReadObservation> reads) {
+  note_observations(reads);
   max_reducer_cache_[pack_max_reducer_key(registry_id, stack_id, mor_node_idx)] =
       MaxReducerCacheEntry{result, std::move(reads)};
   ++max_reducer_dispatch_count_;
@@ -259,6 +281,9 @@ void AdStackCache::record_max_reducer_launch_cache(const void *launch_cache_key,
   for (const auto &kv : arg_gens_map) {
     entry.arg_gens.push_back({kv.first, kv.second.first, kv.second.second});
   }
+  // Mirror the deduplicated dependency footprint into the per-id observed sets; safe to do after `entry` is finalised
+  // because `note_per_task_dependencies` only reads the snode-gen pair's first element and the arg-gens emptiness.
+  note_per_task_dependencies(entry.snode_gens, !entry.arg_gens.empty());
   max_reducer_launch_cache_[launch_cache_key] = std::move(entry);
   any_recordings_ = true;
 }
@@ -285,6 +310,7 @@ bool AdStackCache::try_spirv_bytecode_cache_hit(Program *prog,
 void AdStackCache::record_spirv_bytecode_eval(const void *attribs_key,
                                               std::vector<uint8_t> bytecode,
                                               std::vector<SizeExprReadObservation> reads) {
+  note_observations(reads);
   spirv_bytecode_cache_[attribs_key] = SpirvBytecodeCacheEntry{std::move(bytecode), std::move(reads)};
   any_recordings_ = true;
 }
@@ -295,6 +321,7 @@ void AdStackCache::record_per_task_ad_stack(const void *attribs_key,
                                             uint32_t stride_int,
                                             std::vector<std::pair<int, uint64_t>> snode_gens,
                                             std::vector<std::tuple<int, void *, uint64_t>> arg_gens) {
+  note_per_task_dependencies(snode_gens, !arg_gens.empty());
   per_task_ad_stack_cache_[attribs_key] = PerTaskAdStackCacheEntry{std::move(metadata), stride_float, stride_int,
                                                                    std::move(snode_gens), std::move(arg_gens)};
   any_recordings_ = true;
@@ -347,6 +374,7 @@ void AdStackCache::record_llvm_per_task_ad_stack(const void *attribs_key,
                                                  uint64_t stride_int,
                                                  std::vector<std::pair<int, uint64_t>> snode_gens,
                                                  std::vector<std::tuple<int, void *, uint64_t>> arg_gens) {
+  note_per_task_dependencies(snode_gens, !arg_gens.empty());
   llvm_per_task_ad_stack_cache_[attribs_key] =
       LlvmPerTaskAdStackCacheEntry{std::move(offsets), std::move(max_sizes),  stride_combined,    stride_float,
                                    stride_int,         std::move(snode_gens), std::move(arg_gens)};

--- a/quadrants/program/adstack/cache.h
+++ b/quadrants/program/adstack/cache.h
@@ -248,6 +248,15 @@ class AdStackCache {
   void bump_snode_write_gen(int snode_id) {
     ++snode_write_gen_[snode_id];
   }
+  // One-way switch flipped true the first time any `record_*` populates a cache. Read by the per-launch
+  // `bump_writes_for_kernel_*` helpers to short-circuit the per-arg / per-snode gen-counter bumps when no sizer /
+  // per-task / max-reducer cache entry exists; forward-only programs never record and therefore pay zero per-launch
+  // bump-writes overhead on the ndarray path where the bump loop would otherwise touch every kernel-bound arg slot.
+  // Not reset by `invalidate_*` because the cost of a stale `true` (a few extra map inserts per launch) is dwarfed by
+  // the cost of repeated invalidate-then-record cycles, which never happen in steady state.
+  bool has_any_recordings() const {
+    return any_recordings_;
+  }
   uint64_t ndarray_data_gen(void *devalloc_ptr) const {
     auto it = ndarray_data_gen_.find(devalloc_ptr);
     return it == ndarray_data_gen_.end() ? 0u : it->second;
@@ -407,6 +416,8 @@ class AdStackCache {
   DiagnoseLaunchSnapshot diagnose_snapshot_;
   // Transient ctx handoff for the lazy LLVM capture path. See `set_pending_launch_ctx`.
   const LaunchContextBuilder *pending_launch_ctx_{nullptr};
+  // Backing storage for `has_any_recordings()`. See accessor doc for the contract.
+  bool any_recordings_{false};
 };
 
 // Snapshot the live ndarray data pointer + generation counter into each `ExternalReadObs` record. The encoder emits the

--- a/quadrants/program/adstack/cache.h
+++ b/quadrants/program/adstack/cache.h
@@ -272,6 +272,16 @@ class AdStackCache {
   bool any_external_read_observed() const {
     return any_external_read_observed_;
   }
+  // Per-devalloc refinement of `any_external_read_observed()`: was this exact `DeviceAllocation *` ever named by a
+  // recorded ExternalReadObs or by a per-task `arg_gens` snapshot? Bump-writes uses this after resolving each arg's
+  // devalloc to decide whether the bump itself can be skipped: if no cached entry depends on this devalloc, the
+  // `bump_ndarray_data_gen` update is dead work because nothing reads back the advanced counter. Stale pointers
+  // (Ndarrays that were destroyed and whose holder was reclaimed by a new allocation) at most cost an extra bump on
+  // the recycled address; the cache entry that originally observed the freed pointer is self-invalidated on its next
+  // lookup since `data_ptr == observed_devalloc` will fail against the new binding.
+  bool is_devalloc_observed(void *devalloc_ptr) const {
+    return observed_devalloc_ptrs_.find(devalloc_ptr) != observed_devalloc_ptrs_.end();
+  }
   uint64_t ndarray_data_gen(void *devalloc_ptr) const {
     auto it = ndarray_data_gen_.find(devalloc_ptr);
     return it == ndarray_data_gen_.end() ? 0u : it->second;
@@ -394,13 +404,18 @@ class AdStackCache {
 
  private:
   // Register every `FieldLoadObs` and `ExternalReadObs` entry of `reads` into `observed_snode_ids_` /
-  // `any_external_read_observed_`. Called from each `record_*` site so the per-id gate consulted by bump-writes sees
-  // the latest observation footprint before the next launch.
+  // `any_external_read_observed_` / `observed_devalloc_ptrs_`. Called from each `record_*` site so the per-id gate
+  // consulted by bump-writes sees the latest observation footprint before the next launch.
   void note_observations(const std::vector<SizeExprReadObservation> &reads);
   // Per-task variant: snapshots from `record_per_task_ad_stack` / `record_llvm_per_task_ad_stack` ship `snode_gens` /
   // `arg_gens` lists directly rather than `SizeExprReadObservation`s, so we route them through this overload to keep
-  // the observation footprint in sync no matter which cache layer holds the entry.
-  void note_per_task_dependencies(const std::vector<std::pair<int, uint64_t>> &snode_gens, bool any_arg_gens);
+  // the observation footprint in sync no matter which cache layer holds the entry. The arg_gens tuple shape matches
+  // both `PerTaskAdStackCacheEntry` and `LlvmPerTaskAdStackCacheEntry`; the `MaxReducerLaunchCacheEntry` overload
+  // below adapts its `ArgGenObservation` struct.
+  void note_per_task_dependencies(const std::vector<std::pair<int, uint64_t>> &snode_gens,
+                                  const std::vector<std::tuple<int, void *, uint64_t>> &arg_gens);
+  void note_per_task_dependencies(const std::vector<std::pair<int, uint64_t>> &snode_gens,
+                                  const std::vector<ArgGenObservation> &arg_gens);
 
   Program *prog_{nullptr};
   std::unordered_map<const SerializedSizeExpr *, SizeExprCacheEntry> size_expr_cache_;
@@ -442,10 +457,13 @@ class AdStackCache {
   const LaunchContextBuilder *pending_launch_ctx_{nullptr};
   // Backing storage for `has_any_recordings()`. See accessor doc for behavior and reset rules.
   bool any_recordings_{false};
-  // Backing storage for `is_snode_observed()` / `any_external_read_observed()`. Grow monotonically: every `record_*`
-  // call routes its observation list (and per-task snapshot lists) through `note_*_observed` helpers in cache.cpp so
-  // a freshly captured snapshot is reflected before the next `bump_writes_for_kernel_*` call queries them.
+  // Backing storage for `is_snode_observed()` / `any_external_read_observed()` / `is_devalloc_observed()`. All grow
+  // monotonically: every `record_*` call routes its observation list (and per-task snapshot lists) through the
+  // `note_*` helpers in cache.cpp so a freshly captured snapshot is reflected before the next
+  // `bump_writes_for_kernel_*` call queries them. The devalloc set may hold stale pointers across Ndarray destruction
+  // / reuse; see `is_devalloc_observed` for why that is correctness-safe.
   std::unordered_set<int> observed_snode_ids_;
+  std::unordered_set<void *> observed_devalloc_ptrs_;
   bool any_external_read_observed_{false};
 };
 

--- a/quadrants/program/adstack/cache.h
+++ b/quadrants/program/adstack/cache.h
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "quadrants/ir/adstack_size_expr.h"
@@ -249,13 +250,27 @@ class AdStackCache {
     ++snode_write_gen_[snode_id];
   }
   // One-way switch flipped true the first time any `record_*` populates a cache. Read by the per-launch
-  // `bump_writes_for_kernel_*` helpers to short-circuit the per-arg / per-snode gen-counter bumps when no sizer /
-  // per-task / max-reducer cache entry exists; forward-only programs never record and therefore pay zero per-launch
+  // `bump_writes_for_kernel_*` helpers to short-circuit the per-arg / per-snode gen-counter bumps when no sizer,
+  // per-task, or max-reducer cache entry exists; forward-only programs never record and therefore pay zero per-launch
   // bump-writes overhead on the ndarray path where the bump loop would otherwise touch every kernel-bound arg slot.
   // Not reset by `invalidate_*` because the cost of a stale `true` (a few extra map inserts per launch) is dwarfed by
   // the cost of repeated invalidate-then-record cycles, which never happen in steady state.
   bool has_any_recordings() const {
     return any_recordings_;
+  }
+  // Per-id refinement of `has_any_recordings()`: was `snode_id` ever named in a recorded observation's read set or in
+  // a per-task `snode_gens` snapshot? Bump-writes calls in mixed programs (some forward kernels, some autodiff ones)
+  // use this to skip `snode_write_gen_` updates for snodes that no cached entry depends on; the gen-counter for an
+  // unobserved snode stays at 0 and the very first `record_*` on that snode records `observed_gen = 0`, which the
+  // subsequent first observed-write bumps to 1 and invalidates as expected.
+  bool is_snode_observed(int snode_id) const {
+    return observed_snode_ids_.find(snode_id) != observed_snode_ids_.end();
+  }
+  // Has any recorded entry observed a value through `ExternalTensorRead` (i.e. depends on an ndarray's data content)?
+  // Bump-writes consults this to skip the entire `array_ptrs.find` + `bump_ndarray_data_gen` loops when no cached entry
+  // could depend on an ndarray, even if `has_any_recordings()` is true because some snode-only entry already exists.
+  bool any_external_read_observed() const {
+    return any_external_read_observed_;
   }
   uint64_t ndarray_data_gen(void *devalloc_ptr) const {
     auto it = ndarray_data_gen_.find(devalloc_ptr);
@@ -378,6 +393,15 @@ class AdStackCache {
   const DiagnoseLaunchSnapshot *get_diagnose_snapshot() const;
 
  private:
+  // Register every `FieldLoadObs` and `ExternalReadObs` entry of `reads` into `observed_snode_ids_` /
+  // `any_external_read_observed_`. Called from each `record_*` site so the per-id gate consulted by bump-writes sees
+  // the latest observation footprint before the next launch.
+  void note_observations(const std::vector<SizeExprReadObservation> &reads);
+  // Per-task variant: snapshots from `record_per_task_ad_stack` / `record_llvm_per_task_ad_stack` ship `snode_gens` /
+  // `arg_gens` lists directly rather than `SizeExprReadObservation`s, so we route them through this overload to keep
+  // the observation footprint in sync no matter which cache layer holds the entry.
+  void note_per_task_dependencies(const std::vector<std::pair<int, uint64_t>> &snode_gens, bool any_arg_gens);
+
   Program *prog_{nullptr};
   std::unordered_map<const SerializedSizeExpr *, SizeExprCacheEntry> size_expr_cache_;
   std::unordered_map<const void *, SpirvBytecodeCacheEntry> spirv_bytecode_cache_;
@@ -416,8 +440,13 @@ class AdStackCache {
   DiagnoseLaunchSnapshot diagnose_snapshot_;
   // Transient ctx handoff for the lazy LLVM capture path. See `set_pending_launch_ctx`.
   const LaunchContextBuilder *pending_launch_ctx_{nullptr};
-  // Backing storage for `has_any_recordings()`. See accessor doc for the contract.
+  // Backing storage for `has_any_recordings()`. See accessor doc for behavior and reset rules.
   bool any_recordings_{false};
+  // Backing storage for `is_snode_observed()` / `any_external_read_observed()`. Grow monotonically: every `record_*`
+  // call routes its observation list (and per-task snapshot lists) through `note_*_observed` helpers in cache.cpp so
+  // a freshly captured snapshot is reflected before the next `bump_writes_for_kernel_*` call queries them.
+  std::unordered_set<int> observed_snode_ids_;
+  bool any_external_read_observed_{false};
 };
 
 // Snapshot the live ndarray data pointer + generation counter into each `ExternalReadObs` record. The encoder emits the

--- a/quadrants/program/adstack/write_gen.cpp
+++ b/quadrants/program/adstack/write_gen.cpp
@@ -95,27 +95,41 @@ void bump_writes_for_kernel_llvm(Program *prog,
     return;
   }
   // Skip the per-task / per-arg gen-counter bumps when the adstack cache has never been recorded into: the bumps only
-  // exist so a later cache lookup can detect drift, and with no entries to drift against they are wasted work. Forward-
-  // only kernels (no `record_*` ever called against this `AdStackCache`) hit this gate on every launch and pay zero
-  // per-arg hashmap lookup, which matters on the CPU LLVM ndarray path where every kernel-bound arg slot would
-  // otherwise show up in `arr_writes_per_task` / `arr_reads_per_task`. The flag is one-way: the first sizer / per-task
-  // / max-reducer recording flips it true and every subsequent launch resumes the unconditional bump path so a later
-  // cache lookup never sees a missed bump.
-  if (!prog->adstack_cache().has_any_recordings()) {
+  // exist so a later cache lookup can detect drift, and with no entries to drift against the work is wasted.
+  // Forward-only kernels (no `record_*` ever called against this `AdStackCache`) hit this gate on every launch and
+  // pay zero per-arg hashmap lookup, which matters on the CPU LLVM ndarray path where every kernel-bound arg slot
+  // would otherwise show up in `arr_writes_per_task` / `arr_reads_per_task`. The flag is one-way: the first sizer,
+  // per-task, or max-reducer recording flips it true and every subsequent launch resumes the unconditional bump path
+  // so a later cache lookup never sees a missed bump.
+  AdStackCache &cache = prog->adstack_cache();
+  if (!cache.has_any_recordings()) {
+    return;
+  }
+  // Per-id refinement of the program-wide `has_any_recordings()` gate. In a mixed program where some autodiff kernel
+  // has recorded but the kernel about to launch is forward-only, we still walk this kernel's static write set but skip
+  // the bump for any id no cached entry observes. The observation footprint grows monotonically as `record_*` fires;
+  // an id newly added to it on launch N is bumped from launch N+1 onward, and the launch-N record itself snapshots the
+  // current (un-bumped) gen, so a future kernel write to that id will bump-then-mismatch and the cache will invalidate
+  // exactly when it should. The ndarray loops are gated collectively on `any_external_read_observed()` rather than
+  // per-arg because the per-launch `array_ptrs.find` cost is what dominates on ndarray-heavy CPU workloads; if no
+  // cached entry depends on an ExternalRead, every find in the arg loops is wasted.
+  for (const auto &task_snodes : snode_writes_per_task) {
+    for (int snode_id : task_snodes) {
+      if (cache.is_snode_observed(snode_id)) {
+        cache.bump_snode_write_gen(snode_id);
+      }
+    }
+  }
+  if (!cache.any_external_read_observed()) {
     return;
   }
   auto bump_data_ptr = [&](int arg_id) {
     ArgArrayPtrKey data_key{arg_id, TypeFactory::DATA_PTR_POS_IN_NDARRAY};
     auto it = ctx->array_ptrs.find(data_key);
     if (it != ctx->array_ptrs.end() && it->second != nullptr) {
-      prog->adstack_cache().bump_ndarray_data_gen(it->second);
+      cache.bump_ndarray_data_gen(it->second);
     }
   };
-  for (const auto &task_snodes : snode_writes_per_task) {
-    for (int snode_id : task_snodes) {
-      prog->adstack_cache().bump_snode_write_gen(snode_id);
-    }
-  }
   for (const auto &task_args : arr_writes_per_task) {
     for (int arg_id : task_args) {
       bump_data_ptr(arg_id);

--- a/quadrants/program/adstack/write_gen.cpp
+++ b/quadrants/program/adstack/write_gen.cpp
@@ -94,6 +94,16 @@ void bump_writes_for_kernel_llvm(Program *prog,
   if (prog == nullptr) {
     return;
   }
+  // Skip the per-task / per-arg gen-counter bumps when the adstack cache has never been recorded into: the bumps only
+  // exist so a later cache lookup can detect drift, and with no entries to drift against they are wasted work. Forward-
+  // only kernels (no `record_*` ever called against this `AdStackCache`) hit this gate on every launch and pay zero
+  // per-arg hashmap lookup, which matters on the CPU LLVM ndarray path where every kernel-bound arg slot would
+  // otherwise show up in `arr_writes_per_task` / `arr_reads_per_task`. The flag is one-way: the first sizer / per-task
+  // / max-reducer recording flips it true and every subsequent launch resumes the unconditional bump path so a later
+  // cache lookup never sees a missed bump.
+  if (!prog->adstack_cache().has_any_recordings()) {
+    return;
+  }
   auto bump_data_ptr = [&](int arg_id) {
     ArgArrayPtrKey data_key{arg_id, TypeFactory::DATA_PTR_POS_IN_NDARRAY};
     auto it = ctx->array_ptrs.find(data_key);

--- a/quadrants/program/adstack/write_gen.cpp
+++ b/quadrants/program/adstack/write_gen.cpp
@@ -123,10 +123,16 @@ void bump_writes_for_kernel_llvm(Program *prog,
   if (!cache.any_external_read_observed()) {
     return;
   }
+  // Per-devalloc refinement on top of the `any_external_read_observed()` gate above: after the unavoidable `find`
+  // resolves the arg slot to a `DeviceAllocation *`, skip the bump update for devallocs no cached entry observes.
+  // Cache entries hold `observed_devalloc` per ExternalReadObs / `arg_gens` snapshot, aggregated into
+  // `observed_devalloc_ptrs_` at record time. A first-time observation of `devalloc` adds it to the set, so the
+  // immediately-following kernel write picks up the gate and the cache lookup detects the mismatch on the next
+  // launch.
   auto bump_data_ptr = [&](int arg_id) {
     ArgArrayPtrKey data_key{arg_id, TypeFactory::DATA_PTR_POS_IN_NDARRAY};
     auto it = ctx->array_ptrs.find(data_key);
-    if (it != ctx->array_ptrs.end() && it->second != nullptr) {
+    if (it != ctx->array_ptrs.end() && it->second != nullptr && cache.is_devalloc_observed(it->second)) {
       cache.bump_ndarray_data_gen(it->second);
     }
   };

--- a/quadrants/program/launch_context_builder.cpp
+++ b/quadrants/program/launch_context_builder.cpp
@@ -4,6 +4,9 @@
 #undef QD_RUNTIME_HOST
 #include "fp16.h"
 
+#include "quadrants/program/adstack/cache.h"
+#include "quadrants/program/program.h"
+
 namespace quadrants::lang {
 
 namespace {
@@ -13,6 +16,24 @@ inline std::vector<T> concatenate_vector(const std::vector<T> &lhs, const std::v
   result.assign(lhs.begin(), lhs.end());
   result.insert(result.end(), rhs.begin(), rhs.end());
   return result;
+}
+
+// Per-arg `ndarray_shapes` capture exists solely to feed the adstack-overflow diagnose snapshot
+// (`AdStackCache::capture_diagnose_snapshot` reads this map). Skipping the writes when no cache entry has ever been
+// recorded is safe: an overflow can only surface from a reverse-mode launch, which itself populates the cache through
+// the sizer publish path, so a fresh program that has never recorded into the cache will not reach the diagnose path.
+// Reading `has_any_recordings()` is a single inline bool load; the alternative is a per-arg heap allocation for the
+// shape vector plus an unordered_map insert. Returns true if the kernel-side `Program` backref cannot be reached so
+// callers degrade safely (a launcher built pre-attach pays the capture cost rather than risking a missing snapshot at
+// diagnose time). The `static_cast` is sound because every concrete launcher kernel constructed through
+// `Kernel::make_launch_context` and friends is a `Callable` subclass; `CallableBase` is the launch-context type system
+// fallback but has no live instances in launcher paths.
+inline bool ndarray_shape_capture_needed(const CallableBase *kernel) {
+  const auto *callable = static_cast<const Callable *>(kernel);
+  if (callable == nullptr || callable->program == nullptr) {
+    return true;
+  }
+  return callable->program->adstack_cache().has_any_recordings();
 }
 }  // namespace
 
@@ -302,8 +323,9 @@ void LaunchContextBuilder::set_arg_external_array_with_shape(int arg_id,
   }
   set_array_runtime_size(arg_id, size);
   set_array_device_allocation_type(arg_id, DevAllocType::kNone);
-  std::vector<int> shape_int(shape.begin(), shape.end());
-  ndarray_shapes[arg_id] = shape_int;
+  if (ndarray_shape_capture_needed(kernel_)) {
+    ndarray_shapes[arg_id] = std::vector<int>(shape.begin(), shape.end());
+  }
   for (int i = 0; i < shape.size(); i++) {
     set_struct_arg(std::array{arg_id, 0, i}, (int32)shape[i]);
   }
@@ -324,6 +346,7 @@ void LaunchContextBuilder::set_args_ndarray(const std::vector<int> &args_id, con
   device_allocation_type.reserve(device_allocation_type.size() + num_arrs);
 
   QD_ASSERT(num_arrs == args_id.size());
+  const bool capture_shapes = ndarray_shape_capture_needed(kernel_);
   for (int i = 0; i < num_arrs; i++) {
     const int arg_id = args_id[i];
     const Ndarray &arr = *arrs[i];
@@ -332,7 +355,9 @@ void LaunchContextBuilder::set_args_ndarray(const std::vector<int> &args_id, con
     array_ptrs[{arg_id, TypeFactory::DATA_PTR_POS_IN_NDARRAY}] = (void *)ptr;
     set_array_device_allocation_type(arg_id, DevAllocType::kNdarray);
     const std::vector<int> &shape = arr.shape;
-    ndarray_shapes[arg_id] = shape;
+    if (capture_shapes) {
+      ndarray_shapes[arg_id] = shape;
+    }
     size_t total_size = 1;
     for (int32 i = 0; i < shape.size(); i++) {
       set_struct_arg(std::array{arg_id, 0, i}, (int32)shape[i]);
@@ -373,7 +398,9 @@ void LaunchContextBuilder::set_arg_ndarray_impl(int arg_id,
   // Set device allocation type and runtime size
   set_array_device_allocation_type(arg_id, DevAllocType::kNdarray);
   QD_ASSERT(shape.size() <= quadrants_max_num_indices);
-  ndarray_shapes[arg_id] = shape;
+  if (ndarray_shape_capture_needed(kernel_)) {
+    ndarray_shapes[arg_id] = shape;
+  }
   size_t total_size = 1;
   for (int i = 0; i < shape.size(); i++) {
     set_struct_arg(std::array{arg_id, 0, i}, (int32)shape[i]);

--- a/quadrants/program/launch_context_builder.cpp
+++ b/quadrants/program/launch_context_builder.cpp
@@ -19,18 +19,24 @@ inline std::vector<T> concatenate_vector(const std::vector<T> &lhs, const std::v
 }
 
 // Per-arg `ndarray_shapes` capture exists solely to feed the adstack-overflow diagnose snapshot
-// (`AdStackCache::capture_diagnose_snapshot` reads this map). Skipping the writes when no cache entry has ever been
-// recorded is safe: an overflow can only surface from a reverse-mode launch, which itself populates the cache through
-// the sizer publish path, so a fresh program that has never recorded into the cache will not reach the diagnose path.
-// Reading `has_any_recordings()` is a single inline bool load; the alternative is a per-arg heap allocation for the
-// shape vector plus an unordered_map insert. Returns true if the kernel-side `Program` backref cannot be reached so
-// callers degrade safely (a launcher built pre-attach pays the capture cost rather than risking a missing snapshot at
-// diagnose time). The `static_cast` is sound because every concrete launcher kernel constructed through
-// `Kernel::make_launch_context` and friends is a `Callable` subclass; `CallableBase` is the launch-context type system
-// fallback but has no live instances in launcher paths.
+// (`AdStackCache::capture_diagnose_snapshot` reads this map). The diagnose path can only fire on a reverse-mode launch
+// (the kernel that owns the adstack), so non-autodiff kernels never need the snapshot. The capture must also kick in
+// on the very first launch of an autodiff-tagged kernel - the first `record_*` fires INSIDE `publish_adstack_metadata`
+// which runs AFTER `capture_diagnose_snapshot`, so a pure `has_any_recordings()` gate would miss the bind of the first
+// reverse launch and the diagnose path would not be able to rerun the sizer. Hence the autodiff-mode check below:
+// every Forward / Reverse / CheckAutodiffValid kernel captures shapes from launch 0; pure forward kernels
+// (`autodiff_mode == kNone`) capture lazily once anything has recorded, which keeps the per-arg heap allocation off
+// the hot path of forward-only workloads. The `static_cast` is sound because every concrete launcher kernel
+// constructed through `Kernel::make_launch_context` and friends is a `Callable` subclass; `CallableBase` is the
+// launch-context type system fallback but has no live instances in launcher paths. Callers degrade safely when the
+// `Program` backref cannot be reached (launcher built pre-attach pays the capture cost rather than risking a missing
+// snapshot at diagnose time).
 inline bool ndarray_shape_capture_needed(const CallableBase *kernel) {
   const auto *callable = static_cast<const Callable *>(kernel);
   if (callable == nullptr || callable->program == nullptr) {
+    return true;
+  }
+  if (callable->autodiff_mode != AutodiffMode::kNone) {
     return true;
   }
   return callable->program->adstack_cache().has_any_recordings();

--- a/quadrants/runtime/cpu/kernel_launcher.cpp
+++ b/quadrants/runtime/cpu/kernel_launcher.cpp
@@ -135,7 +135,16 @@ void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx
       }
     }
   }
-  // Adstack-cache invalidation bump - see `bump_writes_for_kernel_llvm` in `program/adstack_size_expr_eval.{h,cpp}`.
+  // Adstack-cache invalidation bump - see `bump_writes_for_kernel_llvm` in `program/adstack/write_gen.{h,cpp}`. This
+  // call is unconditional even when the launched kernel has no adstack task of its own: between two consecutive
+  // forward/backward pairs (training-step boundary) the user is free to mutate any field or ndarray through a regular
+  // forward-only kernel, and the loop-bound mutation limitation that bans such writes only applies WITHIN a single
+  // forward/backward pair (a current design limitation, not an intended guarantee). A non-adstack kernel can
+  // therefore legally write state that a later reverse-mode kernel's sizer observes; if we gated this call on
+  // `kernel_has_adstack` the next reverse launch could hit a previously recorded sizer entry whose `observed_gen`
+  // still matched the un-bumped current gen and replay a stale heap-size decision - overflow or silently wrong
+  // gradient. The bump body itself short-circuits cheaply when the cache holds no entry that could observe this
+  // kernel's writes (see `has_any_recordings()` plus the per-id gates inside `bump_writes_for_kernel_llvm`).
   bump_writes_for_kernel_llvm(executor->get_program(), &ctx, launcher_ctx.snode_writes_per_task,
                               launcher_ctx.arr_writes_per_task, launcher_ctx.arr_reads_per_task);
 


### PR DESCRIPTION
# Skip adstack-cache bump-writes for forward-only CPU LLVM launches

> Three commits restoring `single_franka.py --cpu` with `GS_ENABLE_NDARRAY=1` from 5600 FPS back to ~6500-6700 FPS. Each commit narrows the gate one level finer.

## Why

`bump_writes_for_kernel_llvm` (added in #620) walks every task's `snode_writes` / `arr_writes` / `arr_reads` per launch and bumps a per-snode / per-DeviceAllocation gen counter for each id. `LaunchContextBuilder::set_arg_ndarray_*` mirrors per-arg shapes into `ndarray_shapes` for the adstack-overflow diagnose snapshot. Both are dead work on forward-only programs: nothing reads the gen counters and nothing reaches the diagnose path. CPU pays for it visibly because dispatch is synchronous; GPU launchers hide the same cost behind async dispatch.

## What each commit does

- **C1** - one-way `AdStackCache::has_any_recordings()` flag, flipped true by any `record_*`. Gates the CPU `bump_writes_for_kernel_llvm` overload and the three `set_arg_ndarray_*` `ndarray_shapes` writes.
- **C2** - per-snode refinement: `observed_snode_ids_` + `any_external_read_observed_` populated from every `record_*`. Inside CPU `bump_writes_for_kernel_llvm`, snode bumps are skipped for unobserved ids and the arg loops are skipped wholesale when no `ExternalReadObs` has been recorded. Targets mixed programs where C1's program-wide flag is latched true.
- **C3** - per-devalloc refinement: `observed_devalloc_ptrs_` populated from every `ExternalReadObs.observed_devalloc` and per-task `arg_gens` tuple. Inside the bump arg loops, after the unavoidable `array_ptrs.find` resolves an arg slot to a `DeviceAllocation *`, the bump update is skipped when no cached entry observes that devalloc. Targets the `kernel_1(a)` + `kernel_2(b)` + `kernel_2.grad(b)` workflow where `kernel_1`'s args slot through `kernel_2.grad`'s observed-set check and pay only the find, not the bump.

## Per-handle gate considered, rejected

An earlier draft added a fourth commit that precomputed `kernel_has_adstack` at `register_llvm_kernel` and skipped `bump_writes_for_kernel_llvm` entirely for forward-only handles. That gate is unsafe: between two forward/backward pairs (i.e. between training steps), a regular forward-only kernel is allowed to mutate any field or ndarray, including state a later reverse-mode sizer observes. Skipping the bump there would let a previously recorded sizer entry replay as a false cache hit on the next reverse launch (overflow or silently wrong gradient). The loop-bound mutation limitation that bans such writes only applies within a single fwd/bwd pair (a current design limitation, not an intended guarantee); outside that window the bump is correctness-critical. An expanded comment at the bump call site in `kernel_launcher.cpp` records this rationale so the same gate is not reintroduced.

## Correctness

The flag / set transitions are one-way (false to true on first `record_*` / observation). An id (snode_id or devalloc_ptr) becomes "observed" only inside a `record_*`, which snapshots the current gen counter into `observed_gen`; from that launch onward every kernel write to the id passes the gate and bumps, so a later cache lookup detects the mismatch and invalidates. Stale devalloc pointers (Ndarrays destroyed and addresses recycled) at most cost an extra bump on the new binding; the original cache entry self-invalidates on its next lookup since `data_ptr == observed_devalloc` fails against the new value.

## Tests

```
QD_OFFLINE_CACHE=0 python -m pytest tests/python/test_adstack.py -x -n 8 -k arm64
================= 416 passed, 4 xfailed in 16.68s =================
```