### PR TITLE
[AMDGPU] HIP graph runtime support for @qd.kernel(graph=True)

### DIFF
--- a/docs/source/user_guide/graph.md
+++ b/docs/source/user_guide/graph.md
@@ -1,6 +1,8 @@
-# CUDA Graph
+# GPU Graphs (CUDA / HIP)
 
-CUDA graphs reduce kernel launch overhead by capturing a sequence of GPU operations into a graph, then replaying it in a single launch. On non-CUDA platforms, the cuda graph annotation is simply ignored, and code runs normally.
+GPU graphs reduce kernel launch overhead by capturing a sequence of GPU operations into a graph, then replaying it in a single launch. Quadrants supports basic `graph=True` on both CUDA (via CUDA graphs) and AMDGPU (via HIP graphs). On backends without a graph runtime (e.g. CPU, Vulkan), the `graph=True` annotation is silently ignored and code runs normally.
+
+Device-side iteration with `graph_do_while` is currently only fully native on CUDA SM 9.0+ (Hopper); on AMDGPU and older CUDA GPUs it falls back to a host-side loop (see [GPU-side iteration with `graph_do_while`](#gpu-side-iteration-with-graph_do_while) below).
 
 ## Basic usage
 
@@ -30,10 +32,14 @@ my_kernel(x, y)  # first call: builds and caches the graph
 my_kernel(x, y)  # subsequent calls: replays the cached graph
 ```
 
+This works the same way on CUDA and AMDGPU. The cache is keyed per (compiled-kernel-specialization, launch-id), so different template instantiations (different field bindings, etc.) get their own cached graph.
+
 ### Restrictions
 
-- **No struct return values.** Kernels that return values (e.g. `-> qd.i32`) cannot use CUDA graphs. An error is raised if `graph=True` is set on such a kernel.
+- **No struct return values.** Kernels that return values (e.g. `-> qd.i32`) cannot use GPU graphs. An error is raised if `graph=True` is set on such a kernel.
 - **Primal kernels only.** The `graph=True` flag is applied to the primal (forward) kernel only, not its adjoint. Autodiff kernels use the normal launch path.
+- **Device-resident ndarrays.** Graph mode bakes device pointers into the cached graph, so all ndarray arguments must be on the GPU. Passing a host-resident ndarray raises an error.
+- **`qd_stream` is incompatible** with `graph=True`. Choose one or the other.
 
 ### Passing different arguments
 
@@ -77,8 +83,8 @@ solve(x, counter)
 
 The argument to `qd.graph_do_while()` must be the name of a scalar `qd.i32` ndarray parameter. The loop body repeats while this value is non-zero.
 
-- On SM 9.0+ (Hopper), this uses CUDA conditional while nodes — the entire iteration runs on the GPU with no host involvement.
-- On older CUDA GPUs and non-CUDA backends, it falls back to a host-side do-while loop.
+- On CUDA SM 9.0+ (Hopper), this uses CUDA conditional while nodes — the entire iteration runs on the GPU with no host involvement.
+- On older CUDA GPUs, AMDGPU, and non-GPU backends, it falls back to a host-side do-while loop (see [Caveats](#caveats)). HIP does not currently expose conditional / while graph nodes, so AMDGPU cannot run the loop fully on the device today.
 
 ### Patterns
 
@@ -128,11 +134,13 @@ However, other parameters can be any supported Quadrants kernel parameter type.
 
 ### Caveats
 
-On currently unsupported GPU platforms, such as AMDGPU at the time of writing, the value of the `graph_do_while` parameter will be copied from the GPU to the host each iteration, in order to check whether we should continue iterating. This causes a GPU pipeline stall. At the end of each loop iteration:
+On platforms without native device-side conditional graph nodes — currently CUDA pre-SM 9.0 and **AMDGPU** (HIP has no conditional / while node API as of ROCm 7.2) — the value of the `graph_do_while` parameter will be copied from the GPU to the host each iteration, in order to check whether we should continue iterating. This causes a GPU pipeline stall. At the end of each loop iteration:
 - wait for GPU async queue to finish processing
 - copy condition value to hostside
 - evaluate condition value on hostside
 - launch new kernels for next loop iteration, if not finished yet
+
+Note: the basic `graph=True` path (without `graph_do_while`) does **not** stall the host like this on either CUDA or AMDGPU — the entire kernel sequence runs as a single GPU-side graph replay.
 
 Therefore on unsupported platforms, you might consider creating a second implementation, which works differently. e.g.:
 - fixed number of loop iterations, so no dependency on gpu data for kernel launch; combined perhaps with:

--- a/quadrants/rhi/amdgpu/amdgpu_driver.h
+++ b/quadrants/rhi/amdgpu/amdgpu_driver.h
@@ -41,10 +41,9 @@ constexpr uint32 HIP_JIT_MAX_REGISTERS = 0;
 constexpr uint32 HIP_POINTER_ATTRIBUTE_MEMORY_TYPE = 2;
 constexpr uint32 HIP_SUCCESS = 0;
 constexpr uint32 HIP_MEMORYTYPE_DEVICE = 1;
-// `hipFuncAttributeMaxDynamicSharedMemorySize` from the `hipFuncAttribute` enum in
-// ROCm/clr hipamd/include/hip/hip_runtime_api.h. Used with `kernel_set_attribute`
-// (`hipFuncSetAttribute`) to opt in to >48 KB of dynamic shared memory for graph
-// kernel nodes that request it.
+// `hipFuncAttributeMaxDynamicSharedMemorySize` from the `hipFuncAttribute` enum in ROCm/clr
+// hipamd/include/hip/hip_runtime_api.h. Used with `kernel_set_attribute` (`hipFuncSetAttribute`) to opt in to >48 KB
+// of dynamic shared memory for graph kernel nodes that request it.
 constexpr uint32 HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES = 8;
 
 std::string get_amdgpu_error_message(uint32 err);

--- a/quadrants/rhi/amdgpu/amdgpu_driver.h
+++ b/quadrants/rhi/amdgpu/amdgpu_driver.h
@@ -41,6 +41,11 @@ constexpr uint32 HIP_JIT_MAX_REGISTERS = 0;
 constexpr uint32 HIP_POINTER_ATTRIBUTE_MEMORY_TYPE = 2;
 constexpr uint32 HIP_SUCCESS = 0;
 constexpr uint32 HIP_MEMORYTYPE_DEVICE = 1;
+// `hipFuncAttributeMaxDynamicSharedMemorySize` from the `hipFuncAttribute` enum in
+// ROCm/clr hipamd/include/hip/hip_runtime_api.h. Used with `kernel_set_attribute`
+// (`hipFuncSetAttribute`) to opt in to >48 KB of dynamic shared memory for graph
+// kernel nodes that request it.
+constexpr uint32 HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES = 8;
 
 std::string get_amdgpu_error_message(uint32 err);
 

--- a/quadrants/rhi/amdgpu/amdgpu_driver_functions.inc.h
+++ b/quadrants/rhi/amdgpu/amdgpu_driver_functions.inc.h
@@ -72,7 +72,13 @@ PER_AMDGPU_FUNCTION(kernel_set_attribute, hipFuncSetAttribute, const void *, uin
 // `@qd.kernel(graph=True)`. Conditional / while nodes are not yet available in HIP, so device-side
 // `graph_do_while` falls back to the host-side loop in `KernelLauncher::launch_offloaded_tasks_with_do_while`.
 PER_AMDGPU_FUNCTION(graph_create, hipGraphCreate, void **, uint32);
-PER_AMDGPU_FUNCTION(graph_add_kernel_node, hipGraphAddKernelNode, void **, void *, const void *, std::size_t, const void *);
+PER_AMDGPU_FUNCTION(graph_add_kernel_node,
+                    hipGraphAddKernelNode,
+                    void **,
+                    void *,
+                    const void *,
+                    std::size_t,
+                    const void *);
 PER_AMDGPU_FUNCTION(graph_instantiate, hipGraphInstantiate, void **, void *, void *, char *, std::size_t);
 PER_AMDGPU_FUNCTION(graph_launch, hipGraphLaunch, void *, void *);
 PER_AMDGPU_FUNCTION(graph_destroy, hipGraphDestroy, void *);

--- a/quadrants/rhi/amdgpu/amdgpu_driver_functions.inc.h
+++ b/quadrants/rhi/amdgpu/amdgpu_driver_functions.inc.h
@@ -66,6 +66,17 @@ PER_AMDGPU_FUNCTION(launch_kernel,
                     void **);
 PER_AMDGPU_FUNCTION(kernel_get_attribute, hipFuncGetAttribute, int *, uint32, void *);
 PER_AMDGPU_FUNCTION(kernel_get_occupancy, hipOccupancyMaxActiveBlocksPerMultiprocessor, int *, void *, int, size_t);
+PER_AMDGPU_FUNCTION(kernel_set_attribute, hipFuncSetAttribute, const void *, uint32, int);
+
+// Graph management. HIP exposes the kernel-launch / instantiate / launch / destroy subset that we need for
+// `@qd.kernel(graph=True)`. Conditional / while nodes are not yet available in HIP, so device-side
+// `graph_do_while` falls back to the host-side loop in `KernelLauncher::launch_offloaded_tasks_with_do_while`.
+PER_AMDGPU_FUNCTION(graph_create, hipGraphCreate, void **, uint32);
+PER_AMDGPU_FUNCTION(graph_add_kernel_node, hipGraphAddKernelNode, void **, void *, const void *, std::size_t, const void *);
+PER_AMDGPU_FUNCTION(graph_instantiate, hipGraphInstantiate, void **, void *, void *, char *, std::size_t);
+PER_AMDGPU_FUNCTION(graph_launch, hipGraphLaunch, void *, void *);
+PER_AMDGPU_FUNCTION(graph_destroy, hipGraphDestroy, void *);
+PER_AMDGPU_FUNCTION(graph_exec_destroy, hipGraphExecDestroy, void *);
 
 // Stream management
 PER_AMDGPU_FUNCTION(stream_synchronize, hipStreamSynchronize, void *);

--- a/quadrants/runtime/amdgpu/CMakeLists.txt
+++ b/quadrants/runtime/amdgpu/CMakeLists.txt
@@ -3,6 +3,8 @@
 add_library(amdgpu_runtime)
 target_sources(amdgpu_runtime
   PRIVATE
+    amdgpu_utils.cpp
+    graph_manager.cpp
     jit_amdgpu.cpp
     kernel_launcher.cpp
   )

--- a/quadrants/runtime/amdgpu/amdgpu_utils.cpp
+++ b/quadrants/runtime/amdgpu/amdgpu_utils.cpp
@@ -6,8 +6,8 @@ namespace amdgpu {
 
 bool on_amdgpu_device(void *ptr) {
   unsigned int attr_val[8];
-  // `mem_get_attribute` is unreliable on ROCm; `mem_get_attributes` (plural)
-  // returns the attribute block and we read the `memoryType` slot from it.
+  // `mem_get_attribute` is unreliable on ROCm; `mem_get_attributes` (plural) returns the attribute block and we read
+  // the `memoryType` slot from it.
   uint32_t ret_code = AMDGPUDriver::get_instance().mem_get_attributes.call(attr_val, ptr);
   return ret_code == HIP_SUCCESS && attr_val[0] == HIP_MEMORYTYPE_DEVICE;
 }

--- a/quadrants/runtime/amdgpu/amdgpu_utils.cpp
+++ b/quadrants/runtime/amdgpu/amdgpu_utils.cpp
@@ -1,0 +1,16 @@
+#include "quadrants/runtime/amdgpu/amdgpu_utils.h"
+#include "quadrants/rhi/amdgpu/amdgpu_driver.h"
+
+namespace quadrants::lang {
+namespace amdgpu {
+
+bool on_amdgpu_device(void *ptr) {
+  unsigned int attr_val[8];
+  // `mem_get_attribute` is unreliable on ROCm; `mem_get_attributes` (plural)
+  // returns the attribute block and we read the `memoryType` slot from it.
+  uint32_t ret_code = AMDGPUDriver::get_instance().mem_get_attributes.call(attr_val, ptr);
+  return ret_code == HIP_SUCCESS && attr_val[0] == HIP_MEMORYTYPE_DEVICE;
+}
+
+}  // namespace amdgpu
+}  // namespace quadrants::lang

--- a/quadrants/runtime/amdgpu/amdgpu_utils.h
+++ b/quadrants/runtime/amdgpu/amdgpu_utils.h
@@ -3,9 +3,8 @@
 namespace quadrants::lang {
 namespace amdgpu {
 
-// Returns true if `ptr` refers to memory whose HIP attribute reports
-// `hipMemoryTypeDevice`. Used to gate graph-build / device-only fast paths
-// that cannot HtoD-stage host-resident pointers.
+// Returns true if `ptr` refers to memory whose HIP attribute reports `hipMemoryTypeDevice`. Used to gate graph-build /
+// device-only fast paths that cannot HtoD-stage host-resident pointers.
 bool on_amdgpu_device(void *ptr);
 
 }  // namespace amdgpu

--- a/quadrants/runtime/amdgpu/amdgpu_utils.h
+++ b/quadrants/runtime/amdgpu/amdgpu_utils.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace quadrants::lang {
+namespace amdgpu {
+
+// Returns true if `ptr` refers to memory whose HIP attribute reports
+// `hipMemoryTypeDevice`. Used to gate graph-build / device-only fast paths
+// that cannot HtoD-stage host-resident pointers.
+bool on_amdgpu_device(void *ptr);
+
+}  // namespace amdgpu
+}  // namespace quadrants::lang

--- a/quadrants/runtime/amdgpu/graph_manager.cpp
+++ b/quadrants/runtime/amdgpu/graph_manager.cpp
@@ -18,10 +18,9 @@ CachedGraph::CachedGraph(std::size_t arg_buf_size, std::size_t result_buf_size, 
     AMDGPUDriver::get_instance().malloc(reinterpret_cast<void **>(&persistent_device_arg_buffer), arg_buffer_size);
   }
 
-  // Device-side `RuntimeContext` for graph kernel-node args. Unlike the CUDA
-  // path which passes a host pointer (relying on UVA / HMM), AMDGPU kernels
-  // dereference the pointer directly on the GPU, so it must point at device
-  // memory. See `runtime/amdgpu/graph_manager.h` for the full rationale.
+  // Device-side `RuntimeContext` for graph kernel-node args. Unlike the CUDA path which passes a host pointer (relying
+  // on UVA / HMM), AMDGPU kernels dereference the pointer directly on the GPU, so it must point at device memory. See
+  // `runtime/amdgpu/graph_manager.h` for the full rationale.
   AMDGPUDriver::get_instance().malloc(&device_runtime_ctx, sizeof(RuntimeContext));
 
   persistent_ctx.runtime = executor->get_llvm_runtime();
@@ -29,9 +28,8 @@ CachedGraph::CachedGraph(std::size_t arg_buf_size, std::size_t result_buf_size, 
   persistent_ctx.result_buffer = reinterpret_cast<uint64 *>(persistent_device_result_buffer);
   persistent_ctx.cpu_thread_id = 0;
 
-  // The single kernel arg every offloaded task takes is a RuntimeContext *.
-  // Stage the device pointer value into the persistent CachedKernelArgs so
-  // the extra-config addresses are stable for the graph's lifetime.
+  // The single kernel arg every offloaded task takes is a RuntimeContext *. Stage the device pointer value into the
+  // persistent CachedKernelArgs so the extra-config addresses are stable for the graph's lifetime.
   kernel_args.packed_runtime_ctx_ptr = device_runtime_ctx;
   kernel_args.pack_size = sizeof(void *);
   kernel_args.extra_config[0] = reinterpret_cast<void *>(0x01);  // HIP_LAUNCH_PARAM_BUFFER_POINTER
@@ -66,9 +64,8 @@ CachedGraph::CachedGraph(CachedGraph &&other) noexcept
       arg_buffer_size(other.arg_buffer_size),
       result_buffer_size(other.result_buffer_size),
       num_nodes(other.num_nodes) {
-  // The moved-from object must not free our resources at destruction time.
-  // Rebind `kernel_args.extra_config` so it points at *our* members after the
-  // move, not the moved-from object's (which is about to be destroyed).
+  // The moved-from object must not free our resources at destruction time. Rebind `kernel_args.extra_config` so it
+  // points at *our* members after the move, not the moved-from object's (which is about to be destroyed).
   kernel_args.extra_config[1] = &kernel_args.packed_runtime_ctx_ptr;
   kernel_args.extra_config[3] = &kernel_args.pack_size;
   other.graph_exec = nullptr;
@@ -78,8 +75,8 @@ CachedGraph::CachedGraph(CachedGraph &&other) noexcept
 }
 
 CachedGraph &CachedGraph::operator=(CachedGraph &&other) noexcept {
-  // Move-and-swap: after the swaps, `raii_guard` holds our old resources and
-  // its destructor frees them, so every owned pointer is released uniformly.
+  // Move-and-swap: after the swaps, `raii_guard` holds our old resources and its destructor frees them, so every owned
+  // pointer is released uniformly.
   CachedGraph raii_guard(std::move(other));
   std::swap(graph_exec, raii_guard.graph_exec);
   std::swap(persistent_device_arg_buffer, raii_guard.persistent_device_arg_buffer);
@@ -87,9 +84,8 @@ CachedGraph &CachedGraph::operator=(CachedGraph &&other) noexcept {
   std::swap(persistent_ctx, raii_guard.persistent_ctx);
   std::swap(device_runtime_ctx, raii_guard.device_runtime_ctx);
   std::swap(kernel_args, raii_guard.kernel_args);
-  // After the swap, kernel_args is `raii_guard`'s old kernel_args (which had
-  // extra_config[1,3] bound to its own members). Rebind to ours so the
-  // addresses stay valid through the swap.
+  // After the swap, kernel_args is `raii_guard`'s old kernel_args (which had extra_config[1,3] bound to its own
+  // members). Rebind to ours so the addresses stay valid through the swap.
   kernel_args.extra_config[1] = &kernel_args.packed_runtime_ctx_ptr;
   kernel_args.extra_config[3] = &kernel_args.pack_size;
   raii_guard.kernel_args.extra_config[1] = &raii_guard.kernel_args.packed_runtime_ctx_ptr;
@@ -100,12 +96,11 @@ CachedGraph &CachedGraph::operator=(CachedGraph &&other) noexcept {
   return *this;
 }
 
-// Resolves ndarray parameter handles in the launch context to raw device
-// pointers, writing them into the arg buffer via `set_ndarray_ptrs`.
+// Resolves ndarray parameter handles in the launch context to raw device pointers, writing them into the arg buffer
+// via `set_ndarray_ptrs`.
 //
-// Unlike the normal launch path, this does not handle host-resident arrays
-// (no temporary device allocation or host-to-device transfer). Errors if any
-// external array is on the host, since graph mode bakes device pointers into
+// Unlike the normal launch path, this does not handle host-resident arrays (no temporary device allocation or
+// host-to-device transfer). Errors if any external array is on the host, since graph mode bakes device pointers into
 // the cached graph.
 void GraphManager::resolve_ctx_ndarray_ptrs(LaunchContextBuilder &ctx,
                                             const std::vector<std::pair<int, Callable::Parameter>> &parameters,
@@ -158,10 +153,9 @@ void *GraphManager::add_kernel_node(void *graph,
                                     unsigned int block_dim,
                                     unsigned int shared_mem,
                                     CachedKernelArgs &kernel_args) {
-  // Opt in to the requested dynamic shared memory size. `hipFuncSetAttribute`
-  // is mostly a no-op for the AMD backend per its header comments, but we
-  // call it for parity with the CUDA path and to forward the request to any
-  // backend that honours it.
+  // Opt in to the requested dynamic shared memory size. `hipFuncSetAttribute` is mostly a no-op for the AMD backend
+  // per its header comments, but we call it for parity with the CUDA path and to forward the request to any backend
+  // that honours it.
   if (shared_mem > 0) {
     AMDGPUDriver::get_instance().kernel_set_attribute(func, HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
                                                       static_cast<int>(shared_mem));
@@ -171,13 +165,11 @@ void *GraphManager::add_kernel_node(void *graph,
   params.blockDimX = block_dim;
   params.blockDimY = 1;
   params.blockDimZ = 1;
-  // HIP's AMD backend expects kernel args via the `extra` byte-buffer convention
-  // (HIP_LAUNCH_PARAM_BUFFER_POINTER / SIZE / END markers), not via the
-  // per-arg `kernelParams` array. See the matching setup in
-  // `rhi/amdgpu/amdgpu_context.cpp::AMDGPUContext::launch`. Passing
-  // `kernelParams` here instead silently corrupts kernel arg loads on RDNA3
-  // and the launched kernels fault asynchronously, surfacing as
-  // `hipErrorIllegalAddress` at the next host-visible sync point.
+  // HIP's AMD backend expects kernel args via the `extra` byte-buffer convention (HIP_LAUNCH_PARAM_BUFFER_POINTER /
+  // SIZE / END markers), not via the per-arg `kernelParams` array. See the matching setup in
+  // `rhi/amdgpu/amdgpu_context.cpp::AMDGPUContext::launch`. Passing `kernelParams` here instead silently corrupts
+  // kernel arg loads on RDNA3 and the launched kernels fault asynchronously, surfacing as `hipErrorIllegalAddress` at
+  // the next host-visible sync point.
   params.extra = kernel_args.extra_config;
   params.func = func;
   params.gridDimX = grid_dim;
@@ -197,9 +189,8 @@ bool GraphManager::launch_cached_graph(CachedGraph &cached, LaunchContextBuilder
   if (ctx.arg_buffer_size > 0) {
     // Async HtoD on the launch stream: the subsequent `graph_launch` is queued on the same stream,
     // so the kernel nodes are ordered after the arg-buffer upload without a host-side barrier.
-    AMDGPUDriver::get_instance().memcpy_host_to_device_async(cached.persistent_device_arg_buffer,
-                                                             ctx.get_context().arg_buffer, cached.arg_buffer_size,
-                                                             stream);
+    AMDGPUDriver::get_instance().memcpy_host_to_device_async(
+        cached.persistent_device_arg_buffer, ctx.get_context().arg_buffer, cached.arg_buffer_size, stream);
   }
   AMDGPUDriver::get_instance().graph_launch(cached.graph_exec, stream);
   used_on_last_call_ = true;
@@ -244,14 +235,12 @@ bool GraphManager::try_launch(int launch_id,
 
   auto *stream_for_setup = AMDGPUContext::get_instance().get_stream();
   if (cached.arg_buffer_size > 0) {
-    AMDGPUDriver::get_instance().memcpy_host_to_device_async(cached.persistent_device_arg_buffer,
-                                                             ctx.get_context().arg_buffer, cached.arg_buffer_size,
-                                                             stream_for_setup);
+    AMDGPUDriver::get_instance().memcpy_host_to_device_async(
+        cached.persistent_device_arg_buffer, ctx.get_context().arg_buffer, cached.arg_buffer_size, stream_for_setup);
   }
 
-  // Stage the RuntimeContext on device. Its arg_buffer / result_buffer
-  // pointers reference the persistent device buffers above; none of its
-  // fields change between graph launches so one copy is sufficient.
+  // Stage the RuntimeContext on device. Its arg_buffer / result_buffer pointers reference the persistent device
+  // buffers above; none of its fields change between graph launches so one copy is sufficient.
   AMDGPUDriver::get_instance().memcpy_host_to_device_async(cached.device_runtime_ctx, &cached.persistent_ctx,
                                                            sizeof(RuntimeContext), stream_for_setup);
   AMDGPUDriver::get_instance().stream_synchronize(stream_for_setup);
@@ -259,10 +248,9 @@ bool GraphManager::try_launch(int launch_id,
   void *graph = nullptr;
   AMDGPUDriver::get_instance().graph_create(&graph, 0);
 
-  // Each kernel node receives the device-side RuntimeContext pointer via the
-  // shared `cached.kernel_args` extra-config (see graph_manager.h for why all
-  // nodes share one). Stream-parallel groups (`stream_parallel_group_id != 0`)
-  // are silently serialized inside the graph, matching the CUDA implementation.
+  // Each kernel node receives the device-side RuntimeContext pointer via the shared `cached.kernel_args` extra-config
+  // (see graph_manager.h for why all nodes share one). Stream-parallel groups (`stream_parallel_group_id != 0`) are
+  // silently serialized inside the graph, matching the CUDA implementation.
   void *prev_node = nullptr;
   for (const auto &task : offloaded_tasks) {
     void *func = amdgpu_module->lookup_function(task.name);

--- a/quadrants/runtime/amdgpu/graph_manager.cpp
+++ b/quadrants/runtime/amdgpu/graph_manager.cpp
@@ -28,6 +28,17 @@ CachedGraph::CachedGraph(std::size_t arg_buf_size, std::size_t result_buf_size, 
   persistent_ctx.arg_buffer = persistent_device_arg_buffer;
   persistent_ctx.result_buffer = reinterpret_cast<uint64 *>(persistent_device_result_buffer);
   persistent_ctx.cpu_thread_id = 0;
+
+  // The single kernel arg every offloaded task takes is a RuntimeContext *.
+  // Stage the device pointer value into the persistent CachedKernelArgs so
+  // the extra-config addresses are stable for the graph's lifetime.
+  kernel_args.packed_runtime_ctx_ptr = device_runtime_ctx;
+  kernel_args.pack_size = sizeof(void *);
+  kernel_args.extra_config[0] = reinterpret_cast<void *>(0x01);  // HIP_LAUNCH_PARAM_BUFFER_POINTER
+  kernel_args.extra_config[1] = &kernel_args.packed_runtime_ctx_ptr;
+  kernel_args.extra_config[2] = reinterpret_cast<void *>(0x02);  // HIP_LAUNCH_PARAM_BUFFER_SIZE
+  kernel_args.extra_config[3] = &kernel_args.pack_size;
+  kernel_args.extra_config[4] = reinterpret_cast<void *>(0x03);  // HIP_LAUNCH_PARAM_END
 }
 
 CachedGraph::~CachedGraph() {
@@ -51,9 +62,15 @@ CachedGraph::CachedGraph(CachedGraph &&other) noexcept
       persistent_device_result_buffer(other.persistent_device_result_buffer),
       persistent_ctx(other.persistent_ctx),
       device_runtime_ctx(other.device_runtime_ctx),
+      kernel_args(other.kernel_args),
       arg_buffer_size(other.arg_buffer_size),
       result_buffer_size(other.result_buffer_size),
       num_nodes(other.num_nodes) {
+  // The moved-from object must not free our resources at destruction time.
+  // Rebind `kernel_args.extra_config` so it points at *our* members after the
+  // move, not the moved-from object's (which is about to be destroyed).
+  kernel_args.extra_config[1] = &kernel_args.packed_runtime_ctx_ptr;
+  kernel_args.extra_config[3] = &kernel_args.pack_size;
   other.graph_exec = nullptr;
   other.persistent_device_arg_buffer = nullptr;
   other.persistent_device_result_buffer = nullptr;
@@ -69,6 +86,14 @@ CachedGraph &CachedGraph::operator=(CachedGraph &&other) noexcept {
   std::swap(persistent_device_result_buffer, raii_guard.persistent_device_result_buffer);
   std::swap(persistent_ctx, raii_guard.persistent_ctx);
   std::swap(device_runtime_ctx, raii_guard.device_runtime_ctx);
+  std::swap(kernel_args, raii_guard.kernel_args);
+  // After the swap, kernel_args is `raii_guard`'s old kernel_args (which had
+  // extra_config[1,3] bound to its own members). Rebind to ours so the
+  // addresses stay valid through the swap.
+  kernel_args.extra_config[1] = &kernel_args.packed_runtime_ctx_ptr;
+  kernel_args.extra_config[3] = &kernel_args.pack_size;
+  raii_guard.kernel_args.extra_config[1] = &raii_guard.kernel_args.packed_runtime_ctx_ptr;
+  raii_guard.kernel_args.extra_config[3] = &raii_guard.kernel_args.pack_size;
   std::swap(arg_buffer_size, raii_guard.arg_buffer_size);
   std::swap(result_buffer_size, raii_guard.result_buffer_size);
   std::swap(num_nodes, raii_guard.num_nodes);
@@ -132,7 +157,7 @@ void *GraphManager::add_kernel_node(void *graph,
                                     unsigned int grid_dim,
                                     unsigned int block_dim,
                                     unsigned int shared_mem,
-                                    void **kernel_params) {
+                                    CachedKernelArgs &kernel_args) {
   // Opt in to the requested dynamic shared memory size. `hipFuncSetAttribute`
   // is mostly a no-op for the AMD backend per its header comments, but we
   // call it for parity with the CUDA path and to forward the request to any
@@ -146,12 +171,19 @@ void *GraphManager::add_kernel_node(void *graph,
   params.blockDimX = block_dim;
   params.blockDimY = 1;
   params.blockDimZ = 1;
-  params.extra = nullptr;
+  // HIP's AMD backend expects kernel args via the `extra` byte-buffer convention
+  // (HIP_LAUNCH_PARAM_BUFFER_POINTER / SIZE / END markers), not via the
+  // per-arg `kernelParams` array. See the matching setup in
+  // `rhi/amdgpu/amdgpu_context.cpp::AMDGPUContext::launch`. Passing
+  // `kernelParams` here instead silently corrupts kernel arg loads on RDNA3
+  // and the launched kernels fault asynchronously, surfacing as
+  // `hipErrorIllegalAddress` at the next host-visible sync point.
+  params.extra = kernel_args.extra_config;
   params.func = func;
   params.gridDimX = grid_dim;
   params.gridDimY = 1;
   params.gridDimZ = 1;
-  params.kernelParams = kernel_params;
+  params.kernelParams = nullptr;
   params.sharedMemBytes = shared_mem;
 
   void *node = nullptr;
@@ -161,11 +193,14 @@ void *GraphManager::add_kernel_node(void *graph,
 }
 
 bool GraphManager::launch_cached_graph(CachedGraph &cached, LaunchContextBuilder &ctx) {
-  if (ctx.arg_buffer_size > 0) {
-    AMDGPUDriver::get_instance().memcpy_host_to_device(cached.persistent_device_arg_buffer,
-                                                       ctx.get_context().arg_buffer, cached.arg_buffer_size);
-  }
   auto *stream = AMDGPUContext::get_instance().get_stream();
+  if (ctx.arg_buffer_size > 0) {
+    // Async HtoD on the launch stream: the subsequent `graph_launch` is queued on the same stream,
+    // so the kernel nodes are ordered after the arg-buffer upload without a host-side barrier.
+    AMDGPUDriver::get_instance().memcpy_host_to_device_async(cached.persistent_device_arg_buffer,
+                                                             ctx.get_context().arg_buffer, cached.arg_buffer_size,
+                                                             stream);
+  }
   AMDGPUDriver::get_instance().graph_launch(cached.graph_exec, stream);
   used_on_last_call_ = true;
   num_nodes_on_last_call_ = cached.num_nodes;
@@ -207,32 +242,32 @@ bool GraphManager::try_launch(int launch_id,
   AMDGPUContext::get_instance().make_current();
   CachedGraph cached(ctx.arg_buffer_size, ctx.result_buffer_size, executor);
 
+  auto *stream_for_setup = AMDGPUContext::get_instance().get_stream();
   if (cached.arg_buffer_size > 0) {
-    AMDGPUDriver::get_instance().memcpy_host_to_device(cached.persistent_device_arg_buffer,
-                                                       ctx.get_context().arg_buffer, cached.arg_buffer_size);
+    AMDGPUDriver::get_instance().memcpy_host_to_device_async(cached.persistent_device_arg_buffer,
+                                                             ctx.get_context().arg_buffer, cached.arg_buffer_size,
+                                                             stream_for_setup);
   }
 
   // Stage the RuntimeContext on device. Its arg_buffer / result_buffer
   // pointers reference the persistent device buffers above; none of its
   // fields change between graph launches so one copy is sufficient.
-  AMDGPUDriver::get_instance().memcpy_host_to_device(cached.device_runtime_ctx, &cached.persistent_ctx,
-                                                     sizeof(RuntimeContext));
+  AMDGPUDriver::get_instance().memcpy_host_to_device_async(cached.device_runtime_ctx, &cached.persistent_ctx,
+                                                           sizeof(RuntimeContext), stream_for_setup);
+  AMDGPUDriver::get_instance().stream_synchronize(stream_for_setup);
 
   void *graph = nullptr;
   AMDGPUDriver::get_instance().graph_create(&graph, 0);
 
-  // Each kernel node receives the device-side RuntimeContext pointer. Note we
-  // bake the value of `device_runtime_ctx` (a single device address) into the
-  // kernel-node args; the kernels on the GPU then dereference this pointer to
-  // read the arg buffer / result buffer pointers. Stream-parallel groups
-  // (`stream_parallel_group_id != 0`) are silently serialized inside the
-  // graph, matching the CUDA implementation.
+  // Each kernel node receives the device-side RuntimeContext pointer via the
+  // shared `cached.kernel_args` extra-config (see graph_manager.h for why all
+  // nodes share one). Stream-parallel groups (`stream_parallel_group_id != 0`)
+  // are silently serialized inside the graph, matching the CUDA implementation.
   void *prev_node = nullptr;
   for (const auto &task : offloaded_tasks) {
-    void *ctx_ptr = cached.device_runtime_ctx;
-    prev_node =
-        add_kernel_node(graph, prev_node, amdgpu_module->lookup_function(task.name), (unsigned int)task.grid_dim,
-                        (unsigned int)task.block_dim, (unsigned int)task.dynamic_shared_array_bytes, &ctx_ptr);
+    void *func = amdgpu_module->lookup_function(task.name);
+    prev_node = add_kernel_node(graph, prev_node, func, (unsigned int)task.grid_dim, (unsigned int)task.block_dim,
+                                (unsigned int)task.dynamic_shared_array_bytes, cached.kernel_args);
   }
 
   AMDGPUDriver::get_instance().graph_instantiate(&cached.graph_exec, graph, nullptr, nullptr, 0);

--- a/quadrants/runtime/amdgpu/graph_manager.cpp
+++ b/quadrants/runtime/amdgpu/graph_manager.cpp
@@ -1,0 +1,256 @@
+#include "quadrants/runtime/amdgpu/graph_manager.h"
+#include "quadrants/runtime/amdgpu/amdgpu_utils.h"
+#include "quadrants/rhi/amdgpu/amdgpu_context.h"
+#include "quadrants/rhi/amdgpu/amdgpu_driver.h"
+
+#include <algorithm>
+#include <vector>
+
+namespace quadrants::lang {
+namespace amdgpu {
+
+CachedGraph::CachedGraph(std::size_t arg_buf_size, std::size_t result_buf_size, LlvmRuntimeExecutor *executor)
+    : arg_buffer_size(arg_buf_size), result_buffer_size(result_buf_size) {
+  AMDGPUDriver::get_instance().malloc(reinterpret_cast<void **>(&persistent_device_result_buffer),
+                                      std::max(result_buffer_size, sizeof(uint64)));
+
+  if (arg_buffer_size > 0) {
+    AMDGPUDriver::get_instance().malloc(reinterpret_cast<void **>(&persistent_device_arg_buffer), arg_buffer_size);
+  }
+
+  // Device-side `RuntimeContext` for graph kernel-node args. Unlike the CUDA
+  // path which passes a host pointer (relying on UVA / HMM), AMDGPU kernels
+  // dereference the pointer directly on the GPU, so it must point at device
+  // memory. See `runtime/amdgpu/graph_manager.h` for the full rationale.
+  AMDGPUDriver::get_instance().malloc(&device_runtime_ctx, sizeof(RuntimeContext));
+
+  persistent_ctx.runtime = executor->get_llvm_runtime();
+  persistent_ctx.arg_buffer = persistent_device_arg_buffer;
+  persistent_ctx.result_buffer = reinterpret_cast<uint64 *>(persistent_device_result_buffer);
+  persistent_ctx.cpu_thread_id = 0;
+}
+
+CachedGraph::~CachedGraph() {
+  if (graph_exec) {
+    AMDGPUDriver::get_instance().graph_exec_destroy(graph_exec);
+  }
+  if (persistent_device_arg_buffer) {
+    AMDGPUDriver::get_instance().mem_free(persistent_device_arg_buffer);
+  }
+  if (persistent_device_result_buffer) {
+    AMDGPUDriver::get_instance().mem_free(persistent_device_result_buffer);
+  }
+  if (device_runtime_ctx) {
+    AMDGPUDriver::get_instance().mem_free(device_runtime_ctx);
+  }
+}
+
+CachedGraph::CachedGraph(CachedGraph &&other) noexcept
+    : graph_exec(other.graph_exec),
+      persistent_device_arg_buffer(other.persistent_device_arg_buffer),
+      persistent_device_result_buffer(other.persistent_device_result_buffer),
+      persistent_ctx(other.persistent_ctx),
+      device_runtime_ctx(other.device_runtime_ctx),
+      arg_buffer_size(other.arg_buffer_size),
+      result_buffer_size(other.result_buffer_size),
+      num_nodes(other.num_nodes) {
+  other.graph_exec = nullptr;
+  other.persistent_device_arg_buffer = nullptr;
+  other.persistent_device_result_buffer = nullptr;
+  other.device_runtime_ctx = nullptr;
+}
+
+CachedGraph &CachedGraph::operator=(CachedGraph &&other) noexcept {
+  // Move-and-swap: after the swaps, `raii_guard` holds our old resources and
+  // its destructor frees them, so every owned pointer is released uniformly.
+  CachedGraph raii_guard(std::move(other));
+  std::swap(graph_exec, raii_guard.graph_exec);
+  std::swap(persistent_device_arg_buffer, raii_guard.persistent_device_arg_buffer);
+  std::swap(persistent_device_result_buffer, raii_guard.persistent_device_result_buffer);
+  std::swap(persistent_ctx, raii_guard.persistent_ctx);
+  std::swap(device_runtime_ctx, raii_guard.device_runtime_ctx);
+  std::swap(arg_buffer_size, raii_guard.arg_buffer_size);
+  std::swap(result_buffer_size, raii_guard.result_buffer_size);
+  std::swap(num_nodes, raii_guard.num_nodes);
+  return *this;
+}
+
+// Resolves ndarray parameter handles in the launch context to raw device
+// pointers, writing them into the arg buffer via `set_ndarray_ptrs`.
+//
+// Unlike the normal launch path, this does not handle host-resident arrays
+// (no temporary device allocation or host-to-device transfer). Errors if any
+// external array is on the host, since graph mode bakes device pointers into
+// the cached graph.
+void GraphManager::resolve_ctx_ndarray_ptrs(LaunchContextBuilder &ctx,
+                                            const std::vector<std::pair<int, Callable::Parameter>> &parameters,
+                                            LlvmRuntimeExecutor *executor) {
+  for (int i = 0; i < (int)parameters.size(); i++) {
+    const auto &kv = parameters[i];
+    const auto &arg_id = kv.first;
+    const auto &parameter = kv.second;
+    if (parameter.is_array) {
+      const auto arr_sz = ctx.array_runtime_sizes[arg_id];
+      if (arr_sz == 0)
+        continue;
+
+      ArgArrayPtrKey data_ptr_idx{arg_id, TypeFactory::DATA_PTR_POS_IN_NDARRAY};
+      ArgArrayPtrKey grad_ptr_idx{arg_id, TypeFactory::GRAD_PTR_POS_IN_NDARRAY};
+      auto data_ptr = ctx.array_ptrs[data_ptr_idx];
+      auto grad_ptr = ctx.array_ptrs[grad_ptr_idx];
+
+      QD_ERROR_IF(grad_ptr != nullptr,
+                  "graph does not support autograd; "
+                  "ndarray arg {} has a non-null gradient pointer",
+                  arg_id);
+
+      void *resolved_data = nullptr;
+      if (ctx.device_allocation_type[arg_id] == LaunchContextBuilder::DevAllocType::kNone) {
+        QD_ERROR_IF(!on_amdgpu_device(data_ptr),
+                    "graph requires all ndarrays to be device-resident; "
+                    "ndarray arg {} is host-resident",
+                    arg_id);
+        resolved_data = data_ptr;
+      } else if (arr_sz > 0) {
+        DeviceAllocation *ptr = static_cast<DeviceAllocation *>(data_ptr);
+        resolved_data = executor->get_device_alloc_info_ptr(*ptr);
+      }
+
+      if (resolved_data) {
+        ctx.set_ndarray_ptrs(arg_id, (uint64)resolved_data, (uint64) nullptr);
+        if (arg_id == ctx.graph_do_while_arg_id) {
+          ctx.graph_do_while_flag_dev_ptr = resolved_data;
+        }
+      }
+    }
+  }
+}
+
+void *GraphManager::add_kernel_node(void *graph,
+                                    void *prev_node,
+                                    void *func,
+                                    unsigned int grid_dim,
+                                    unsigned int block_dim,
+                                    unsigned int shared_mem,
+                                    void **kernel_params) {
+  // Opt in to the requested dynamic shared memory size. `hipFuncSetAttribute`
+  // is mostly a no-op for the AMD backend per its header comments, but we
+  // call it for parity with the CUDA path and to forward the request to any
+  // backend that honours it.
+  if (shared_mem > 0) {
+    AMDGPUDriver::get_instance().kernel_set_attribute(func, HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                                                      static_cast<int>(shared_mem));
+  }
+
+  HipKernelNodeParams params{};
+  params.blockDimX = block_dim;
+  params.blockDimY = 1;
+  params.blockDimZ = 1;
+  params.extra = nullptr;
+  params.func = func;
+  params.gridDimX = grid_dim;
+  params.gridDimY = 1;
+  params.gridDimZ = 1;
+  params.kernelParams = kernel_params;
+  params.sharedMemBytes = shared_mem;
+
+  void *node = nullptr;
+  AMDGPUDriver::get_instance().graph_add_kernel_node(&node, graph, prev_node ? &prev_node : nullptr, prev_node ? 1 : 0,
+                                                     &params);
+  return node;
+}
+
+bool GraphManager::launch_cached_graph(CachedGraph &cached, LaunchContextBuilder &ctx) {
+  if (ctx.arg_buffer_size > 0) {
+    AMDGPUDriver::get_instance().memcpy_host_to_device(cached.persistent_device_arg_buffer,
+                                                       ctx.get_context().arg_buffer, cached.arg_buffer_size);
+  }
+  auto *stream = AMDGPUContext::get_instance().get_stream();
+  AMDGPUDriver::get_instance().graph_launch(cached.graph_exec, stream);
+  used_on_last_call_ = true;
+  num_nodes_on_last_call_ = cached.num_nodes;
+  return true;
+}
+
+bool GraphManager::try_launch(int launch_id,
+                              LaunchContextBuilder &ctx,
+                              JITModule *amdgpu_module,
+                              const std::vector<std::pair<int, Callable::Parameter>> &parameters,
+                              const std::vector<OffloadedTask> &offloaded_tasks,
+                              LlvmRuntimeExecutor *executor) {
+  if (offloaded_tasks.empty()) {
+    return false;
+  }
+
+  QD_ERROR_IF(ctx.result_buffer_size > 0,
+              "graph=True is not supported for kernels with struct return "
+              "values; remove graph=True or avoid returning values");
+
+  // Adstack-bearing kernels cannot go through the graph path. See the matching comment in
+  // `runtime/cuda/graph_manager.cpp::try_launch` for the full rationale: the per-task adstack
+  // setup runs host-side between the serial range_for-bounds kernel and the range_for kernel
+  // itself, and there is no host hook between graph nodes.
+  for (const auto &task : offloaded_tasks) {
+    QD_ERROR_IF(!task.ad_stack.allocas.empty(),
+                "graph=True is not supported for kernels that use the reverse-mode autodiff stack "
+                "(task '{}' has {} adstack allocas). Launch without graph=True.",
+                task.name, task.ad_stack.allocas.size());
+  }
+
+  resolve_ctx_ndarray_ptrs(ctx, parameters, executor);
+
+  auto it = cache_.find(launch_id);
+  if (it != cache_.end()) {
+    return launch_cached_graph(it->second, ctx);
+  }
+
+  AMDGPUContext::get_instance().make_current();
+  CachedGraph cached(ctx.arg_buffer_size, ctx.result_buffer_size, executor);
+
+  if (cached.arg_buffer_size > 0) {
+    AMDGPUDriver::get_instance().memcpy_host_to_device(cached.persistent_device_arg_buffer,
+                                                       ctx.get_context().arg_buffer, cached.arg_buffer_size);
+  }
+
+  // Stage the RuntimeContext on device. Its arg_buffer / result_buffer
+  // pointers reference the persistent device buffers above; none of its
+  // fields change between graph launches so one copy is sufficient.
+  AMDGPUDriver::get_instance().memcpy_host_to_device(cached.device_runtime_ctx, &cached.persistent_ctx,
+                                                     sizeof(RuntimeContext));
+
+  void *graph = nullptr;
+  AMDGPUDriver::get_instance().graph_create(&graph, 0);
+
+  // Each kernel node receives the device-side RuntimeContext pointer. Note we
+  // bake the value of `device_runtime_ctx` (a single device address) into the
+  // kernel-node args; the kernels on the GPU then dereference this pointer to
+  // read the arg buffer / result buffer pointers. Stream-parallel groups
+  // (`stream_parallel_group_id != 0`) are silently serialized inside the
+  // graph, matching the CUDA implementation.
+  void *prev_node = nullptr;
+  for (const auto &task : offloaded_tasks) {
+    void *ctx_ptr = cached.device_runtime_ctx;
+    prev_node =
+        add_kernel_node(graph, prev_node, amdgpu_module->lookup_function(task.name), (unsigned int)task.grid_dim,
+                        (unsigned int)task.block_dim, (unsigned int)task.dynamic_shared_array_bytes, &ctx_ptr);
+  }
+
+  AMDGPUDriver::get_instance().graph_instantiate(&cached.graph_exec, graph, nullptr, nullptr, 0);
+
+  auto *stream = AMDGPUContext::get_instance().get_stream();
+  AMDGPUDriver::get_instance().graph_launch(cached.graph_exec, stream);
+
+  AMDGPUDriver::get_instance().graph_destroy(graph);
+
+  cached.num_nodes = offloaded_tasks.size();
+  QD_TRACE("HIP graph created with {} kernel nodes for launch_id={}", cached.num_nodes, launch_id);
+
+  num_nodes_on_last_call_ = cached.num_nodes;
+  ++total_builds_;
+  cache_.emplace(launch_id, std::move(cached));
+  used_on_last_call_ = true;
+  return true;
+}
+
+}  // namespace amdgpu
+}  // namespace quadrants::lang

--- a/quadrants/runtime/amdgpu/graph_manager.h
+++ b/quadrants/runtime/amdgpu/graph_manager.h
@@ -10,15 +10,13 @@
 namespace quadrants::lang {
 namespace amdgpu {
 
-// Mirrors `hipKernelNodeParams` from /opt/rocm/include/hip/hip_runtime_api.h.
-// We define our own copy because Quadrants loads the HIP runtime dynamically
-// rather than linking against it, so we don't pull in the HIP headers here.
-// Field order matters: HIP's struct is NOT the same shape as CUDA's
-// `CUDA_KERNEL_NODE_PARAMS` (see `runtime/cuda/graph_manager.h`).
+// Mirrors `hipKernelNodeParams` from /opt/rocm/include/hip/hip_runtime_api.h. We define our own copy because Quadrants
+// loads the HIP runtime dynamically rather than linking against it, so we don't pull in the HIP headers here. Field
+// order matters: HIP's struct is NOT the same shape as CUDA's `CUDA_KERNEL_NODE_PARAMS` (see
+// `runtime/cuda/graph_manager.h`).
 struct HipKernelNodeParams {
-  // HIP's `dim3` is `{uint32 x, uint32 y, uint32 z}`. We flatten to three
-  // explicit fields rather than depending on the HIP type to keep this file
-  // header-only.
+  // HIP's `dim3` is `{uint32 x, uint32 y, uint32 z}`. We flatten to three explicit fields rather than depending on the
+  // HIP type to keep this file header-only.
   unsigned int blockDimX;
   unsigned int blockDimY;
   unsigned int blockDimZ;
@@ -31,56 +29,45 @@ struct HipKernelNodeParams {
   unsigned int sharedMemBytes;
 };
 
-// Kernel node arg-packing wrapper. HIP's hipModuleLaunchKernel on AMD requires
-// args via the `extra` byte-buffer convention (see
-// `rhi/amdgpu/amdgpu_context.cpp::AMDGPUContext::launch`), not via the per-arg
-// `kernelParams` pointer array. Graph kernel nodes follow the same calling
-// convention, so we mirror the non-graph launcher's setup: a packed byte
-// buffer + a 5-element extra config with HIP_LAUNCH_PARAM_* markers.
+// Kernel node arg-packing wrapper. HIP's hipModuleLaunchKernel on AMD requires args via the `extra` byte-buffer
+// convention (see `rhi/amdgpu/amdgpu_context.cpp::AMDGPUContext::launch`), not via the per-arg `kernelParams` pointer
+// array. Graph kernel nodes follow the same calling convention, so we mirror the non-graph launcher's setup: a packed
+// byte buffer + a 5-element extra config with HIP_LAUNCH_PARAM_* markers.
 //
-// One instance per graph (not per node): all kernel nodes in a cached graph
-// share a single `device_runtime_ctx` pointer arg, and the size never changes.
+// One instance per graph (not per node): all kernel nodes in a cached graph share a single `device_runtime_ctx` pointer
+// arg, and the size never changes.
 struct CachedKernelArgs {
-  // Byte-packed copy of the single kernel arg: the device-side RuntimeContext
-  // pointer. Sized for `sizeof(void *)`.
+  // Byte-packed copy of the single kernel arg: the device-side RuntimeContext pointer. Sized for `sizeof(void *)`.
   void *packed_runtime_ctx_ptr{nullptr};
   std::size_t pack_size{sizeof(void *)};
-  // {HIP_LAUNCH_PARAM_BUFFER_POINTER=0x01, &packed_runtime_ctx_ptr,
-  //  HIP_LAUNCH_PARAM_BUFFER_SIZE=0x02, &pack_size, HIP_LAUNCH_PARAM_END=0x03}.
-  // Held by value so its address is stable for the graph's lifetime.
+  // {HIP_LAUNCH_PARAM_BUFFER_POINTER=0x01, &packed_runtime_ctx_ptr, HIP_LAUNCH_PARAM_BUFFER_SIZE=0x02, &pack_size,
+  // HIP_LAUNCH_PARAM_END=0x03}. Held by value so its address is stable for the graph's lifetime.
   void *extra_config[5]{};
 };
 
-// Per-(launch_id) graph cache entry. Construction allocates the persistent
-// device-side buffers that the cached graph reads through; destruction frees
-// them and the instantiated `hipGraphExec_t`.
+// Per-(launch_id) graph cache entry. Construction allocates the persistent device-side buffers that the cached graph
+// reads through; destruction frees them and the instantiated `hipGraphExec_t`.
 struct CachedGraph {
-  // hipGraphExec_t. The instantiated, launchable form of the captured HIP
-  // graph. Typed as void * since the driver is loaded dynamically.
+  // hipGraphExec_t. The instantiated, launchable form of the captured HIP graph. Typed as void * since the driver is
+  // loaded dynamically.
   void *graph_exec{nullptr};
-  // Persistent device buffer that the host arg buffer is copied into before
-  // every graph launch. The graph kernel nodes read from this address
-  // (baked in via the persistent `RuntimeContext`'s `arg_buffer` field below).
+  // Persistent device buffer that the host arg buffer is copied into before every graph launch. The graph kernel nodes
+  // read from this address (baked in via the persistent `RuntimeContext`'s `arg_buffer` field below).
   char *persistent_device_arg_buffer{nullptr};
-  // Persistent device buffer for struct return values. Unused at the moment
-  // (graph mode rejects kernels with struct returns up-front) but kept for
-  // parity with the CUDA implementation and future expansion.
+  // Persistent device buffer for struct return values. Unused at the moment (graph mode rejects kernels with struct
+  // returns up-front) but kept for parity with the CUDA implementation and future expansion.
   char *persistent_device_result_buffer{nullptr};
-  // Host-side shadow of the `RuntimeContext` fields. The pointers it carries
-  // (`runtime`, `arg_buffer`, `result_buffer`) reference the persistent
-  // device buffers above. Filled once in the constructor; copied into
+  // Host-side shadow of the `RuntimeContext` fields. The pointers it carries (`runtime`, `arg_buffer`,
+  // `result_buffer`) reference the persistent device buffers above. Filled once in the constructor; copied into
   // `device_runtime_ctx` exactly once at graph build time.
   RuntimeContext persistent_ctx{};
-  // Device-resident copy of `persistent_ctx`. The graph's kernel-node args
-  // bake the *value* of this pointer; the kernels dereference it on the GPU
-  // to reach the persistent arg / result buffers. Unlike the CUDA path which
-  // can pass a host pointer and rely on UVA / HMM, the AMDGPU runtime
-  // device-stages the `RuntimeContext` (see `runtime/amdgpu/kernel_launcher.cpp`
-  // for the per-launch equivalent).
+  // Device-resident copy of `persistent_ctx`. The graph's kernel-node args bake the *value* of this pointer; the
+  // kernels dereference it on the GPU to reach the persistent arg / result buffers. Unlike the CUDA path which can pass
+  // a host pointer and rely on UVA / HMM, the AMDGPU runtime device-stages the `RuntimeContext` (see
+  // `runtime/amdgpu/kernel_launcher.cpp` for the per-launch equivalent).
   void *device_runtime_ctx{nullptr};
-  // Per-graph kernel-arg packing (see CachedKernelArgs). Held by value so the
-  // `extra_config` array's address is stable for the cached graph's lifetime.
-  // All kernel nodes in this graph share the same packed args (the device
+  // Per-graph kernel-arg packing (see CachedKernelArgs). Held by value so the `extra_config` array's address is stable
+  // for the cached graph's lifetime. All kernel nodes in this graph share the same packed args (the device
   // RuntimeContext pointer).
   CachedKernelArgs kernel_args;
   std::size_t arg_buffer_size{0};
@@ -97,11 +84,9 @@ struct CachedGraph {
 
 class GraphManager {
  public:
-  // Attempts to launch the kernel via a cached or newly built HIP graph.
-  // Returns true on success; false if the graph path can't be used (e.g.
-  // host-resident ndarrays) and the caller should fall back to the regular
-  // streaming launch. Tracks whether the graph was used, queryable via
-  // `used_on_last_call()`.
+  // Attempts to launch the kernel via a cached or newly built HIP graph. Returns true on success; false if the graph
+  // path can't be used (e.g. host-resident ndarrays) and the caller should fall back to the regular streaming launch.
+  // Tracks whether the graph was used, queryable via `used_on_last_call()`.
   bool try_launch(int launch_id,
                   LaunchContextBuilder &ctx,
                   JITModule *amdgpu_module,
@@ -109,9 +94,8 @@ class GraphManager {
                   const std::vector<OffloadedTask> &offloaded_tasks,
                   LlvmRuntimeExecutor *executor);
 
-  // Reset the per-call flags. Called by the launcher when the graph path is
-  // skipped, so the test-facing accessors below report the absence of a
-  // cache hit on the most recent launch.
+  // Reset the per-call flags. Called by the launcher when the graph path is skipped, so the test-facing accessors
+  // below report the absence of a cache hit on the most recent launch.
   void mark_not_used() {
     used_on_last_call_ = false;
     num_nodes_on_last_call_ = 0;
@@ -142,8 +126,8 @@ class GraphManager {
                         unsigned int shared_mem,
                         CachedKernelArgs &kernel_args);
 
-  // Keyed by `launch_id`, which uniquely identifies a compiled kernel variant
-  // (each template specialization gets its own launch_id).
+  // Keyed by `launch_id`, which uniquely identifies a compiled kernel variant (each template specialization gets its
+  // own launch_id).
   std::unordered_map<int, CachedGraph> cache_;
   bool used_on_last_call_{false};
   std::size_t num_nodes_on_last_call_{0};

--- a/quadrants/runtime/amdgpu/graph_manager.h
+++ b/quadrants/runtime/amdgpu/graph_manager.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include <cstddef>
+#include <unordered_map>
+#include <vector>
+
+#include "quadrants/codegen/llvm/compiled_kernel_data.h"
+#include "quadrants/runtime/llvm/llvm_runtime_executor.h"
+
+namespace quadrants::lang {
+namespace amdgpu {
+
+// Mirrors `hipKernelNodeParams` from /opt/rocm/include/hip/hip_runtime_api.h.
+// We define our own copy because Quadrants loads the HIP runtime dynamically
+// rather than linking against it, so we don't pull in the HIP headers here.
+// Field order matters: HIP's struct is NOT the same shape as CUDA's
+// `CUDA_KERNEL_NODE_PARAMS` (see `runtime/cuda/graph_manager.h`).
+struct HipKernelNodeParams {
+  // HIP's `dim3` is `{uint32 x, uint32 y, uint32 z}`. We flatten to three
+  // explicit fields rather than depending on the HIP type to keep this file
+  // header-only.
+  unsigned int blockDimX;
+  unsigned int blockDimY;
+  unsigned int blockDimZ;
+  void **extra;
+  void *func;
+  unsigned int gridDimX;
+  unsigned int gridDimY;
+  unsigned int gridDimZ;
+  void **kernelParams;
+  unsigned int sharedMemBytes;
+};
+
+// Per-(launch_id) graph cache entry. Construction allocates the persistent
+// device-side buffers that the cached graph reads through; destruction frees
+// them and the instantiated `hipGraphExec_t`.
+struct CachedGraph {
+  // hipGraphExec_t. The instantiated, launchable form of the captured HIP
+  // graph. Typed as void * since the driver is loaded dynamically.
+  void *graph_exec{nullptr};
+  // Persistent device buffer that the host arg buffer is copied into before
+  // every graph launch. The graph kernel nodes read from this address
+  // (baked in via the persistent `RuntimeContext`'s `arg_buffer` field below).
+  char *persistent_device_arg_buffer{nullptr};
+  // Persistent device buffer for struct return values. Unused at the moment
+  // (graph mode rejects kernels with struct returns up-front) but kept for
+  // parity with the CUDA implementation and future expansion.
+  char *persistent_device_result_buffer{nullptr};
+  // Host-side shadow of the `RuntimeContext` fields. The pointers it carries
+  // (`runtime`, `arg_buffer`, `result_buffer`) reference the persistent
+  // device buffers above. Filled once in the constructor; copied into
+  // `device_runtime_ctx` exactly once at graph build time.
+  RuntimeContext persistent_ctx{};
+  // Device-resident copy of `persistent_ctx`. The graph's kernel-node args
+  // bake the *value* of this pointer; the kernels dereference it on the GPU
+  // to reach the persistent arg / result buffers. Unlike the CUDA path which
+  // can pass a host pointer and rely on UVA / HMM, the AMDGPU runtime
+  // device-stages the `RuntimeContext` (see `runtime/amdgpu/kernel_launcher.cpp`
+  // for the per-launch equivalent).
+  void *device_runtime_ctx{nullptr};
+  std::size_t arg_buffer_size{0};
+  std::size_t result_buffer_size{0};
+  std::size_t num_nodes{0};
+
+  CachedGraph(std::size_t arg_buffer_size, std::size_t result_buffer_size, LlvmRuntimeExecutor *executor);
+  ~CachedGraph();
+  CachedGraph(const CachedGraph &) = delete;
+  CachedGraph &operator=(const CachedGraph &) = delete;
+  CachedGraph(CachedGraph &&other) noexcept;
+  CachedGraph &operator=(CachedGraph &&other) noexcept;
+};
+
+class GraphManager {
+ public:
+  // Attempts to launch the kernel via a cached or newly built HIP graph.
+  // Returns true on success; false if the graph path can't be used (e.g.
+  // host-resident ndarrays) and the caller should fall back to the regular
+  // streaming launch. Tracks whether the graph was used, queryable via
+  // `used_on_last_call()`.
+  bool try_launch(int launch_id,
+                  LaunchContextBuilder &ctx,
+                  JITModule *amdgpu_module,
+                  const std::vector<std::pair<int, Callable::Parameter>> &parameters,
+                  const std::vector<OffloadedTask> &offloaded_tasks,
+                  LlvmRuntimeExecutor *executor);
+
+  // Reset the per-call flags. Called by the launcher when the graph path is
+  // skipped, so the test-facing accessors below report the absence of a
+  // cache hit on the most recent launch.
+  void mark_not_used() {
+    used_on_last_call_ = false;
+    num_nodes_on_last_call_ = 0;
+  }
+  std::size_t cache_size() const {
+    return cache_.size();
+  }
+  bool used_on_last_call() const {
+    return used_on_last_call_;
+  }
+  std::size_t num_nodes_on_last_call() const {
+    return num_nodes_on_last_call_;
+  }
+  std::size_t total_builds() const {
+    return total_builds_;
+  }
+
+ private:
+  bool launch_cached_graph(CachedGraph &cached, LaunchContextBuilder &ctx);
+  void resolve_ctx_ndarray_ptrs(LaunchContextBuilder &ctx,
+                                const std::vector<std::pair<int, Callable::Parameter>> &parameters,
+                                LlvmRuntimeExecutor *executor);
+  void *add_kernel_node(void *graph,
+                        void *prev_node,
+                        void *func,
+                        unsigned int grid_dim,
+                        unsigned int block_dim,
+                        unsigned int shared_mem,
+                        void **kernel_params);
+
+  // Keyed by `launch_id`, which uniquely identifies a compiled kernel variant
+  // (each template specialization gets its own launch_id).
+  std::unordered_map<int, CachedGraph> cache_;
+  bool used_on_last_call_{false};
+  std::size_t num_nodes_on_last_call_{0};
+  std::size_t total_builds_{0};
+};
+
+}  // namespace amdgpu
+}  // namespace quadrants::lang

--- a/quadrants/runtime/amdgpu/graph_manager.h
+++ b/quadrants/runtime/amdgpu/graph_manager.h
@@ -31,6 +31,26 @@ struct HipKernelNodeParams {
   unsigned int sharedMemBytes;
 };
 
+// Kernel node arg-packing wrapper. HIP's hipModuleLaunchKernel on AMD requires
+// args via the `extra` byte-buffer convention (see
+// `rhi/amdgpu/amdgpu_context.cpp::AMDGPUContext::launch`), not via the per-arg
+// `kernelParams` pointer array. Graph kernel nodes follow the same calling
+// convention, so we mirror the non-graph launcher's setup: a packed byte
+// buffer + a 5-element extra config with HIP_LAUNCH_PARAM_* markers.
+//
+// One instance per graph (not per node): all kernel nodes in a cached graph
+// share a single `device_runtime_ctx` pointer arg, and the size never changes.
+struct CachedKernelArgs {
+  // Byte-packed copy of the single kernel arg: the device-side RuntimeContext
+  // pointer. Sized for `sizeof(void *)`.
+  void *packed_runtime_ctx_ptr{nullptr};
+  std::size_t pack_size{sizeof(void *)};
+  // {HIP_LAUNCH_PARAM_BUFFER_POINTER=0x01, &packed_runtime_ctx_ptr,
+  //  HIP_LAUNCH_PARAM_BUFFER_SIZE=0x02, &pack_size, HIP_LAUNCH_PARAM_END=0x03}.
+  // Held by value so its address is stable for the graph's lifetime.
+  void *extra_config[5]{};
+};
+
 // Per-(launch_id) graph cache entry. Construction allocates the persistent
 // device-side buffers that the cached graph reads through; destruction frees
 // them and the instantiated `hipGraphExec_t`.
@@ -58,6 +78,11 @@ struct CachedGraph {
   // device-stages the `RuntimeContext` (see `runtime/amdgpu/kernel_launcher.cpp`
   // for the per-launch equivalent).
   void *device_runtime_ctx{nullptr};
+  // Per-graph kernel-arg packing (see CachedKernelArgs). Held by value so the
+  // `extra_config` array's address is stable for the cached graph's lifetime.
+  // All kernel nodes in this graph share the same packed args (the device
+  // RuntimeContext pointer).
+  CachedKernelArgs kernel_args;
   std::size_t arg_buffer_size{0};
   std::size_t result_buffer_size{0};
   std::size_t num_nodes{0};
@@ -115,7 +140,7 @@ class GraphManager {
                         unsigned int grid_dim,
                         unsigned int block_dim,
                         unsigned int shared_mem,
-                        void **kernel_params);
+                        CachedKernelArgs &kernel_args);
 
   // Keyed by `launch_id`, which uniquely identifies a compiled kernel variant
   // (each template specialization gets its own launch_id).

--- a/quadrants/runtime/amdgpu/kernel_launcher.cpp
+++ b/quadrants/runtime/amdgpu/kernel_launcher.cpp
@@ -235,14 +235,12 @@ bool KernelLauncher::on_amdgpu_device(void *ptr) {
 void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx) {
   QD_ASSERT(handle.get_launch_id() < contexts_.size());
 
-  // HIP graph fast path. Used when the kernel was declared `@qd.kernel(graph=True)` AND there is no
-  // `graph_do_while` arg. The `graph_do_while` case falls through to the regular streaming launch
-  // below, which handles it via `launch_offloaded_tasks_with_do_while` (host-side loop + DtoH of the
-  // counter ndarray each iteration). HIP exposes kernel-launch graph nodes but no conditional / while
-  // nodes today, so the CUDA fast path that builds a conditional graph cannot be ported. The
-  // `AmdgpuDefaultStreamPinGuard` further down is skipped on this branch; that's fine because
-  // `graph_launch` enqueues a single op on the active stream and there are no recursive launches to
-  // reorder.
+  // HIP graph fast path. Used when the kernel was declared `@qd.kernel(graph=True)` AND there is no `graph_do_while`
+  // arg. The `graph_do_while` case falls through to the regular streaming launch below, which handles it via
+  // `launch_offloaded_tasks_with_do_while` (host-side loop + DtoH of the counter ndarray each iteration). HIP exposes
+  // kernel-launch graph nodes but no conditional / while nodes today, so the CUDA fast path that builds a conditional
+  // graph cannot be ported. The `AmdgpuDefaultStreamPinGuard` further down is skipped on this branch; that's fine
+  // because `graph_launch` enqueues a single op on the active stream and there are no recursive launches to reorder.
   if (ctx.use_graph && ctx.graph_do_while_arg_id < 0) {
     auto &lctx = contexts_[handle.get_launch_id()];
     if (graph_manager_.try_launch(handle.get_launch_id(), ctx, lctx.jit_module, *lctx.parameters, lctx.offloaded_tasks,

--- a/quadrants/runtime/amdgpu/kernel_launcher.cpp
+++ b/quadrants/runtime/amdgpu/kernel_launcher.cpp
@@ -6,6 +6,7 @@
 #include "quadrants/program/adstack_size_expr_eval.h"
 #include "quadrants/program/launch_context_builder.h"
 #include "quadrants/program/program.h"
+#include "quadrants/runtime/amdgpu/amdgpu_utils.h"
 #include "quadrants/runtime/llvm/llvm_runtime_executor.h"
 
 namespace quadrants::lang {
@@ -228,15 +229,29 @@ void KernelLauncher::launch_offloaded_tasks_with_do_while(LaunchContextBuilder &
 }
 
 bool KernelLauncher::on_amdgpu_device(void *ptr) {
-  unsigned int attr_val[8];
-  // mem_get_attribute doesn't work well on ROCm
-  uint32_t ret_code = AMDGPUDriver::get_instance().mem_get_attributes.call(attr_val, ptr);
-
-  return ret_code == HIP_SUCCESS && attr_val[0] == HIP_MEMORYTYPE_DEVICE;
+  return ::quadrants::lang::amdgpu::on_amdgpu_device(ptr);
 }
 
 void KernelLauncher::launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx) {
   QD_ASSERT(handle.get_launch_id() < contexts_.size());
+
+  // HIP graph fast path. Used when the kernel was declared `@qd.kernel(graph=True)` AND there is no
+  // `graph_do_while` arg. The `graph_do_while` case falls through to the regular streaming launch
+  // below, which handles it via `launch_offloaded_tasks_with_do_while` (host-side loop + DtoH of the
+  // counter ndarray each iteration). HIP exposes kernel-launch graph nodes but no conditional / while
+  // nodes today, so the CUDA fast path that builds a conditional graph cannot be ported. The
+  // `AmdgpuDefaultStreamPinGuard` further down is skipped on this branch; that's fine because
+  // `graph_launch` enqueues a single op on the active stream and there are no recursive launches to
+  // reorder.
+  if (ctx.use_graph && ctx.graph_do_while_arg_id < 0) {
+    auto &lctx = contexts_[handle.get_launch_id()];
+    if (graph_manager_.try_launch(handle.get_launch_id(), ctx, lctx.jit_module, *lctx.parameters, lctx.offloaded_tasks,
+                                  get_runtime_executor())) {
+      return;
+    }
+  }
+  graph_manager_.mark_not_used();
+
   // Mutable reference: per-handle persistent buffers are lazy-allocated / grow on demand on the first launch of
   // each kernel. Recursive launches from `publish_adstack_metadata`'s host-eval (snode-reader kernels) hit a
   // *different* handle's `Context` and so cannot clobber the parent's `arg_buffer_dev_ptr` / `runtime_context_dev_ptr`.

--- a/quadrants/runtime/amdgpu/kernel_launcher.h
+++ b/quadrants/runtime/amdgpu/kernel_launcher.h
@@ -3,6 +3,7 @@
 #include <deque>
 
 #include "quadrants/codegen/llvm/compiled_kernel_data.h"
+#include "quadrants/runtime/amdgpu/graph_manager.h"
 #include "quadrants/runtime/llvm/kernel_launcher.h"
 
 namespace quadrants::lang {
@@ -32,6 +33,18 @@ class KernelLauncher : public LLVM::KernelLauncher {
 
   void launch_llvm_kernel(Handle handle, LaunchContextBuilder &ctx) override;
   Handle register_llvm_kernel(const LLVM::CompiledKernelData &compiled) override;
+  std::size_t get_graph_cache_size() const override {
+    return graph_manager_.cache_size();
+  }
+  bool get_graph_cache_used_on_last_call() const override {
+    return graph_manager_.used_on_last_call();
+  }
+  std::size_t get_graph_num_nodes_on_last_call() const override {
+    return graph_manager_.num_nodes_on_last_call();
+  }
+  std::size_t get_graph_total_builds() const override {
+    return graph_manager_.total_builds();
+  }
 
  private:
   void launch_offloaded_tasks(LaunchContextBuilder &ctx,
@@ -56,6 +69,7 @@ class KernelLauncher : public LLVM::KernelLauncher {
   // holds a reference into the container.  std::deque never invalidates references on push_back / resize, so the
   // parent's `launcher_ctx` reference survives the child's registration.
   std::deque<Context> contexts_;
+  GraphManager graph_manager_;
 
  public:
   ~KernelLauncher() override;

--- a/tests/python/test_graph.py
+++ b/tests/python/test_graph.py
@@ -15,8 +15,10 @@ def _graph_used():
     return impl.get_runtime().prog.get_graph_cache_used_on_last_call()
 
 
-def _on_cuda():
-    return impl.current_cfg().arch == qd.cuda
+def _platform_supports_graph():
+    """Backends with a real graph cache (CUDA, AMDGPU). Other backends ignore graph=True."""
+    arch = impl.current_cfg().arch
+    return arch == qd.cuda or arch == qd.amdgpu
 
 
 def _num_offloaded_tasks():
@@ -31,7 +33,7 @@ def _graph_num_nodes():
 @test_utils.test()
 def test_graph_two_loops(tensor_type):
     """A kernel with two top-level for loops should be fused into a CUDA graph."""
-    platform_supports_graph = _on_cuda()
+    platform_supports_graph = _platform_supports_graph()
     n = 1024
 
     Annotation = qd.types.NDArray[qd.f32, 1] if tensor_type == qd.ndarray else qd.Template
@@ -70,7 +72,7 @@ def test_graph_two_loops(tensor_type):
 @test_utils.test()
 def test_graph_three_loops(tensor_type):
     """A kernel with three top-level for loops."""
-    platform_supports_graph = _on_cuda()
+    platform_supports_graph = _platform_supports_graph()
     n = 512
 
     Annotation = qd.types.NDArray[qd.f32, 1] if tensor_type == qd.ndarray else qd.Template
@@ -120,7 +122,7 @@ def test_graph_three_loops(tensor_type):
 @test_utils.test()
 def test_graph_multi_func(tensor_type):
     """A kernel calling three funcs with 2, 4, and 3 top-level for loops."""
-    platform_supports_graph = _on_cuda()
+    platform_supports_graph = _platform_supports_graph()
     n = 256
 
     Annotation = qd.types.NDArray[qd.f32, 1] if tensor_type == qd.ndarray else qd.Template
@@ -232,7 +234,7 @@ def test_no_graph_annotation(tensor_type):
 @test_utils.test()
 def test_graph_changed_args(tensor_type):
     """Graph should produce correct results when called with different tensors."""
-    platform_supports_graph = _on_cuda()
+    platform_supports_graph = _platform_supports_graph()
     n = 256
 
     Annotation = qd.types.NDArray[qd.f32, 1] if tensor_type == qd.ndarray else qd.Template
@@ -297,7 +299,7 @@ def test_graph_different_sizes(tensor_type):
     For fields, different-sized fields are separate template specializations,
     so each gets its own graph cache entry.
     """
-    platform_supports_graph = _on_cuda()
+    platform_supports_graph = _platform_supports_graph()
 
     Annotation = qd.types.NDArray[qd.f32, 1] if tensor_type == qd.ndarray else qd.Template
 
@@ -340,7 +342,7 @@ def test_graph_different_sizes(tensor_type):
 @test_utils.test()
 def test_graph_after_reset(tensor_type):
     """graph=True kernel must work correctly after qd.reset()."""
-    platform_supports_graph = _on_cuda()
+    platform_supports_graph = _platform_supports_graph()
 
     Annotation = qd.types.NDArray[qd.f32, 1] if tensor_type == qd.ndarray else qd.Template
 
@@ -386,7 +388,7 @@ def test_graph_after_reset(tensor_type):
 @test_utils.test()
 def test_graph_annotation_cross_platform(tensor_type):
     """graph=True should be a harmless no-op on non-CUDA backends."""
-    platform_supports_graph = _on_cuda()
+    platform_supports_graph = _platform_supports_graph()
     n = 256
 
     Annotation = qd.types.NDArray[qd.f32, 1] if tensor_type == qd.ndarray else qd.Template


### PR DESCRIPTION
## Summary

Ports the basic kernel-launch / instantiate / replay subset of the existing
CUDA graph manager to HIP. Each `@qd.kernel(graph=True)` kernel call now
builds a `hipGraphExec_t` on first invocation and replays it on subsequent
calls — collapsing per-launch overhead the same way the CUDA backend already
does.

Design doc (in [`perso_hugh`](https://github.com/Genesis-Embodied-AI/perso_hugh/blob/main/doc/graph_amd.md)) was iterated through the implementation and reflects the final
shape.

### What's in

- Driver bindings for `hipGraphCreate` / `hipGraphAddKernelNode` /
  `hipGraphInstantiate` / `hipGraphLaunch` / `hipGraphDestroy` /
  `hipGraphExecDestroy` (plus `hipFuncSetAttribute` for shared-memory
  opt-in).
- New `runtime/amdgpu/graph_manager.{h,cpp}`: per-`launch_id` `CachedGraph`
  cache, `resolve_ctx_ndarray_ptrs` for device-only ndarray gating, linear
  kernel-node chaining.
- `runtime/amdgpu/amdgpu_utils.{h,cpp}`: lifts `on_amdgpu_device` to a free
  function so both the launcher and graph manager can share it (mirrors
  `cuda_utils.{h,cpp}`).
- Launcher gates the new path on `ctx.use_graph &&
  ctx.graph_do_while_arg_id < 0` and forwards `get_graph_*` introspection
  accessors so existing tests can introspect cache size / hits / total
  builds the same way they already do on CUDA.

### Two AMDGPU-specific gotchas worth flagging at review

1. **`RuntimeContext` is device-staged, not host-pointer-relied-on.**
   The CUDA graph path passes `&cached.persistent_ctx` (a host pointer) to
   kernels and relies on UVA / HMM. AMDGPU on RDNA3 / Ubuntu doesn't have
   that shortcut by default and the non-graph AMDGPU launcher already
   `hipMalloc`s + `memcpy_host_to_device`s the `RuntimeContext` per launch.
   `CachedGraph` owns a persistent `device_runtime_ctx` buffer and stages
   into it exactly once at graph build (the fields are stable for the
   cached graph's lifetime).
2. **HIP's AMD backend takes kernel args via `extra`, not
   `kernelParams`.** The non-graph AMDGPU launcher already uses the
   `HIP_LAUNCH_PARAM_BUFFER_POINTER` / `BUFFER_SIZE` / `END` byte-buffer
   convention via `hipModuleLaunchKernel`. The graph kernel nodes must use
   the same convention. Passing `kernelParams` instead silently corrupts
   kernel arg loads on RDNA3 and the launched kernels fault asynchronously,
   surfacing as `hipErrorIllegalAddress` at the next host-visible sync. The
   second commit on this branch documents and fixes this — see
   `CachedKernelArgs` in `graph_manager.h` and the `params.extra = ...` /
   `params.kernelParams = nullptr` setup in `add_kernel_node`.

Stream-parallel groups (`stream_parallel_group_id != 0`) are silently
serialized inside the graph, matching the CUDA implementation. A parallel
DAG inside the graph is a possible follow-up.

`graph_do_while` (device-side iteration) is NOT covered by this PR: HIP has
no conditional / while graph nodes as of ROCm 7.2. AMDGPU `graph_do_while`
continues to use the existing host-side loop in
`launch_offloaded_tasks_with_do_while`.

## Test plan

- [x] AMDGPU: `tests/python/test_graph.py` + `tests/python/test_graph_do_while.py` — **24 / 24 passed** on amddesktop (Radeon RX 7900 XTX, `gfx1100` / RDNA3, ROCm 7.2.0).
- [x] AMDGPU regression smoke: `test_ndarray*` + `test_streams.py` — **110 passed, 75 skipped**.
- [x] CUDA regression: `tests/python/test_graph.py` + `tests/python/test_graph_do_while.py` — **24 / 24 passed** on the cluster (RTX PRO 6000 Blackwell).
- [x] User-facing docs updated (`docs/source/user_guide/graph.md`) — renamed "CUDA Graph" → "GPU Graphs", clarified AMDGPU support and `graph_do_while` fall-back behaviour.
- [ ] (deferred) MI300X / `gfx942` verification on `amdcloud` — only RDNA3 / `gfx1100` was hardware-tested here.
- [ ] (deferred) Performance measurement of the AMDGPU graph speed-up; the path is correctness-tested only.


Made with [Cursor](https://cursor.com)