### PR TITLE
[algorithms] PrefixSumExecutor: drop unused GRID_SZ local

### DIFF
--- a/python/quadrants/algorithms/_algorithms.py
+++ b/python/quadrants/algorithms/_algorithms.py
@@ -56,7 +56,6 @@ class PrefixSumExecutor:
         self.sorting_length = length
 
         BLOCK_SZ = 64
-        GRID_SZ = int((length + BLOCK_SZ - 1) / BLOCK_SZ)
 
         # Buffer position and length
         # This is a single buffer implementation for ease of aot usage


### PR DESCRIPTION
## Summary

Remove a dead local in `PrefixSumExecutor.__init__`: `GRID_SZ` was computed but never read. Leftover from a refactor.

Closes #682.

## Test plan

- Mechanical removal of an unused local; no behaviour change.

Made with [Cursor](https://cursor.com)