### PR TITLE
[Lang] @qd.func with dataclass annotation accepts dataclass values with extra fields (structural subset)

### DIFF
--- a/python/quadrants/lang/ast/ast_transformers/call_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformers/call_transformer.py
@@ -166,20 +166,31 @@ class CallTransformer:
 
     @staticmethod
     def _expand_Call_dataclass_args(
-        ctx: ASTTransformerFuncContext, args: tuple[ast.stmt, ...]
+        ctx: ASTTransformerFuncContext,
+        args: tuple[ast.stmt, ...],
+        callee_annotations: tuple[Any, ...] | None = None,
     ) -> tuple[tuple[ast.stmt, ...], tuple[ast.stmt, ...]]:
         """
         We require that each node has a .ptr attribute added to it, that contains
-        the associated Python object
+        the associated Python object.
+
+        callee_annotations, when provided, supplies the declared parameter type for each positional
+        arg. If the callee declares a dataclass that is a structural subset of the caller-side
+        value, iteration is driven by the callee's fields so extra caller-side fields are dropped.
         """
         args_new = []
         added_args = []
         pruning = ctx.global_context.pruning
         func_id = ctx.func.func_id
-        for arg in args:
+        for i, arg in enumerate(args):
             val = arg.ptr
             if dataclasses.is_dataclass(val) and isinstance(val, type):
-                dataclass_type = val
+                callee_t = None
+                if callee_annotations is not None and i < len(callee_annotations):
+                    cand = callee_annotations[i]
+                    if dataclasses.is_dataclass(cand) and isinstance(cand, type):
+                        callee_t = cand
+                dataclass_type = callee_t if callee_t is not None else val
                 for field in dataclasses.fields(dataclass_type):
                     try:
                         child_name = create_flat_name(arg.id, field.name)
@@ -198,7 +209,9 @@ class CallTransformer:
                     )
                     if dataclasses.is_dataclass(field.type):
                         arg_node.ptr = field.type
-                        _added_args, _args_new = CallTransformer._expand_Call_dataclass_args(ctx, (arg_node,))
+                        _added_args, _args_new = CallTransformer._expand_Call_dataclass_args(
+                            ctx, (arg_node,), callee_annotations=(field.type,)
+                        )
                         args_new.extend(_args_new)
                         added_args.extend(_added_args)
                     else:
@@ -213,19 +226,29 @@ class CallTransformer:
         ctx: ASTTransformerFuncContext,
         kwargs: list[ast.keyword],
         used_args: set[str] | None,
+        callee_annotations_by_name: dict[str, Any] | None = None,
     ) -> tuple[list[ast.keyword], list[ast.keyword]]:
         """
         We require that each node has a .ptr attribute added to it, that contains
         the associated Python object
 
         used_args are the names of parameters that are used, and should not be pruned.
+
+        callee_annotations_by_name, when provided, maps callee parameter name to its declared type.
+        Drives field iteration so a caller-side dataclass that is a structural superset of the
+        callee's declared dataclass is silently narrowed to the callee's expected fields.
         """
         kwargs_new = []
         added_kwargs = []
         for i, kwarg in enumerate(kwargs):
             val = kwarg.ptr[kwarg.arg]
             if dataclasses.is_dataclass(val) and isinstance(val, type):
-                dataclass_type = val
+                callee_t = None
+                if callee_annotations_by_name is not None:
+                    cand = callee_annotations_by_name.get(kwarg.arg)
+                    if dataclasses.is_dataclass(cand) and isinstance(cand, type):
+                        callee_t = cand
+                dataclass_type = callee_t if callee_t is not None else val
                 for field in dataclasses.fields(dataclass_type):
                     src_name = create_flat_name(kwarg.value.id, field.name)
                     child_name = create_flat_name(kwarg.arg, field.name)
@@ -254,7 +277,10 @@ class CallTransformer:
                     if dataclasses.is_dataclass(field.type):
                         kwarg_node.ptr = {child_name: field.type}
                         _added_kwargs, _kwargs_new = CallTransformer._expand_Call_dataclass_kwargs(
-                            ctx, [kwarg_node], used_args
+                            ctx,
+                            [kwarg_node],
+                            used_args,
+                            callee_annotations_by_name={child_name: field.type},
                         )
                         kwargs_new.extend(_kwargs_new)
                         added_kwargs.extend(_added_kwargs)
@@ -290,8 +316,22 @@ class CallTransformer:
             called_func_id_ = func.wrapper.func_id  # type: ignore
             called_needed = pruning.used_vars_by_func_id[called_func_id_]
 
-        added_args, node_args = CallTransformer._expand_Call_dataclass_args(ctx, node.args)
-        added_keywords, node_keywords = CallTransformer._expand_Call_dataclass_kwargs(ctx, node.keywords, called_needed)
+        callee_pos_annotations: tuple[Any, ...] | None = None
+        callee_kw_annotations: dict[str, Any] | None = None
+        if is_func_base_wrapper:
+            callee_arg_metas = getattr(func.wrapper, "arg_metas", None)
+            if callee_arg_metas is not None:
+                skip = 1 if func_type is BoundQuadrantsCallable else 0
+                visible_metas = callee_arg_metas[skip:]
+                callee_pos_annotations = tuple(m.annotation for m in visible_metas)
+                callee_kw_annotations = {m.name: m.annotation for m in visible_metas}
+
+        added_args, node_args = CallTransformer._expand_Call_dataclass_args(
+            ctx, node.args, callee_annotations=callee_pos_annotations
+        )
+        added_keywords, node_keywords = CallTransformer._expand_Call_dataclass_kwargs(
+            ctx, node.keywords, called_needed, callee_annotations_by_name=callee_kw_annotations
+        )
 
         # Create variables for the now-expanded dataclass members.
         # We don't want to include these now-expanded dataclass members in

--- a/tests/python/test_py_dataclass.py
+++ b/tests/python/test_py_dataclass.py
@@ -2511,3 +2511,65 @@ def test_pruning_iterate_function_no_iterate() -> None:
     assert my_struct._f1[0, 0] == 101
     assert my_struct._f2[0, 0] == 102
     assert kernel_args_count_by_type[KernelBatchedArgType.QD_ARRAY] == 3
+
+
+@test_utils.test()
+def test_func_accepts_dataclass_with_extra_fields() -> None:
+    @dataclass
+    class FooSmall:
+        pos: qd.types.NDArray[qd.i32, 1]
+
+    @dataclass
+    class FooBig:
+        pos: qd.types.NDArray[qd.i32, 1]
+        extra: qd.types.NDArray[qd.i32, 1]
+
+    @qd.func
+    def first(foo: FooSmall) -> qd.i32:
+        return foo.pos[0]
+
+    @qd.kernel
+    def k_small(
+        foo: FooSmall,
+        out: qd.types.NDArray[qd.i32, 1],
+    ) -> None:
+        out[0] = first(foo)
+
+    @qd.kernel
+    def k_big(
+        foo: FooBig,
+        out: qd.types.NDArray[qd.i32, 1],
+    ) -> None:
+        out[0] = first(foo)
+
+    @qd.kernel
+    def k_big_kwargs(
+        foo: FooBig,
+        out: qd.types.NDArray[qd.i32, 1],
+    ) -> None:
+        out[0] = first(foo=foo)
+
+    pos_s = qd.ndarray(dtype=qd.i32, shape=(4,))
+    pos_b = qd.ndarray(dtype=qd.i32, shape=(4,))
+    extra = qd.ndarray(dtype=qd.i32, shape=(4,))
+    out = qd.ndarray(dtype=qd.i32, shape=(1,))
+
+    @qd.kernel
+    def fill(t: qd.types.NDArray[qd.i32, 1], base: qd.i32) -> None:
+        for i in range(4):
+            t[i] = base + i
+
+    fill(pos_s, 10)
+    fill(pos_b, 100)
+    fill(extra, 0)
+
+    k_small(FooSmall(pos=pos_s), out)
+    assert out[0] == 10
+
+    out[0] = 0
+    k_big(FooBig(pos=pos_b, extra=extra), out)
+    assert out[0] == 100
+
+    out[0] = 0
+    k_big_kwargs(FooBig(pos=pos_b, extra=extra), out)
+    assert out[0] == 100


### PR DESCRIPTION
# Accept structurally-wider dataclasses at `@qd.func` call sites

> Lets a `@qd.func` annotated with a `FooSmall` parameter be called with a `FooBig` value as long as `FooBig` contains every field `FooSmall` declares. Extra fields on the caller side are silently dropped.

## TL;DR

When a kernel holds a value of dataclass type `FooBig` and calls a `@qd.func` declaring `foo: FooSmall`, the call site previously flattened the argument by the caller-side type (emitting every field of `FooBig`). The callee's `arg_metas_expanded` is built from `FooSmall` and therefore expects fewer positional / keyword args, producing `QuadrantsSyntaxError: Too many arguments` at compile time.

The fix narrows the call-site flattening to the callee's declared annotation when one is available, so only the fields the callee actually expects are emitted.

## Why

Practical templating: callers often share a fat dataclass (full state) but downstream `@qd.func`s only need a slice. Re-typing the dataclass at every boundary forced users to either restructure code or manually unpack fields. The flattening was already field-name-based; the change makes positional / keyword flattening respect the declared parameter shape instead of the actual value shape.

## Mechanism

`call_transformer.build_Call` now resolves the callee's declared `arg_metas` (skipping the implicit `self` for `BoundQuadrantsCallable`) and threads them into:

- `_expand_Call_dataclass_args(callee_annotations=...)` - per-positional override
- `_expand_Call_dataclass_kwargs(callee_annotations_by_name=...)` - per-keyword override

When the override at a given position / name is itself a dataclass type, field iteration uses that type rather than the caller-side `val`. Nested dataclasses recurse with the callee's nested `field.type`, so deeper subtyping works too. When no override is present (legacy callers / non-`QuadrantsCallable` targets), behaviour is unchanged.

## Tests

`tests/python/test_py_dataclass.py::test_func_accepts_dataclass_with_extra_fields` covers the positional, keyword, and same-shape (`FooSmall -> FooSmall`) paths. Verified the test fails on the base branch with the original `Too many arguments` error and passes after the fix; the full `test_py_dataclass.py` + AST-transformer suites (174 tests) stay green.