### PR TITLE
[CI] Enable kernel disk cache during tests

### DIFF
--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -6,6 +6,20 @@
 * *format/linter*: Before pushing any commits, ensure you set up `pre-commit` and run it using `pre-commit run -a`
 * No need to force push to keep a clean history as the merging is eventually done by squashing commits.
 
+## Running tests
+
+Run the test suite with `python tests/run_tests.py`. CLI arguments are forwarded to pytest. For example, to run only Metal tests matching a keyword:
+
+```
+python tests/run_tests.py --arch metal -k "test_tile16_cholesky"
+```
+
+### Kernel compilation cache
+
+During test runs, compiled kernels are cached to disk so that the same kernel is not recompiled after each `qd.reset()`/`qd.init()` cycle.
+
+A fresh, empty cache directory is created for each test session by pytest's `tmp_path_factory` (typically under `/tmp/pytest-of-<user>/pytest-<N>/qdcache0/`). Pytest's `tmp_path_retention_count` setting (default: 3) controls how many old sessions' cache dirs are kept. This cache is separate from the user-facing `~/.cache/quadrants/` cache.
+
 ## Creating your build/dev environment
 
 It is recommended to use a virtual env. Quadrants supports Python 3.10–3.13 for building and testing. However, `pre-commit` is configured with a pinned Python `3.10` to ensure consistent formatting, so you will need Python 3.10 available for running pre-commit hooks.

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -14,11 +14,13 @@ Run the test suite with `python tests/run_tests.py`. CLI arguments are forwarded
 python tests/run_tests.py --arch metal -k "test_tile16_cholesky"
 ```
 
+The target architecture can also be set via the `QD_WANTED_ARCHS` environment variable.
+
 ### Kernel compilation cache
 
 During test runs, compiled kernels are cached to disk so that the same kernel is not recompiled after each `qd.reset()`/`qd.init()` cycle.
 
-A fresh, empty cache directory is created for each test session by pytest's `tmp_path_factory` (typically under `/tmp/pytest-of-<user>/pytest-<N>/qdcache0/`). Pytest's `tmp_path_retention_count` setting (default: 3) controls how many old sessions' cache dirs are kept. This cache is separate from the user-facing `~/.cache/quadrants/` cache.
+A fresh, empty cache directory is created for each test session by pytest's [`tmp_path_factory`](https://docs.pytest.org/en/stable/how-to/tmp_path.html) (typically under `/tmp/pytest-of-<user>/pytest-<N>/qdcache0/`). Old session directories are cleaned up automatically by pytest's retention policy. This cache is separate from the user-facing `~/.cache/quadrants/` cache.
 
 ## Creating your build/dev environment
 

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -14,7 +14,7 @@ Run the test suite with `python tests/run_tests.py`. CLI arguments are forwarded
 python tests/run_tests.py --arch metal -k "test_tile16_cholesky"
 ```
 
-The target architecture can also be set via the `QD_WANTED_ARCHS` environment variable.
+The target architecture can also be set via the `QD_WANTED_ARCHS` environment variable (comma-separated, e.g. `QD_WANTED_ARCHS=metal,vulkan`).
 
 ### Kernel compilation cache
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -15,6 +15,20 @@ import quadrants as qd
 pytest_rerunfailures.works_with_current_xdist = lambda: True
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _offline_cache_dir(tmp_path_factory):
+    """Enable the kernel compilation disk cache for the test session.
+
+    Uses pytest's tmp_path_factory so the cache directory is managed by pytest's retention policy
+    (tmp_path_retention_count / tmp_path_retention_policy) and cleaned up automatically. This avoids recompiling
+    identical kernels after each qd.reset()/qd.init() cycle within a session.
+    """
+    cache_dir = tmp_path_factory.mktemp("qdcache")
+    os.environ["QD_OFFLINE_CACHE"] = "1"
+    os.environ["QD_OFFLINE_CACHE_FILE_PATH"] = str(cache_dir)
+    os.environ.setdefault("QD_OFFLINE_CACHE_CLEANING_POLICY", "never")
+
+
 @pytest.fixture(autouse=True)
 def run_gc_after_test():
     """

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,9 +1,6 @@
 import argparse
-import atexit
 import importlib.util
 import os
-import shutil
-import tempfile
 
 
 def _test_python(args, default_dir="python"):
@@ -239,21 +236,6 @@ def test():
         action="store_true",
         help="Exclude arch(s) from test instead of include them, together with -a",
     )
-    parser.add_argument(
-        "--with-offline-cache",
-        action="store_true",
-        default=os.environ.get("QD_TEST_OFFLINE_CACHE", "0") == "1",
-        dest="with_offline_cache",
-        help="Run tests with offline_cache=True",
-    )
-    parser.add_argument(
-        "--rerun-with-offline-cache",
-        type=int,
-        dest="rerun_with_offline_cache",
-        default=1,
-        help="Rerun all tests with offline_cache=True for given times, together with --with-offline-cache",
-    )
-
     run_count = 1
     args = parser.parse_args()
     print(args)
@@ -264,41 +246,6 @@ def test():
             arch = "^" + arch
         print(f"Running on Arch={arch}")
         os.environ["QD_WANTED_ARCHS"] = arch
-
-    if args.with_offline_cache:
-        run_count += args.rerun_with_offline_cache
-        args.timeout *= run_count
-        tmp_cache_file_path = tempfile.mkdtemp()
-        os.environ["QD_OFFLINE_CACHE"] = "1"
-        os.environ["QD_OFFLINE_CACHE_FILE_PATH"] = tmp_cache_file_path
-        if not os.environ.get("QD_OFFLINE_CACHE_CLEANING_POLICY"):
-            os.environ["QD_OFFLINE_CACHE_CLEANING_POLICY"] = "never"
-
-        def print_and_remove():
-            def size_of_dir(dir):
-                size = 0
-                for root, dirs, files in os.walk(dir):
-                    size += sum([os.path.getsize(os.path.join(root, name)) for name in files])
-                return size
-
-            size = size_of_dir(tmp_cache_file_path)
-            stat = {}
-            countof_tic = 0
-            for p in os.listdir(tmp_cache_file_path):
-                subdir_path = os.path.join(tmp_cache_file_path, p)
-                if os.path.isdir(subdir_path):
-                    stat[p] = len(os.listdir(subdir_path))
-                elif p.endswith(".tic"):
-                    countof_tic += 1
-            stat["*.tic"] = countof_tic
-            shutil.rmtree(tmp_cache_file_path)
-            print("Summary of testing the offline cache:")
-            print(f"    Simple statistics: {stat}")
-            print(f"    Size of cache files: {size / 1024:.2f} KB")
-
-        atexit.register(print_and_remove)
-    else:  # Default: disable offline cache
-        os.environ["QD_OFFLINE_CACHE"] = "0"
 
     if args.cpp:
         # C++ tests are now handled by pytest too,


### PR DESCRIPTION
The test runner was explicitly disabling the offline kernel compilation cache (QD_OFFLINE_CACHE=0), causing every kernel to recompile from scratch after each qd.reset()/qd.init() cycle. This made parametrized tests extremely slow — e.g. test_tile16_cholesky compiled the same kernel 18 times at ~2s each.

Now the cache is always enabled via a session-scoped conftest fixture that uses pytest's tmp_path_factory. The cache directory is fresh each session (no stale artifact risk) and cleaned up by pytest's retention policy. Measured speedup on test_tile16_cholesky: 40.7s -> 11.3s (3.6x wall clock).

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
