### PR TITLE
[block] sync(): fix unsupported-arch error message

### DIFF
--- a/python/quadrants/lang/simt/block.py
+++ b/python/quadrants/lang/simt/block.py
@@ -38,7 +38,7 @@ def sync():
         return impl.call_internal("block_barrier", with_runtime_context=False)
     if arch_uses_spv(arch):
         return impl.call_internal("workgroupBarrier", with_runtime_context=False)
-    raise ValueError(f"qd.block.shared_array is not supported for arch {arch}")
+    raise ValueError(f"qd.block.sync is not supported for arch {arch}")
 
 
 def sync_all_nonzero(predicate):


### PR DESCRIPTION
## Summary

`block.sync()` was raising `qd.block.shared_array is not supported for arch ...` when the arch wasn't CUDA / AMDGPU / Vulkan / Metal -- a copy-paste leftover from `SharedArray`. Switch to `qd.block.sync` so the message matches the function and follows the convention used by every other primitive in `block.py` (`sync_all_nonzero`, `mem_fence`, `thread_idx`, `global_thread_idx`, ...).

Closes #646.

## Test plan

- Code-only diff in an unreachable `raise ValueError` path; no behaviour change on supported archs.

Made with [Cursor](https://cursor.com)