### PR TITLE
Pass dataclass sub-structs into qd.func

### DIFF
--- a/docs/source/user_guide/compound_types.md
+++ b/docs/source/user_guide/compound_types.md
@@ -91,10 +91,7 @@ def k2(s: Outer) -> None:
 
 ### Passing nested sub-structs to a `qd.func`
 
-You can pass either a whole nested-dataclass argument or one of its
-sub-struct fields to a `qd.func`. The callee declares the sub-struct's
-type as the parameter annotation; the caller writes the attribute access
-at the call site:
+You can pass either a whole nested-dataclass argument or one of its sub-struct fields to a `qd.func`. The callee declares the sub-struct's type as the parameter annotation; the caller writes the attribute access at the call site:
 
 ```python
 @dataclass
@@ -128,9 +125,7 @@ Sub-struct passing supports:
 - call sites both directly inside `@qd.kernel` bodies and inside other `@qd.func` bodies
 - pruning of the sub-struct's leaf fields that the callee never reads
 
-Note: assigning a sub-struct to a local variable and then passing it
-(`t = s.inner; touch_inner(t)`) is **not** supported. Pass the attribute
-access directly at the call site.
+Note: assigning a sub-struct to a local variable and then passing it (`t = s.inner; touch_inner(t)`) is **not** supported. Pass the attribute access directly at the call site.
 
 ## qd.data_oriented
 

--- a/docs/source/user_guide/compound_types.md
+++ b/docs/source/user_guide/compound_types.md
@@ -89,6 +89,49 @@ def k2(s: Outer) -> None:
     s.y[0] = 2.0
 ```
 
+### Passing nested sub-structs to a `qd.func`
+
+You can pass either a whole nested-dataclass argument or one of its
+sub-struct fields to a `qd.func`. The callee declares the sub-struct's
+type as the parameter annotation; the caller writes the attribute access
+at the call site:
+
+```python
+@dataclass
+class Inner:
+    x: qd.types.NDArray[qd.f32, 1]
+
+@dataclass
+class Outer:
+    inner: Inner
+    y: qd.types.NDArray[qd.f32, 1]
+
+@qd.func
+def touch_inner(inner: Inner) -> None:
+    inner.x[0] += 1.0
+
+@qd.func
+def touch_outer(s: Outer) -> None:
+    s.y[0] += 10.0
+    touch_inner(s.inner)        # call site inside a qd.func body
+
+@qd.kernel
+def k(s: Outer) -> None:
+    touch_outer(s)              # whole-struct call (already supported)
+    touch_inner(s.inner)        # sub-struct call (also supported)
+```
+
+Sub-struct passing supports:
+
+- arbitrary nesting depth (`f(s.a.b.c)` where each level is a dataclass)
+- positional and keyword call sites (`f(s.inner)` and `f(inner=s.inner)`)
+- call sites both directly inside `@qd.kernel` bodies and inside other `@qd.func` bodies
+- pruning of the sub-struct's leaf fields that the callee never reads
+
+Note: assigning a sub-struct to a local variable and then passing it
+(`t = s.inner; touch_inner(t)`) is **not** supported. Pass the attribute
+access directly at the call site.
+
 ## qd.data_oriented
 
 `@qd.data_oriented` is designed for classes that define `@qd.kernel` methods as class members. It wraps these methods to correctly bind `self` during kernel compilation.

--- a/docs/source/user_guide/compound_types.md
+++ b/docs/source/user_guide/compound_types.md
@@ -114,8 +114,8 @@ def touch_outer(s: Outer) -> None:
 
 @qd.kernel
 def k(s: Outer) -> None:
-    touch_outer(s)              # whole-struct call (already supported)
-    touch_inner(s.inner)        # sub-struct call (also supported)
+    touch_outer(s)              # whole-struct call
+    touch_inner(s.inner)        # sub-struct call
 ```
 
 Sub-struct passing supports:

--- a/python/quadrants/lang/_kernel_impl_dataclass.py
+++ b/python/quadrants/lang/_kernel_impl_dataclass.py
@@ -49,14 +49,23 @@ def _populate_struct_locals_from_params_dict(basename: str, struct_locals, struc
     And the members of struct_locals should be:
     - __qd_struct_ab__qd_a
     - __qd_struct_ab__qd_b
+    - __qd_struct_ab__qd_struct_cd
     - __qd_struct_ab__qd_struct_cd__qd_c
     - __qd_struct_ab__qd_struct_cd__qd_d
+    - __qd_struct_ab__qd_struct_cd__qd_struct_ef
     - __qd_struct_ab__qd_struct_cd__qd_struct_ef__qd_e
     - __qd_struct_ab__qd_struct_cd__qd_struct_ef__qd_f
+
+    Intermediate (non-leaf) dataclass nodes are included in struct_locals so that
+    expressions like ``struct_ab.struct_cd`` get rewritten to a single
+    ``Name("__qd_struct_ab__qd_struct_cd")`` by FlattenAttributeNameTransformer.
+    This is needed to support passing sub-structs to ``qd.func``, e.g.
+    ``f(struct_ab.struct_cd)`` where ``f`` is typed ``(c: StructCD)``.
     """
     for field in dataclasses.fields(struct_type):
         child_name = create_flat_name(basename, field.name)
         if dataclasses.is_dataclass(field.type):
+            struct_locals.add(child_name)
             _populate_struct_locals_from_params_dict(child_name, struct_locals, field.type)
         else:
             struct_locals.add(child_name)
@@ -86,6 +95,8 @@ def extract_struct_locals_from_context(ctx: ASTTransformerFuncContext) -> set[st
             for field in dataclasses.fields(dc_type):
                 child_name = create_flat_name(param_name, field.name)
                 if dataclasses.is_dataclass(field.type):
+                    # Intermediate node — see _populate_struct_locals_from_params_dict docstring.
+                    struct_locals.add(child_name)
                     _populate_struct_locals_from_params_dict(child_name, struct_locals, field.type)
                     continue
                 struct_locals.add(child_name)

--- a/python/quadrants/lang/_kernel_impl_dataclass.py
+++ b/python/quadrants/lang/_kernel_impl_dataclass.py
@@ -56,11 +56,10 @@ def _populate_struct_locals_from_params_dict(basename: str, struct_locals, struc
     - __qd_struct_ab__qd_struct_cd__qd_struct_ef__qd_e
     - __qd_struct_ab__qd_struct_cd__qd_struct_ef__qd_f
 
-    Intermediate (non-leaf) dataclass nodes are included in struct_locals so that
-    expressions like ``struct_ab.struct_cd`` get rewritten to a single
-    ``Name("__qd_struct_ab__qd_struct_cd")`` by FlattenAttributeNameTransformer.
-    This is needed to support passing sub-structs to ``qd.func``, e.g.
-    ``f(struct_ab.struct_cd)`` where ``f`` is typed ``(c: StructCD)``.
+    Intermediate (non-leaf) dataclass nodes are included in struct_locals so that expressions like
+    ``struct_ab.struct_cd`` get rewritten to a single ``Name("__qd_struct_ab__qd_struct_cd")`` by
+    FlattenAttributeNameTransformer. This is needed to support passing sub-structs to ``qd.func``,
+    e.g. ``f(struct_ab.struct_cd)`` where ``f`` is typed ``(c: StructCD)``.
     """
     for field in dataclasses.fields(struct_type):
         child_name = create_flat_name(basename, field.name)

--- a/python/quadrants/lang/ast/ast_transformers/function_def_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformers/function_def_transformer.py
@@ -408,6 +408,25 @@ class FunctionDefTransformer:
         return None
 
     @staticmethod
+    def _bind_intermediate_dataclass_sentinels(ctx: ASTTransformerFuncContext, basename: str, dc_type: Any) -> None:
+        """Recursively bind every nested dataclass node ``__qd_<basename>__qd_<field>`` to its
+        dataclass type, so AST-flattened intermediate names (e.g. ``s.child`` rewritten to
+        ``Name("__qd_s__qd_child")`` by FlattenAttributeNameTransformer) resolve at lookup
+        time and call-site expansion in ``_expand_Call_dataclass_args`` triggers correctly.
+
+        Mirrors what ``_transform_kernel_arg`` already does kernel-side via its recursion
+        (each recursive call's first action is ``ctx.create_variable(flat_name, field.type)``).
+        On the func side these intermediates are missing, because ``_transform_func_arg`` is
+        invoked once per *leaf* arg (``fuse_args`` has already expanded the dataclass into
+        leaf arg-metas by then).
+        """
+        for field in dataclasses.fields(dc_type):
+            if dataclasses.is_dataclass(field.type):
+                child_name = create_flat_name(basename, field.name)
+                ctx.create_variable(child_name, field.type)
+                FunctionDefTransformer._bind_intermediate_dataclass_sentinels(ctx, child_name, field.type)
+
+    @staticmethod
     def _transform_as_func(ctx: ASTTransformerFuncContext, node: ast.FunctionDef, args: ast.arguments) -> None:
         # pylint: disable=import-outside-toplevel
         from quadrants.lang.kernel_impl import Func
@@ -422,6 +441,7 @@ class FunctionDefTransformer:
         for v in ctx.func.orig_arguments:
             if dataclasses.is_dataclass(v.annotation):
                 ctx.create_variable(v.name, v.annotation)
+                FunctionDefTransformer._bind_intermediate_dataclass_sentinels(ctx, v.name, v.annotation)
 
     @staticmethod
     def build_FunctionDef(

--- a/python/quadrants/lang/ast/ast_transformers/function_def_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformers/function_def_transformer.py
@@ -409,16 +409,15 @@ class FunctionDefTransformer:
 
     @staticmethod
     def _bind_intermediate_dataclass_sentinels(ctx: ASTTransformerFuncContext, basename: str, dc_type: Any) -> None:
-        """Recursively bind every nested dataclass node ``__qd_<basename>__qd_<field>`` to its
-        dataclass type, so AST-flattened intermediate names (e.g. ``s.child`` rewritten to
-        ``Name("__qd_s__qd_child")`` by FlattenAttributeNameTransformer) resolve at lookup
-        time and call-site expansion in ``_expand_Call_dataclass_args`` triggers correctly.
+        """Recursively bind every nested dataclass node ``__qd_<basename>__qd_<field>`` to its dataclass type, so
+        AST-flattened intermediate names (e.g. ``s.child`` rewritten to ``Name("__qd_s__qd_child")`` by
+        FlattenAttributeNameTransformer) resolve at lookup time and call-site expansion in
+        ``_expand_Call_dataclass_args`` triggers correctly.
 
-        Mirrors what ``_transform_kernel_arg`` already does kernel-side via its recursion
-        (each recursive call's first action is ``ctx.create_variable(flat_name, field.type)``).
-        On the func side these intermediates are missing, because ``_transform_func_arg`` is
-        invoked once per *leaf* arg (``fuse_args`` has already expanded the dataclass into
-        leaf arg-metas by then).
+        Mirrors what ``_transform_kernel_arg`` already does kernel-side via its recursion (each recursive call's first
+        action is ``ctx.create_variable(flat_name, field.type)``). On the func side these intermediates are missing,
+        because ``_transform_func_arg`` is invoked once per *leaf* arg (``fuse_args`` has already expanded the dataclass
+        into leaf arg-metas by then).
         """
         for field in dataclasses.fields(dc_type):
             if dataclasses.is_dataclass(field.type):

--- a/tests/python/test_py_dataclass.py
+++ b/tests/python/test_py_dataclass.py
@@ -890,92 +890,56 @@ def test_ndarray_struct_multiple_child_structs_field():
 # --- Sub-struct passing: f(s.child) where the child is itself a dataclass ---
 
 
+class _TemplateBuilder:
+    """Makes ``qd.Template`` subscriptable so ``_TemplateBuilder()[qd.i32, 1]`` returns ``qd.Template`` (matching the
+    shape of ``qd.types.ndarray[qd.i32, 1]``). Lets a single test body work for both NDArray-annotated and
+    Template-annotated leaves."""
+
+    def __getitem__(self, _):
+        return qd.Template
+
+
+# (leaf-value factory, leaf-annotation builder). NDArray and qd.Tensor share the same annotation form (qd.Tensor
+# wrappers are unwrapped to bare impls at arg-binding time, so the annotation stays NDArray).
+_SUBSTRUCT_LEAF_KINDS = [
+    pytest.param(qd.ndarray, qd.types.ndarray, id="ndarray"),
+    pytest.param(qd.field, _TemplateBuilder(), id="field"),
+    pytest.param(
+        lambda dtype, shape: qd.tensor(dtype, shape=shape, backend=qd.Backend.NDARRAY),
+        qd.types.ndarray,
+        id="tensor",
+    ),
+]
+
+
 @test_utils.test()
-def test_ndarray_substruct_passed_to_func():
-    """``f(s.struct_cd)`` where the kernel arg is a nested dataclass and the func is typed with the child dataclass.
-    Mirrors test_ndarray_struct_nested_ndarray but passes the sub-struct (not the whole struct) into the inner func."""
-    a = qd.ndarray(qd.i32, shape=(101,))
-    b = qd.ndarray(qd.i32, shape=(57,))
-    c = qd.ndarray(qd.i32, shape=(211,))
-    d = qd.ndarray(qd.i32, shape=(211,))
-    e = qd.ndarray(qd.i32, shape=(251,))
-    f = qd.ndarray(qd.i32, shape=(251,))
+@pytest.mark.parametrize("qd_make,qd_anno", _SUBSTRUCT_LEAF_KINDS)
+def test_substruct_passed_to_func(qd_make: Any, qd_anno: Any) -> None:
+    """``f(s.struct_cd)`` where the kernel arg is a nested dataclass and the callee is typed with the child dataclass.
+    Mirrors test_ndarray_struct_nested_ndarray but passes the sub-struct (not the whole struct) into the inner func.
+    Parametrized across the three supported leaf kinds (raw ndarray, field/template, qd.Tensor wrapper)."""
+    a = qd_make(qd.i32, shape=(101,))
+    b = qd_make(qd.i32, shape=(57,))
+    c = qd_make(qd.i32, shape=(211,))
+    d = qd_make(qd.i32, shape=(211,))
+    e = qd_make(qd.i32, shape=(251,))
+    f = qd_make(qd.i32, shape=(251,))
 
     @dataclass
     class MyStructEF:
-        e: qd.types.NDArray[qd.i32, 1]
-        f: qd.types.NDArray[qd.i32, 1]
+        e: qd_anno[qd.i32, 1]
+        f: qd_anno[qd.i32, 1]
 
     @dataclass
     class MyStructCD:
-        c: qd.types.NDArray[qd.i32, 1]
-        d: qd.types.NDArray[qd.i32, 1]
+        c: qd_anno[qd.i32, 1]
+        d: qd_anno[qd.i32, 1]
         struct_ef: MyStructEF
 
     @dataclass
     class MyStructAB:
-        a: qd.types.NDArray[qd.i32, 1]
-        b: qd.types.NDArray[qd.i32, 1]
-        struct_cd: MyStructCD
-
-    @qd.func
-    def fef(struct_ef: MyStructEF) -> None:
-        struct_ef.e[12] += 14
-        struct_ef.f[18] += 24
-
-    @qd.func
-    def fcd(struct_cd: MyStructCD) -> None:
-        struct_cd.c[11] += 13
-        struct_cd.d[17] += 23
-        # call site: pass sub-struct into another func
-        fef(struct_cd.struct_ef)
-
-    @qd.kernel
-    def k1(my_struct_ab: MyStructAB) -> None:
-        my_struct_ab.a[7] += 3
-        my_struct_ab.b[2] += 5
-        # call site: pass sub-struct directly from kernel into a func
-        fcd(my_struct_ab.struct_cd)
-        # also a 2-level deep sub-struct call
-        fef(my_struct_ab.struct_cd.struct_ef)
-
-    s = MyStructAB(a=a, b=b, struct_cd=MyStructCD(c=c, d=d, struct_ef=MyStructEF(e=e, f=f)))
-    k1(s)
-
-    assert a[7] == 3
-    assert b[2] == 5
-    assert c[11] == 13
-    assert d[17] == 23
-    # fef called twice: once from fcd, once directly from kernel
-    assert e[12] == 28
-    assert f[18] == 48
-
-
-@test_utils.test()
-def test_field_substruct_passed_to_func() -> None:
-    """Field/template variant of test_ndarray_substruct_passed_to_func."""
-    a = qd.field(qd.i32, shape=(55,))
-    b = qd.field(qd.i32, shape=(57,))
-    c = qd.field(qd.i32, shape=(211,))
-    d = qd.field(qd.i32, shape=(211,))
-    e = qd.field(qd.i32, shape=(251,))
-    f = qd.field(qd.i32, shape=(251,))
-
-    @dataclass
-    class MyStructEF:
-        e: qd.Template
-        f: qd.Template
-
-    @dataclass
-    class MyStructCD:
-        c: qd.Template
-        d: qd.Template
-        struct_ef: MyStructEF
-
-    @dataclass
-    class MyStructAB:
-        a: qd.Template
-        b: qd.Template
+        a: qd_anno[qd.i32, 1]
+        b: qd_anno[qd.i32, 1]
         struct_cd: MyStructCD
 
     @qd.func
@@ -1133,6 +1097,65 @@ def test_substruct_scalar_leaf() -> None:
 
     k(AB(out=out, cd=CD(c=3, d=4)))
     assert out[0] == 7
+
+
+@test_utils.test()
+def test_substruct_deep_nesting() -> None:
+    """Three levels of dataclass nesting (L0 -> L1 -> L2 -> L3) combined with a three-level func-call chain
+    (kernel -> touch_l1 -> touch_l2 -> touch_l3). Each layer writes its own leaf and forwards its inner sub-struct to
+    the next callee. The kernel also exercises a direct 3-deep attribute access ``s.inner.inner.inner`` to make sure
+    multi-level call-site flattening works straight from the kernel body, not just via intermediate funcs."""
+    n0 = qd.ndarray(qd.i32, shape=(4,))
+    n1 = qd.ndarray(qd.i32, shape=(4,))
+    n2 = qd.ndarray(qd.i32, shape=(4,))
+    n3 = qd.ndarray(qd.i32, shape=(4,))
+
+    @dataclass
+    class L3:
+        leaf: qd.types.NDArray[qd.i32, 1]
+
+    @dataclass
+    class L2:
+        leaf: qd.types.NDArray[qd.i32, 1]
+        inner: L3
+
+    @dataclass
+    class L1:
+        leaf: qd.types.NDArray[qd.i32, 1]
+        inner: L2
+
+    @dataclass
+    class L0:
+        leaf: qd.types.NDArray[qd.i32, 1]
+        inner: L1
+
+    @qd.func
+    def touch_l3(s: L3) -> None:
+        s.leaf[0] += 1
+
+    @qd.func
+    def touch_l2(s: L2) -> None:
+        s.leaf[0] += 10
+        touch_l3(s.inner)
+
+    @qd.func
+    def touch_l1(s: L1) -> None:
+        s.leaf[0] += 100
+        touch_l2(s.inner)
+
+    @qd.kernel
+    def k(s: L0) -> None:
+        s.leaf[0] += 1000
+        touch_l1(s.inner)
+        touch_l3(s.inner.inner.inner)
+
+    s = L0(leaf=n0, inner=L1(leaf=n1, inner=L2(leaf=n2, inner=L3(leaf=n3))))
+    k(s)
+
+    assert n0[0] == 1000
+    assert n1[0] == 100
+    assert n2[0] == 10
+    assert n3[0] == 1 + 1
 
 
 @pytest.mark.parametrize("use_slots", [False, True])

--- a/tests/python/test_py_dataclass.py
+++ b/tests/python/test_py_dataclass.py
@@ -1040,10 +1040,11 @@ def test_substruct_passed_to_func_kwargs() -> None:
 
 @test_utils.test()
 def test_substruct_pruning() -> None:
-    """When the callee uses only one of the sub-struct's leaves, the unused leaf must not be touched.
-    Exercises pruning across the sub-struct boundary."""
+    """When the callee uses only one of the sub-struct's leaves, the unused leaves must be pruned from the kernel's
+    compiled argument list. Exercises pruning across the sub-struct boundary."""
     c = qd.ndarray(qd.i32, shape=(8,))
     d = qd.ndarray(qd.i32, shape=(8,))
+    a = qd.ndarray(qd.i32, shape=(8,))
 
     @dataclass
     class CD:
@@ -1057,17 +1058,21 @@ def test_substruct_pruning() -> None:
 
     @qd.func
     def fcd(cd: CD) -> None:
-        # only writes cd.c — cd.d is unused and should be pruned
         cd.c[0] += 5
 
     @qd.kernel
     def k(s: AB) -> None:
         fcd(s.cd)
 
-    a = qd.ndarray(qd.i32, shape=(8,))
     k(AB(a=a, cd=CD(c=c, d=d)))
+
     assert c[0] == 5
     assert d[0] == 0
+    assert a[0] == 0
+
+    k_primal: Kernel = k._primal
+    kernel_args_count_by_type = k_primal.launch_stats.kernel_args_count_by_type
+    assert kernel_args_count_by_type[KernelBatchedArgType.QD_ARRAY] == 1
 
 
 @test_utils.test()

--- a/tests/python/test_py_dataclass.py
+++ b/tests/python/test_py_dataclass.py
@@ -887,6 +887,250 @@ def test_ndarray_struct_multiple_child_structs_field():
     assert f[0] == 77
 
 
+# --- Sub-struct passing: f(s.child) where the child is itself a dataclass ---
+
+
+@test_utils.test()
+def test_ndarray_substruct_passed_to_func():
+    """``f(s.struct_cd)`` where the kernel arg is a nested dataclass and the func
+    is typed with the child dataclass. Mirrors test_ndarray_struct_nested_ndarray
+    but passes the sub-struct (not the whole struct) into the inner func."""
+    a = qd.ndarray(qd.i32, shape=(101,))
+    b = qd.ndarray(qd.i32, shape=(57,))
+    c = qd.ndarray(qd.i32, shape=(211,))
+    d = qd.ndarray(qd.i32, shape=(211,))
+    e = qd.ndarray(qd.i32, shape=(251,))
+    f = qd.ndarray(qd.i32, shape=(251,))
+
+    @dataclass
+    class MyStructEF:
+        e: qd.types.NDArray[qd.i32, 1]
+        f: qd.types.NDArray[qd.i32, 1]
+
+    @dataclass
+    class MyStructCD:
+        c: qd.types.NDArray[qd.i32, 1]
+        d: qd.types.NDArray[qd.i32, 1]
+        struct_ef: MyStructEF
+
+    @dataclass
+    class MyStructAB:
+        a: qd.types.NDArray[qd.i32, 1]
+        b: qd.types.NDArray[qd.i32, 1]
+        struct_cd: MyStructCD
+
+    @qd.func
+    def fef(struct_ef: MyStructEF) -> None:
+        struct_ef.e[12] += 14
+        struct_ef.f[18] += 24
+
+    @qd.func
+    def fcd(struct_cd: MyStructCD) -> None:
+        struct_cd.c[11] += 13
+        struct_cd.d[17] += 23
+        # call site: pass sub-struct into another func
+        fef(struct_cd.struct_ef)
+
+    @qd.kernel
+    def k1(my_struct_ab: MyStructAB) -> None:
+        my_struct_ab.a[7] += 3
+        my_struct_ab.b[2] += 5
+        # call site: pass sub-struct directly from kernel into a func
+        fcd(my_struct_ab.struct_cd)
+        # also a 2-level deep sub-struct call
+        fef(my_struct_ab.struct_cd.struct_ef)
+
+    s = MyStructAB(a=a, b=b, struct_cd=MyStructCD(c=c, d=d, struct_ef=MyStructEF(e=e, f=f)))
+    k1(s)
+
+    assert a[7] == 3
+    assert b[2] == 5
+    assert c[11] == 13
+    assert d[17] == 23
+    # fef called twice: once from fcd, once directly from kernel
+    assert e[12] == 28
+    assert f[18] == 48
+
+
+@test_utils.test()
+def test_field_substruct_passed_to_func() -> None:
+    """Field/template variant of test_ndarray_substruct_passed_to_func."""
+    a = qd.field(qd.i32, shape=(55,))
+    b = qd.field(qd.i32, shape=(57,))
+    c = qd.field(qd.i32, shape=(211,))
+    d = qd.field(qd.i32, shape=(211,))
+    e = qd.field(qd.i32, shape=(251,))
+    f = qd.field(qd.i32, shape=(251,))
+
+    @dataclass
+    class MyStructEF:
+        e: qd.Template
+        f: qd.Template
+
+    @dataclass
+    class MyStructCD:
+        c: qd.Template
+        d: qd.Template
+        struct_ef: MyStructEF
+
+    @dataclass
+    class MyStructAB:
+        a: qd.Template
+        b: qd.Template
+        struct_cd: MyStructCD
+
+    @qd.func
+    def fef(struct_ef: MyStructEF) -> None:
+        struct_ef.e[12] += 14
+        struct_ef.f[18] += 24
+
+    @qd.func
+    def fcd(struct_cd: MyStructCD) -> None:
+        struct_cd.c[11] += 13
+        struct_cd.d[17] += 23
+        fef(struct_cd.struct_ef)
+
+    @qd.kernel
+    def k1(my_struct_ab: MyStructAB) -> None:
+        my_struct_ab.a[7] += 3
+        my_struct_ab.b[2] += 5
+        fcd(my_struct_ab.struct_cd)
+        fef(my_struct_ab.struct_cd.struct_ef)
+
+    s = MyStructAB(a=a, b=b, struct_cd=MyStructCD(c=c, d=d, struct_ef=MyStructEF(e=e, f=f)))
+    k1(s)
+
+    assert a[7] == 3
+    assert b[2] == 5
+    assert c[11] == 13
+    assert d[17] == 23
+    assert e[12] == 28
+    assert f[18] == 48
+
+
+@test_utils.test()
+def test_substruct_passed_to_func_kwargs() -> None:
+    """``f(child=s.struct_cd)`` — kwargs at the sub-struct call site."""
+    c = qd.ndarray(qd.i32, shape=(8,))
+    d = qd.ndarray(qd.i32, shape=(8,))
+
+    @dataclass
+    class CD:
+        c: qd.types.NDArray[qd.i32, 1]
+        d: qd.types.NDArray[qd.i32, 1]
+
+    @dataclass
+    class AB:
+        a: qd.types.NDArray[qd.i32, 1]
+        cd: CD
+
+    @qd.func
+    def fcd(cd: CD) -> None:
+        cd.c[0] += 7
+        cd.d[0] += 9
+
+    @qd.kernel
+    def k(s: AB) -> None:
+        fcd(cd=s.cd)
+
+    a = qd.ndarray(qd.i32, shape=(8,))
+    k(AB(a=a, cd=CD(c=c, d=d)))
+    assert c[0] == 7
+    assert d[0] == 9
+
+
+@test_utils.test()
+def test_substruct_pruning() -> None:
+    """When the callee uses only one of the sub-struct's leaves, the unused leaf
+    must not be touched. Exercises pruning across the sub-struct boundary."""
+    c = qd.ndarray(qd.i32, shape=(8,))
+    d = qd.ndarray(qd.i32, shape=(8,))
+
+    @dataclass
+    class CD:
+        c: qd.types.NDArray[qd.i32, 1]
+        d: qd.types.NDArray[qd.i32, 1]
+
+    @dataclass
+    class AB:
+        a: qd.types.NDArray[qd.i32, 1]
+        cd: CD
+
+    @qd.func
+    def fcd(cd: CD) -> None:
+        # only writes cd.c — cd.d is unused and should be pruned
+        cd.c[0] += 5
+
+    @qd.kernel
+    def k(s: AB) -> None:
+        fcd(s.cd)
+
+    a = qd.ndarray(qd.i32, shape=(8,))
+    k(AB(a=a, cd=CD(c=c, d=d)))
+    assert c[0] == 5
+    assert d[0] == 0
+
+
+@test_utils.test()
+def test_substruct_inside_func() -> None:
+    """The sub-struct call site is inside a ``qd.func`` body (not directly in
+    the kernel). Exercises ``_transform_as_func``'s intermediate sentinel binding."""
+    c = qd.ndarray(qd.i32, shape=(8,))
+
+    @dataclass
+    class C:
+        c: qd.types.NDArray[qd.i32, 1]
+
+    @dataclass
+    class A:
+        a: qd.types.NDArray[qd.i32, 1]
+        child: C
+
+    @qd.func
+    def f2(child: C) -> None:
+        child.c[0] += 11
+
+    @qd.func
+    def f1(s: A) -> None:
+        # call site inside a qd.func body
+        f2(s.child)
+
+    @qd.kernel
+    def k(s: A) -> None:
+        f1(s)
+
+    a = qd.ndarray(qd.i32, shape=(8,))
+    k(A(a=a, child=C(c=c)))
+    assert c[0] == 11
+
+
+@test_utils.test()
+def test_substruct_scalar_leaf() -> None:
+    """Sub-struct contains scalar (int) fields, mixed with an ndarray sibling."""
+    out = qd.ndarray(qd.i32, shape=(8,))
+
+    @dataclass
+    class CD:
+        c: int
+        d: int
+
+    @dataclass
+    class AB:
+        out: qd.types.NDArray[qd.i32, 1]
+        cd: CD
+
+    @qd.func
+    def add_pair(cd: CD, out: qd.types.NDArray[qd.i32, 1]) -> None:
+        out[0] = cd.c + cd.d
+
+    @qd.kernel
+    def k(s: AB) -> None:
+        add_pair(s.cd, s.out)
+
+    k(AB(out=out, cd=CD(c=3, d=4)))
+    assert out[0] == 7
+
+
 @pytest.mark.parametrize("use_slots", [False, True])
 @test_utils.test()
 def test_template_mapper_cache(use_slots, monkeypatch):

--- a/tests/python/test_py_dataclass.py
+++ b/tests/python/test_py_dataclass.py
@@ -892,9 +892,8 @@ def test_ndarray_struct_multiple_child_structs_field():
 
 @test_utils.test()
 def test_ndarray_substruct_passed_to_func():
-    """``f(s.struct_cd)`` where the kernel arg is a nested dataclass and the func
-    is typed with the child dataclass. Mirrors test_ndarray_struct_nested_ndarray
-    but passes the sub-struct (not the whole struct) into the inner func."""
+    """``f(s.struct_cd)`` where the kernel arg is a nested dataclass and the func is typed with the child dataclass.
+    Mirrors test_ndarray_struct_nested_ndarray but passes the sub-struct (not the whole struct) into the inner func."""
     a = qd.ndarray(qd.i32, shape=(101,))
     b = qd.ndarray(qd.i32, shape=(57,))
     c = qd.ndarray(qd.i32, shape=(211,))
@@ -1041,8 +1040,8 @@ def test_substruct_passed_to_func_kwargs() -> None:
 
 @test_utils.test()
 def test_substruct_pruning() -> None:
-    """When the callee uses only one of the sub-struct's leaves, the unused leaf
-    must not be touched. Exercises pruning across the sub-struct boundary."""
+    """When the callee uses only one of the sub-struct's leaves, the unused leaf must not be touched.
+    Exercises pruning across the sub-struct boundary."""
     c = qd.ndarray(qd.i32, shape=(8,))
     d = qd.ndarray(qd.i32, shape=(8,))
 
@@ -1073,8 +1072,8 @@ def test_substruct_pruning() -> None:
 
 @test_utils.test()
 def test_substruct_inside_func() -> None:
-    """The sub-struct call site is inside a ``qd.func`` body (not directly in
-    the kernel). Exercises ``_transform_as_func``'s intermediate sentinel binding."""
+    """The sub-struct call site is inside a ``qd.func`` body (not directly in the kernel).
+    Exercises ``_transform_as_func``'s intermediate sentinel binding."""
     c = qd.ndarray(qd.i32, shape=(8,))
 
     @dataclass

--- a/tests/python/test_py_dataclass.py
+++ b/tests/python/test_py_dataclass.py
@@ -969,9 +969,13 @@ def test_substruct_passed_to_func(qd_make: Any, qd_anno: Any, request) -> None:
         fef(my_struct_ab.struct_cd.struct_ef)
 
     s = MyStructAB(
-        a=a, b=b, extra=extra_ab,
+        a=a,
+        b=b,
+        extra=extra_ab,
         struct_cd=MyStructCD(
-            c=c, d=d, extra=extra_cd,
+            c=c,
+            d=d,
+            extra=extra_cd,
             struct_ef=MyStructEF(e=e, f=f, extra=extra_ef),
         ),
     )
@@ -1202,11 +1206,14 @@ def test_substruct_deep_nesting() -> None:
         touch_l3(s.inner.inner.inner)
 
     s = L0(
-        leaf=n0, extra=x0,
+        leaf=n0,
+        extra=x0,
         inner=L1(
-            leaf=n1, extra=x1,
+            leaf=n1,
+            extra=x1,
             inner=L2(
-                leaf=n2, extra=x2,
+                leaf=n2,
+                extra=x2,
                 inner=L3(leaf=n3, extra=x3),
             ),
         ),

--- a/tests/python/test_py_dataclass.py
+++ b/tests/python/test_py_dataclass.py
@@ -914,32 +914,40 @@ _SUBSTRUCT_LEAF_KINDS = [
 
 @test_utils.test()
 @pytest.mark.parametrize("qd_make,qd_anno", _SUBSTRUCT_LEAF_KINDS)
-def test_substruct_passed_to_func(qd_make: Any, qd_anno: Any) -> None:
+def test_substruct_passed_to_func(qd_make: Any, qd_anno: Any, request) -> None:
     """``f(s.struct_cd)`` where the kernel arg is a nested dataclass and the callee is typed with the child dataclass.
     Mirrors test_ndarray_struct_nested_ndarray but passes the sub-struct (not the whole struct) into the inner func.
-    Parametrized across the three supported leaf kinds (raw ndarray, field/template, qd.Tensor wrapper)."""
+    Parametrized across the three supported leaf kinds (raw ndarray, field/template, qd.Tensor wrapper).
+    Every dataclass also carries one ``extra`` leaf that no kernel/func ever reads, so pruning is checked end-to-end
+    via ``kernel_args_count_by_type``."""
     a = qd_make(qd.i32, shape=(101,))
     b = qd_make(qd.i32, shape=(57,))
     c = qd_make(qd.i32, shape=(211,))
     d = qd_make(qd.i32, shape=(211,))
     e = qd_make(qd.i32, shape=(251,))
     f = qd_make(qd.i32, shape=(251,))
+    extra_ab = qd_make(qd.i32, shape=(8,))
+    extra_cd = qd_make(qd.i32, shape=(8,))
+    extra_ef = qd_make(qd.i32, shape=(8,))
 
     @dataclass
     class MyStructEF:
         e: qd_anno[qd.i32, 1]
         f: qd_anno[qd.i32, 1]
+        extra: qd_anno[qd.i32, 1]
 
     @dataclass
     class MyStructCD:
         c: qd_anno[qd.i32, 1]
         d: qd_anno[qd.i32, 1]
+        extra: qd_anno[qd.i32, 1]
         struct_ef: MyStructEF
 
     @dataclass
     class MyStructAB:
         a: qd_anno[qd.i32, 1]
         b: qd_anno[qd.i32, 1]
+        extra: qd_anno[qd.i32, 1]
         struct_cd: MyStructCD
 
     @qd.func
@@ -960,7 +968,13 @@ def test_substruct_passed_to_func(qd_make: Any, qd_anno: Any) -> None:
         fcd(my_struct_ab.struct_cd)
         fef(my_struct_ab.struct_cd.struct_ef)
 
-    s = MyStructAB(a=a, b=b, struct_cd=MyStructCD(c=c, d=d, struct_ef=MyStructEF(e=e, f=f)))
+    s = MyStructAB(
+        a=a, b=b, extra=extra_ab,
+        struct_cd=MyStructCD(
+            c=c, d=d, extra=extra_cd,
+            struct_ef=MyStructEF(e=e, f=f, extra=extra_ef),
+        ),
+    )
     k1(s)
 
     assert a[7] == 3
@@ -970,10 +984,18 @@ def test_substruct_passed_to_func(qd_make: Any, qd_anno: Any) -> None:
     assert e[12] == 28
     assert f[18] == 48
 
+    # The three ``extra`` leaves must be pruned. ndarray/tensor leaves show up in QD_ARRAY; field leaves are template
+    # globals and never appear as kernel args at all (QD_ARRAY == 0 across the board).
+    leaf_kind = request.node.callspec.id.split("-")[0]
+    expected_qd_arrays = 6 if leaf_kind in ("ndarray", "tensor") else 0
+    k1_primal: Kernel = k1._primal
+    assert k1_primal.launch_stats.kernel_args_count_by_type[KernelBatchedArgType.QD_ARRAY] == expected_qd_arrays
+
 
 @test_utils.test()
 def test_substruct_passed_to_func_kwargs() -> None:
-    """``f(child=s.struct_cd)`` — kwargs at the sub-struct call site."""
+    """``f(child=s.struct_cd)`` — kwargs at the sub-struct call site. ``a``, ``extra_ab``, ``extra_cd`` are all
+    unread and must be pruned out of the compiled kernel arg list."""
     c = qd.ndarray(qd.i32, shape=(8,))
     d = qd.ndarray(qd.i32, shape=(8,))
 
@@ -981,10 +1003,12 @@ def test_substruct_passed_to_func_kwargs() -> None:
     class CD:
         c: qd.types.NDArray[qd.i32, 1]
         d: qd.types.NDArray[qd.i32, 1]
+        extra: qd.types.NDArray[qd.i32, 1]
 
     @dataclass
     class AB:
         a: qd.types.NDArray[qd.i32, 1]
+        extra: qd.types.NDArray[qd.i32, 1]
         cd: CD
 
     @qd.func
@@ -997,9 +1021,14 @@ def test_substruct_passed_to_func_kwargs() -> None:
         fcd(cd=s.cd)
 
     a = qd.ndarray(qd.i32, shape=(8,))
-    k(AB(a=a, cd=CD(c=c, d=d)))
+    extra_ab = qd.ndarray(qd.i32, shape=(8,))
+    extra_cd = qd.ndarray(qd.i32, shape=(8,))
+    k(AB(a=a, extra=extra_ab, cd=CD(c=c, d=d, extra=extra_cd)))
+
     assert c[0] == 7
     assert d[0] == 9
+    k_primal: Kernel = k._primal
+    assert k_primal.launch_stats.kernel_args_count_by_type[KernelBatchedArgType.QD_ARRAY] == 2
 
 
 @test_utils.test()
@@ -1042,16 +1071,19 @@ def test_substruct_pruning() -> None:
 @test_utils.test()
 def test_substruct_inside_func() -> None:
     """The sub-struct call site is inside a ``qd.func`` body (not directly in the kernel).
-    Exercises ``_transform_as_func``'s intermediate sentinel binding."""
+    Exercises ``_transform_as_func``'s intermediate sentinel binding. ``a``, ``extra_a``, ``extra_c`` are all unread
+    and must be pruned out of the compiled kernel arg list (only ``c`` survives)."""
     c = qd.ndarray(qd.i32, shape=(8,))
 
     @dataclass
     class C:
         c: qd.types.NDArray[qd.i32, 1]
+        extra: qd.types.NDArray[qd.i32, 1]
 
     @dataclass
     class A:
         a: qd.types.NDArray[qd.i32, 1]
+        extra: qd.types.NDArray[qd.i32, 1]
         child: C
 
     @qd.func
@@ -1060,7 +1092,6 @@ def test_substruct_inside_func() -> None:
 
     @qd.func
     def f1(s: A) -> None:
-        # call site inside a qd.func body
         f2(s.child)
 
     @qd.kernel
@@ -1068,14 +1099,21 @@ def test_substruct_inside_func() -> None:
         f1(s)
 
     a = qd.ndarray(qd.i32, shape=(8,))
-    k(A(a=a, child=C(c=c)))
+    extra_a = qd.ndarray(qd.i32, shape=(8,))
+    extra_c = qd.ndarray(qd.i32, shape=(8,))
+    k(A(a=a, extra=extra_a, child=C(c=c, extra=extra_c)))
+
     assert c[0] == 11
+    k_primal: Kernel = k._primal
+    assert k_primal.launch_stats.kernel_args_count_by_type[KernelBatchedArgType.QD_ARRAY] == 1
 
 
 @test_utils.test()
 def test_substruct_scalar_leaf() -> None:
-    """Sub-struct contains scalar (int) fields, mixed with an ndarray sibling."""
+    """Sub-struct contains scalar (int) fields, mixed with an ndarray sibling. ``extra_ab`` is an unused ndarray on
+    the outer struct and must be pruned out of the kernel arg list (only ``out`` survives as QD_ARRAY)."""
     out = qd.ndarray(qd.i32, shape=(8,))
+    extra_ab = qd.ndarray(qd.i32, shape=(8,))
 
     @dataclass
     class CD:
@@ -1085,6 +1123,7 @@ def test_substruct_scalar_leaf() -> None:
     @dataclass
     class AB:
         out: qd.types.NDArray[qd.i32, 1]
+        extra: qd.types.NDArray[qd.i32, 1]
         cd: CD
 
     @qd.func
@@ -1095,8 +1134,11 @@ def test_substruct_scalar_leaf() -> None:
     def k(s: AB) -> None:
         add_pair(s.cd, s.out)
 
-    k(AB(out=out, cd=CD(c=3, d=4)))
+    k(AB(out=out, extra=extra_ab, cd=CD(c=3, d=4)))
+
     assert out[0] == 7
+    k_primal: Kernel = k._primal
+    assert k_primal.launch_stats.kernel_args_count_by_type[KernelBatchedArgType.QD_ARRAY] == 1
 
 
 @test_utils.test()
@@ -1104,29 +1146,39 @@ def test_substruct_deep_nesting() -> None:
     """Three levels of dataclass nesting (L0 -> L1 -> L2 -> L3) combined with a three-level func-call chain
     (kernel -> touch_l1 -> touch_l2 -> touch_l3). Each layer writes its own leaf and forwards its inner sub-struct to
     the next callee. The kernel also exercises a direct 3-deep attribute access ``s.inner.inner.inner`` to make sure
-    multi-level call-site flattening works straight from the kernel body, not just via intermediate funcs."""
+    multi-level call-site flattening works straight from the kernel body, not just via intermediate funcs.
+    Every level also carries an unused ``extra`` leaf to confirm pruning works at every depth — only the 4 ``leaf``
+    fields must survive in the compiled kernel arg list."""
     n0 = qd.ndarray(qd.i32, shape=(4,))
     n1 = qd.ndarray(qd.i32, shape=(4,))
     n2 = qd.ndarray(qd.i32, shape=(4,))
     n3 = qd.ndarray(qd.i32, shape=(4,))
+    x0 = qd.ndarray(qd.i32, shape=(4,))
+    x1 = qd.ndarray(qd.i32, shape=(4,))
+    x2 = qd.ndarray(qd.i32, shape=(4,))
+    x3 = qd.ndarray(qd.i32, shape=(4,))
 
     @dataclass
     class L3:
         leaf: qd.types.NDArray[qd.i32, 1]
+        extra: qd.types.NDArray[qd.i32, 1]
 
     @dataclass
     class L2:
         leaf: qd.types.NDArray[qd.i32, 1]
+        extra: qd.types.NDArray[qd.i32, 1]
         inner: L3
 
     @dataclass
     class L1:
         leaf: qd.types.NDArray[qd.i32, 1]
+        extra: qd.types.NDArray[qd.i32, 1]
         inner: L2
 
     @dataclass
     class L0:
         leaf: qd.types.NDArray[qd.i32, 1]
+        extra: qd.types.NDArray[qd.i32, 1]
         inner: L1
 
     @qd.func
@@ -1149,13 +1201,24 @@ def test_substruct_deep_nesting() -> None:
         touch_l1(s.inner)
         touch_l3(s.inner.inner.inner)
 
-    s = L0(leaf=n0, inner=L1(leaf=n1, inner=L2(leaf=n2, inner=L3(leaf=n3))))
+    s = L0(
+        leaf=n0, extra=x0,
+        inner=L1(
+            leaf=n1, extra=x1,
+            inner=L2(
+                leaf=n2, extra=x2,
+                inner=L3(leaf=n3, extra=x3),
+            ),
+        ),
+    )
     k(s)
 
     assert n0[0] == 1000
     assert n1[0] == 100
     assert n2[0] == 10
     assert n3[0] == 1 + 1
+    k_primal: Kernel = k._primal
+    assert k_primal.launch_stats.kernel_args_count_by_type[KernelBatchedArgType.QD_ARRAY] == 4
 
 
 @pytest.mark.parametrize("use_slots", [False, True])


### PR DESCRIPTION
## Summary

Allows passing a nested-dataclass field to a `qd.func` (or `qd.kernel`-internal call) where today only passing the entire struct works:

```python
@dataclass
class Inner:
    x: qd.types.NDArray[qd.f32, 1]

@dataclass
class Outer:
    inner: Inner
    y: qd.types.NDArray[qd.f32, 1]

@qd.func
def touch_inner(inner: Inner) -> None:
    inner.x[0] += 1.0

@qd.kernel
def k(s: Outer) -> None:
    touch_inner(s.inner)        # ← previously: AttributeError; now works
```

Today, `s.inner` resolved as `getattr(Outer, "inner")` in `build_Attribute` because `Outer.inner` is only a dataclass field annotation, not a class attribute. The fix is two small Python-side changes (~31 LoC) plus tests:

1. **Include intermediate dataclass nodes in `struct_locals`** (`_kernel_impl_dataclass.py`). `FlattenAttributeNameTransformer` will now rewrite `s.inner` to `Name("__qd_s__qd_inner")` instead of leaving it as an `Attribute`. Kernel-side intermediate sentinels are already bound (via the recursion in `_transform_kernel_arg`).
2. **Bind intermediate dataclass sentinels in func contexts** (`function_def_transformer.py`). On the `qd.func` side, `_transform_func_arg` is invoked once per *leaf* arg (after `fuse_args` has expanded the dataclass), so a recursive walk in `_transform_as_func`'s post-loop is needed to bind every nested dataclass node to its type as a sentinel.

Call-site expansion (`_expand_Call_dataclass_args`/`_kwargs`), the runtime launch path (`_recursive_set_args`), and pruning (`Pruning.record_after_call`/`filter_call_args`) all work as-is — they already key off the leaf flat names which are unchanged.

## Supported

- arbitrary depth (`f(s.a.b.c)`)
- positional and keyword forms (`f(s.inner)`, `f(inner=s.inner)`)
- call sites inside `@qd.kernel` bodies and inside other `@qd.func` bodies
- pruning of unread sub-struct leaves
- ndarray, field, and scalar leaves; mixed with non-dataclass siblings at the call site

## Explicit non-goals

- Local aliasing: `t = s.inner; f(t)` is **not** supported (same as the pre-existing whole-struct case `t = s; f(t)`).
- Template-bound parent + typed callee: pre-existing limitation, not addressed here.
- Real-functions (`is_real_function=True`): out of scope.

Design and PoC log: [`perso_hugh/doc/sub_struct_passing.md`](https://github.com/Genesis-Embodied-AI/perso_hugh/blob/main/doc/sub_struct_passing.md).

## Test plan

- [x] 6 new tests in `tests/python/test_py_dataclass.py` covering ndarray leaves, field leaves, kwargs, pruning, call-from-func, and scalar-leaf sub-structs (18 cases total across x64/vulkan/cuda)
- [x] Full `test_py_dataclass.py` (135 tests) — pass on x64
- [x] Adjacent dataclass suites (`test_kernel_impl_dataclass`, `test_call_transformer`, `test_function_def_transformer`, `test_frozen_dc_dispatch_cache`, `test_all_field_shortcut`, `test_tensor_wrapper_in_struct`, `test_tensor_annotation_in_func`) — pass on x64
- [x] `test_function.py`, fast-caching tests — pass on x64
- Cumulative on x64: 251 + 143 = 394 passed, 9 pre-existing xfail, 0 new failures
- [ ] CI to run on cuda/vulkan as part of merge gating

Made with [Cursor](https://cursor.com)