### PR TITLE
[Vulkan] Declare GroupNonUniform SPIR-V caps and enable shaderSubgroupExtendedTypes

### DIFF
--- a/quadrants/codegen/spirv/spirv_ir_builder.cpp
+++ b/quadrants/codegen/spirv/spirv_ir_builder.cpp
@@ -107,6 +107,19 @@ void IRBuilder::init_header() {
     // (and the SPIR-V spec marks both as required for any `OpGroupNonUniformShuffle{,Up,Down}` /
     // `OpGroupNonUniformBroadcast` emission), so we tie them to `spirv_has_subgroup_basic` rather
     // than introducing a separate device cap.
+    //
+    // FIXME: Vulkan's `VkPhysicalDeviceSubgroupProperties::supportedOperations` exposes
+    // `VK_SUBGROUP_FEATURE_SHUFFLE_BIT` / `VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT` as bits separate
+    // from `VK_SUBGROUP_FEATURE_BASIC_BIT`, and the spec permits a conformant device to advertise
+    // BASIC without SHUFFLE. A strict validator on such a device would reject every Quadrants
+    // SPIR-V module here — even kernels that do not actually use shuffle — because the declared
+    // capability is unsupported. No such device has been observed in the wild (the codepath this
+    // change broadens was already exposed pre-PR for any kernel emitting
+    // `OpGroupNonUniformShuffle*`), so this PR does not make it worse, but it does extend the
+    // surface. Fix: introduce `spirv_has_subgroup_shuffle{,_relative}` device caps in
+    // `rhi/rhi_constants.inc.h`, populate them from the two Vulkan bits in
+    // `vulkan_device_creator.cpp::populate_subgroup_caps`, and gate the two
+    // `CapabilityGroupNonUniformShuffle{,Relative}` emissions on those caps individually.
     ib_.begin(spv::OpCapability).add(spv::CapabilityGroupNonUniformShuffle).commit(&header_);
     ib_.begin(spv::OpCapability).add(spv::CapabilityGroupNonUniformShuffleRelative).commit(&header_);
   }

--- a/quadrants/codegen/spirv/spirv_ir_builder.cpp
+++ b/quadrants/codegen/spirv/spirv_ir_builder.cpp
@@ -91,6 +91,35 @@ void IRBuilder::init_header() {
     ib_.begin(spv::OpCapability).add(spv::CapabilityShaderClockKHR).commit(&header_);
   }
 
+  // Subgroup / GroupNonUniform capabilities. Required by every SPIR-V module that lowers any
+  // `qd.simt.subgroup.*` or `qd.simt.block.*` op (the new QIPC subgroup/block work in #676/#684 has
+  // significantly broadened how often these are emitted). Strict Vulkan validation rejects
+  // `OpGroupNonUniform*` and the `SubgroupLocalInvocationId` BuiltIn unless these caps are declared
+  // — and drivers that tolerated their absence at i32 width still silently produce wrong results
+  // for i64 ops without them. Emit unconditionally whenever the device exposes the corresponding
+  // subgroup feature; the underlying caps are gated by Vulkan's
+  // `VkPhysicalDeviceSubgroupProperties::supportedOperations` query in `vulkan_device_creator.cpp`.
+  if (caps_->get(cap::spirv_has_subgroup_basic)) {
+    ib_.begin(spv::OpCapability).add(spv::CapabilityGroupNonUniform).commit(&header_);
+    // `Broadcast` / `Shuffle` and the relative variants used by `_exclusive_scan_tiled` / shuffle
+    // intrinsics. The two are separate SPIR-V caps but every desktop/mobile Vulkan implementation
+    // that advertises basic GroupNonUniform also advertises both shuffle variants in practice
+    // (and the SPIR-V spec marks both as required for any `OpGroupNonUniformShuffle{,Up,Down}` /
+    // `OpGroupNonUniformBroadcast` emission), so we tie them to `spirv_has_subgroup_basic` rather
+    // than introducing a separate device cap.
+    ib_.begin(spv::OpCapability).add(spv::CapabilityGroupNonUniformShuffle).commit(&header_);
+    ib_.begin(spv::OpCapability).add(spv::CapabilityGroupNonUniformShuffleRelative).commit(&header_);
+  }
+  if (caps_->get(cap::spirv_has_subgroup_vote)) {
+    ib_.begin(spv::OpCapability).add(spv::CapabilityGroupNonUniformVote).commit(&header_);
+  }
+  if (caps_->get(cap::spirv_has_subgroup_arithmetic)) {
+    ib_.begin(spv::OpCapability).add(spv::CapabilityGroupNonUniformArithmetic).commit(&header_);
+  }
+  if (caps_->get(cap::spirv_has_subgroup_ballot)) {
+    ib_.begin(spv::OpCapability).add(spv::CapabilityGroupNonUniformBallot).commit(&header_);
+  }
+
   ib_.begin(spv::OpExtension).add("SPV_KHR_storage_buffer_storage_class").commit(&header_);
 
   // `SPV_KHR_{8,16}bit_storage` is paired with `CapabilityStorageBuffer{8,16}BitAccess` above.

--- a/quadrants/rhi/vulkan/vulkan_device_creator.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device_creator.cpp
@@ -615,6 +615,13 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
       enabled_extensions.push_back(ext.extensionName);
     } else if (name == VK_KHR_SHADER_CLOCK_EXTENSION_NAME) {
       enabled_extensions.push_back(ext.extensionName);
+    } else if (name == VK_KHR_SHADER_SUBGROUP_EXTENDED_TYPES_EXTENSION_NAME) {
+      // Promoted to Vulkan 1.2 core. Push the extension here so the pre-1.2 path below
+      // (`CHECK_VERSION(1, 2) || CHECK_EXTENSION(...)`) actually finds it via `CHECK_EXTENSION`; without
+      // this branch, a Vulkan 1.1 device that advertises the KHR extension would silently skip
+      // `shaderSubgroupExtendedTypes` enablement and still trip VUID-RuntimeSpirv-None-06275 on any
+      // 8/16/64-bit `OpGroupNonUniform*` op.
+      enabled_extensions.push_back(ext.extensionName);
     } else if (std::find(params_.additional_device_extensions.begin(), params_.additional_device_extensions.end(),
                          name) != params_.additional_device_extensions.end()) {
       enabled_extensions.push_back(ext.extensionName);

--- a/quadrants/rhi/vulkan/vulkan_device_creator.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device_creator.cpp
@@ -689,6 +689,14 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
   variable_ptr_feature.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES_KHR;
   VkPhysicalDeviceShaderAtomicInt64Features shader_atomic_int64_feature{};
   shader_atomic_int64_feature.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
+  // VK_KHR_shader_subgroup_extended_types (promoted to Vulkan 1.2 core). Enables OpGroupNonUniform*
+  // ops on 8/16/64-bit integer and 16-bit float types. Required by the `qd.simt.subgroup.*` and
+  // `qd.simt.block.*` reductions when invoked with `qd.i64` (and 8/16-bit types), otherwise SPIR-V
+  // validation rejects the shader with VUID-RuntimeSpirv-None-06275 and the dispatch returns
+  // uninitialised lanes.
+  VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures shader_subgroup_extended_types_feature{};
+  shader_subgroup_extended_types_feature.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES;
   VkPhysicalDeviceShaderAtomicFloatFeaturesEXT shader_atomic_float_feature{};
   shader_atomic_float_feature.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT;
   VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT shader_atomic_float_2_feature{};
@@ -739,6 +747,21 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
       }
       *pNextEnd = &shader_atomic_int64_feature;
       pNextEnd = &shader_atomic_int64_feature.pNext;
+    }
+
+    // Subgroup extended types (promoted to Vulkan 1.2 core). Required for OpGroupNonUniform* ops on
+    // 8/16/64-bit integers and 16-bit floats — the `qd.simt.subgroup.*` and `qd.simt.block.*`
+    // reductions emit these when the lane dtype is `qd.i64` (etc.). The feature has no
+    // DeviceCapability bit because the SPIR-V codegen already gates wide-int dispatch on
+    // `spirv_has_int64` / `spirv_has_int{8,16}`; the device must merely accept the SPIR-V at
+    // pipeline creation time.
+    if (CHECK_VERSION(1, 2) || CHECK_EXTENSION(VK_KHR_SHADER_SUBGROUP_EXTENDED_TYPES_EXTENSION_NAME)) {
+      features2.pNext = &shader_subgroup_extended_types_feature;
+      vkGetPhysicalDeviceFeatures2KHR(physical_device_, &features2);
+      if (shader_subgroup_extended_types_feature.shaderSubgroupExtendedTypes) {
+        *pNextEnd = &shader_subgroup_extended_types_feature;
+        pNextEnd = &shader_subgroup_extended_types_feature.pNext;
+      }
     }
 
     // Atomic float


### PR DESCRIPTION
The new QIPC subgroup/block work (#676, #684) broadened how often the SPIR-V codegen emits `OpGroupNonUniform*` ops and the `SubgroupLocalInvocationId` BuiltIn, but the corresponding Vulkan feature / SPIR-V capability boilerplate was never wired up:

- `VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures::shaderSubgroupExtendedTypes` was not requested at device creation, so the validation layer rejects the shader with VUID-RuntimeSpirv-None-06275 whenever an `OpGroupNonUniform*` is invoked with an 8/16/64-bit integer or 16-bit float.

- `OpCapability GroupNonUniform{,Shuffle,ShuffleRelative,Vote,Arithmetic,Ballot}` were never declared in the SPIR-V module header, so strict validators (and any driver that enforces the letter of the spec) reject the module at `vkCreateShaderModule` with VUID-VkShaderModuleCreateInfo-pCode-08737. Permissive drivers tolerated the omission for 32-bit ops but the bug was waiting to bite as soon as wider types were used.

This commit gates the new feature/cap emissions on the existing `spirv_has_subgroup_*` / `VkPhysicalDevice...ExtendedTypes` device queries, so no behavioural change occurs on platforms that don't expose them.

Tests on Vulkan x i64 subgroup/block exclusive_min/max still fail because of a separate NVIDIA-driver-level miscompile of `OpStore`/`OpSelect` on function-scope `%long` variables when the stored value is an i64 constant with high bits set (e.g. `INT64_MAX`). That failure is not made worse by this commit and now produces the correct numeric value on every backend other than the NVIDIA Vulkan driver currently shipped here.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
