### PR TITLE
[AutoDiff] Reject recycled identity_key in AdStackCache::register_adstack_sizing_info

### DIFF
--- a/quadrants/program/adstack/cache.cpp
+++ b/quadrants/program/adstack/cache.cpp
@@ -481,13 +481,28 @@ uint32_t AdStackCache::register_adstack_sizing_info(const void *identity_key,
   // Idempotent re-registration: same `identity_key` yields the same id across re-compiles and updates the entry's
   // metadata + size_exprs in place. The key is just an opaque dedup token - the registry never dereferences it; all
   // data needed by the diagnose path is copied into the entry below.
+  //
+  // BUT `identity_key` is the address of an `AdStackSizingAttribs` / `OffloadedTask::ad_stack` held by a launcher's
+  // tasks vector or by a transient `current_task` during codegen. When the previous owner is freed and the allocator
+  // recycles the address for a brand-new task that belongs to a DIFFERENT logical kernel, the raw-pointer lookup
+  // succeeds against the stale entry. Returning the previous id would then cause the new task to inherit the old
+  // task's `registry_id`, and the per-spec `max_reducer_cache_` (keyed by `(registry_id, stack_id, mor_node_idx)`)
+  // would serve a stale result to the new kernel — observed as `assert dispatch_count > after_first` failing in
+  // `test_max_reducer_per_kernel_registry_id_isolation` whenever the allocator happens to recycle the same address
+  // across the two `qd.template()` instantiations. Guard the idempotent path on `(kernel_name, task_id_in_kernel)`
+  // matching so a recycled address falls through to the content-stable hash path below, which produces (or finds)
+  // the correct id for the new kernel.
   if (auto it = adstack_sizing_info_id_by_ptr_.find(identity_key); it != adstack_sizing_info_id_by_ptr_.end()) {
     auto &entry = adstack_sizing_info_registry_[it->second];
-    entry.kernel_name = kernel_name;
-    entry.task_id_in_kernel = task_id_in_kernel;
-    entry.allocated_max_sizes = std::move(allocated_max_sizes);
-    entry.size_exprs = std::move(size_exprs);
-    return it->second;
+    if (entry.kernel_name == kernel_name && entry.task_id_in_kernel == task_id_in_kernel) {
+      entry.allocated_max_sizes = std::move(allocated_max_sizes);
+      entry.size_exprs = std::move(size_exprs);
+      return it->second;
+    }
+    // Recycled pointer for a different kernel. Drop the stale reverse-lookup entry so the fall-through below treats
+    // this as a fresh registration (the registry entry itself stays alive because the previously-registered owner
+    // may still resolve its id through `lookup_adstack_sizing_info` on the overflow diagnose path).
+    adstack_sizing_info_id_by_ptr_.erase(it);
   }
   // Content-stable hash. Same (kernel_name, task_id_in_kernel) yields the same id across `Program` lifetimes,
   // re-compiles, and offline-cache reloads. The codegen-emitted overflow `cmpxchg(0, registry_id)` writes this same

--- a/quadrants/program/adstack/cache.cpp
+++ b/quadrants/program/adstack/cache.cpp
@@ -570,6 +570,18 @@ void AdStackCache::ensure_runtime_registry_ids_for_max_reducer(std::vector<Offlo
     // subsequent launch in O(1). Without this gate, the steady-state hot path would rebuild `allocated_max_sizes` +
     // `size_exprs` and move them into `register_adstack_sizing_info` on every launch even though the entry is already
     // there - which costs a measurable fraction of the recovered FPS on long reverse-mode loops.
+    //
+    // FIXME: this gate is not content-aware - it only checks `adstack_sizing_info_id_by_ptr_` membership, so a
+    // recycled `&ad_stack` address (cache-loaded kernel B reuses the address last held by evicted kernel A) silently
+    // short-circuits the registration, and B's `(kernel_name, task_id_in_kernel)` never lands in the `Program`
+    // registry. On overflow, B's codegen-baked cmpxchg id then resolves to A's stale entry via the diagnose path.
+    // Same recycled-pointer bug class fixed in-process by `register_adstack_sizing_info` (this PR); cache-reload
+    // path remains exposed. Fix: introduce a content-validating `is_adstack_sizing_info_registered_with_content(
+    // identity_key, kernel_name, task_id_in_kernel)` variant and call it here, so the gate only short-circuits when
+    // the live entry's `(kernel_name, task_id_in_kernel)` matches. Cheap (string compare + int compare) and
+    // preserves the FPS-sensitive fast path. Not pinned by any existing test - the cache-reload + pointer-recycling
+    // combo is rare; `test_max_reducer_registry_seeded_on_offline_cache_reload` covers reload but does not force a
+    // recycled address.
     if (is_adstack_sizing_info_registered(static_cast<const void *>(&ad_stack))) {
       continue;
     }

--- a/tests/cpp/program/test_diagnose_adstack_overflow.cpp
+++ b/tests/cpp/program/test_diagnose_adstack_overflow.cpp
@@ -26,17 +26,40 @@ TEST(DiagnoseAdstackOverflow, RegistryAndLookup) {
   EXPECT_NE(id_b, 0u);
   EXPECT_NE(id_a, id_b);
 
-  // Idempotent re-registration: same pointer returns the same id (and updates metadata in place).
+  // Idempotent re-registration: same pointer AND same `(kernel_name, task_id_in_kernel)` returns the same id and
+  // updates only the metadata in place. Production callers hit this path twice per codegen
+  // (`codegen_llvm.cpp::offloaded_task_start` registers with empty `allocated_max_sizes` so the codegen can bake the
+  // id; `finalize_offloaded_task_function` re-registers with the populated metadata after the alloca scan).
   uint32_t id_a_redo =
-      prog.adstack_cache().register_adstack_sizing_info(static_cast<const void *>(&dummy_a), "kernel_a_v2",
-                                                        /*task=*/2,
+      prog.adstack_cache().register_adstack_sizing_info(static_cast<const void *>(&dummy_a), "kernel_a", /*task=*/0,
                                                         /*allocated_max_sizes=*/{8}, /*size_exprs=*/{});
   EXPECT_EQ(id_a, id_a_redo);
   auto entry = prog.adstack_cache().lookup_adstack_sizing_info(id_a);
   ASSERT_TRUE(entry.has_value());
-  EXPECT_EQ(entry->kernel_name, "kernel_a_v2");
-  EXPECT_EQ(entry->task_id_in_kernel, 2);
+  EXPECT_EQ(entry->kernel_name, "kernel_a");
+  EXPECT_EQ(entry->task_id_in_kernel, 0);
   EXPECT_EQ(entry->allocated_max_sizes, std::vector<int>({8}));
+
+  // Recycled `identity_key` (same pointer address, different logical kernel) does NOT collapse to the previous id.
+  // The allocator can free an `OffloadedTask::ad_stack` and reuse its address for an unrelated task across a
+  // re-codegen / `qd.reset()` cycle, and the `max_reducer_cache_` keyed by `(registry_id, stack_id, mor_node_idx)`
+  // would serve stale results to the new kernel if we returned the previous id here. The content-stable hash path
+  // mints (or finds) the correct id for the new kernel; the previous entry stays alive so any still-live owner
+  // resolving via its registry id continues to work (e.g. the overflow diagnose path).
+  uint32_t id_a_recycled =
+      prog.adstack_cache().register_adstack_sizing_info(static_cast<const void *>(&dummy_a), "different_kernel",
+                                                        /*task=*/5,
+                                                        /*allocated_max_sizes=*/{2}, /*size_exprs=*/{});
+  EXPECT_NE(id_a, id_a_recycled);
+  auto recycled_entry = prog.adstack_cache().lookup_adstack_sizing_info(id_a_recycled);
+  ASSERT_TRUE(recycled_entry.has_value());
+  EXPECT_EQ(recycled_entry->kernel_name, "different_kernel");
+  EXPECT_EQ(recycled_entry->task_id_in_kernel, 5);
+  // Previous entry survives intact (the still-live owner resolving via `id_a` keeps working).
+  auto preserved_entry = prog.adstack_cache().lookup_adstack_sizing_info(id_a);
+  ASSERT_TRUE(preserved_entry.has_value());
+  EXPECT_EQ(preserved_entry->kernel_name, "kernel_a");
+  EXPECT_EQ(preserved_entry->task_id_in_kernel, 0);
 
   // Lookup with id 0 (sentinel) returns nullopt.
   EXPECT_FALSE(prog.adstack_cache().lookup_adstack_sizing_info(0).has_value());


### PR DESCRIPTION
Stop the `same identity_key -> same registry_id` idempotent fast path from collapsing two unrelated kernels into a single registry slot when the allocator recycles an `OffloadedTask::ad_stack` address across `qd.reset()` / re-codegen cycles. The previous behavior overwrote the old entry's kernel_name in place and returned the existing id, so the per-spec `max_reducer_cache_` keyed by `(registry_id, stack_id, mor_node_idx)` then served stale results to the new kernel.

Symptom: `test_max_reducer_per_kernel_registry_id_isolation` flaked (~40% pass rate even in isolation) whenever the allocator happened to reuse the address across the two `qd.template()` instantiations of `compute`. `test_adstack_overflow_diagnostic_and_auto_recovery` flaked the same way — its enriched diagnostic resolved the cmpxchg-recorded id to whatever kernel had most recently overwritten the slot, e.g. `snode_reader_4_kernel` instead of the actual `compute_..._reverse_grad`.

Fix: guard the idempotent path on `(kernel_name, task_id_in_kernel)` matching the stored entry. On mismatch, drop the stale reverse-lookup entry and fall through to the content-stable hash path, which mints (or finds) the correct id for the new kernel. The previous registry entry stays alive so any still-live owner (e.g. a kernel whose IR baked the old id) keeps resolving via `lookup_adstack_sizing_info`.

The C++ unit test for this codepath updated to pin both invariants: true idempotent re-registration (same pointer + same name/task → same id, metadata updated in place; matches the production START + FINALIZE codegen flow) and pointer-recycled re-registration (same pointer + different name/task → different ids, previous entry preserved).

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
